### PR TITLE
refactor: extract createTestOrchestrator helper

### DIFF
--- a/server/orchestrator/__tests__/orchestrator.dispatch-failure.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.dispatch-failure.integration.test.ts
@@ -1,26 +1,15 @@
 import { access } from "node:fs/promises";
 import { HttpResponse, http } from "msw";
-import { describe, expect, it, vi } from "vitest";
-import { githubCodeHostAdapter } from "../../code-hosts/github.ts";
+import { describe, expect, it } from "vitest";
 import { runs } from "../../db/schema.ts";
-import { createGitHubClient } from "../../github-client.ts";
-import { createRunRepository } from "../../run-repository.ts";
-import { createRunner } from "../../runner/runner.ts";
 import {
 	createGitHubIssue,
-	createTestWorkflow,
 	failingAgent,
 	GITHUB_API,
-	noopAgent,
 	REPO,
 } from "../../testing/support/fixtures.ts";
 import { githubHandlers, server } from "../../testing/support/msw.ts";
-import { createTestConfig } from "../../testing/support/test-config.ts";
-import { createTestDb } from "../../testing/support/test-db.ts";
-import { createTestWorkspaceRoot } from "../../testing/support/test-workspace.ts";
-import { githubTrackerAdapter } from "../../trackers/github.ts";
-import type { RepoWorkflow } from "../../workflow/workflow.ts";
-import { createOrchestrator } from "../orchestrator.ts";
+import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
 
 describe("Orchestrator dispatch failure and polling", () => {
 	it("preserves workspace on agent failure when retries remain", async () => {
@@ -30,26 +19,12 @@ describe("Orchestrator dispatch failure and polling", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		const wsDir = await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({
-				workspace_root: workspace.root,
-				max_retries: 3,
-			}),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
+		await using ctx = await createTestOrchestrator({
+			configOverrides: { max_retries: 3 },
 			runAgent: failingAgent,
 		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		const wsDir = await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -84,26 +59,12 @@ describe("Orchestrator dispatch failure and polling", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		const wsDir = await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({
-				workspace_root: workspace.root,
-				max_retries: 0,
-			}),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
+		await using ctx = await createTestOrchestrator({
+			configOverrides: { max_retries: 0 },
 			runAgent: failingAgent,
 		});
+		const { orchestrator, runner, workspace } = ctx;
+		const wsDir = await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -124,26 +85,12 @@ describe("Orchestrator dispatch failure and polling", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({
-				workspace_root: workspace.root,
-				max_retries: 0,
-			}),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
+		await using ctx = await createTestOrchestrator({
+			configOverrides: { max_retries: 0 },
 			runAgent: failingAgent,
 		});
+		const { orchestrator, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -174,26 +121,12 @@ describe("Orchestrator dispatch failure and polling", () => {
 			),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({
-				workspace_root: workspace.root,
-				max_retries: 0,
-			}),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
+		await using ctx = await createTestOrchestrator({
+			configOverrides: { max_retries: 0 },
 			runAgent: failingAgent,
 		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -239,136 +172,19 @@ describe("Orchestrator dispatch failure and polling", () => {
 			),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
 		// Don't pre-create workspace so git clone fails → dispatch fails → rollback fires
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 5 });
-
-		const codeHost = githubCodeHostAdapter(github);
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: { ...codeHost, cloneUrl: () => "/nonexistent/repo.git" },
-			config: createTestConfig({
-				workspace_root: workspace.root,
+		await using ctx = await createTestOrchestrator({
+			maxConcurrency: 5,
+			codeHost: (defaults) => ({
+				...defaults,
+				cloneUrl: () => "/nonexistent/repo.git",
 			}),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
 		});
+		const { orchestrator, db } = ctx;
 
 		await orchestrator.tick();
 
 		const allRuns = db.select().from(runs).all();
 		expect(allRuns).toHaveLength(0);
-	});
-
-	it("start() triggers polling and stop() halts it", async () => {
-		vi.useFakeTimers();
-
-		let tickCount = 0;
-
-		server.use(
-			...githubHandlers({
-				resolveIssues: () => {
-					tickCount++;
-					return [];
-				},
-			}),
-		);
-
-		await using workspace = await createTestWorkspaceRoot();
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({
-				workspace_root: workspace.root,
-				polling_interval_ms: 1000,
-			}),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
-		});
-
-		orchestrator.start();
-
-		await vi.advanceTimersByTimeAsync(0);
-		expect(tickCount).toBe(2);
-
-		await vi.advanceTimersByTimeAsync(1000);
-		expect(tickCount).toBe(4);
-
-		orchestrator.stop();
-
-		await vi.advanceTimersByTimeAsync(5000);
-		expect(tickCount).toBe(4);
-
-		vi.useRealTimers();
-	});
-
-	it("start() keeps polling when tick() throws on a label swap failure", async () => {
-		vi.useFakeTimers();
-
-		let tickCount = 0;
-
-		server.use(
-			...githubHandlers({
-				resolveIssues: () => {
-					tickCount++;
-					return [createGitHubIssue(1, ["agent"])];
-				},
-			}),
-		);
-		// Label delete always fails, so the initial swap (pending → running) throws
-		server.use(
-			http.delete(
-				`${GITHUB_API}/repos/${REPO}/issues/:number/labels/:label`,
-				() => new HttpResponse(null, { status: 500 }),
-			),
-		);
-
-		await using workspace = await createTestWorkspaceRoot();
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({
-				workspace_root: workspace.root,
-				polling_interval_ms: 1000,
-			}),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
-		});
-
-		orchestrator.start();
-
-		await vi.advanceTimersByTimeAsync(0);
-		expect(tickCount).toBe(2);
-
-		await vi.advanceTimersByTimeAsync(1000);
-		expect(tickCount).toBe(4);
-
-		const allRuns = db.select().from(runs).all();
-		expect(allRuns).toHaveLength(0);
-
-		orchestrator.stop();
-		vi.useRealTimers();
 	});
 });

--- a/server/orchestrator/__tests__/orchestrator.dispatch-hooks.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.dispatch-hooks.integration.test.ts
@@ -1,26 +1,17 @@
-import { access } from "node:fs/promises";
+import { access, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
-import { githubCodeHostAdapter } from "../../code-hosts/github.ts";
 import { runs } from "../../db/schema.ts";
-import { createGitHubClient } from "../../github-client.ts";
-import { createRunRepository } from "../../run-repository.ts";
-import { createRunner } from "../../runner/runner.ts";
 import {
 	createGitHubIssue,
 	createTestWorkflow,
 	GITHUB_API,
-	noopAgent,
 	REPO,
 } from "../../testing/support/fixtures.ts";
 import { githubHandlers, server } from "../../testing/support/msw.ts";
-import { createTestConfig } from "../../testing/support/test-config.ts";
-import { createTestDb } from "../../testing/support/test-db.ts";
-import { createTestWorkspaceRoot } from "../../testing/support/test-workspace.ts";
-import { githubTrackerAdapter } from "../../trackers/github.ts";
-import type { RepoWorkflow } from "../../workflow/workflow.ts";
-import { createOrchestrator } from "../orchestrator.ts";
+import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
 
 describe("Orchestrator dispatch hooks and completion", () => {
 	it("before_run hook executes before agent starts", async () => {
@@ -30,38 +21,26 @@ describe("Orchestrator dispatch hooks and completion", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
 		// Custom agent that checks marker file exists during execution
 		let markerExistedDuringRun = false;
-		// biome-ignore lint/correctness/useYield: agent only needs side effects, no messages to yield
-		async function* checkMarkerAgent() {
-			const wsDir = join(workspace.root, "test-owner_test-repo_1");
-			try {
-				await access(join(wsDir, "marker"));
-				markerExistedDuringRun = true;
-			} catch {
-				markerExistedDuringRun = false;
-			}
-		}
 
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([
+		await using ctx = await createTestOrchestrator({
+			workflows: new Map([
 				[REPO, createTestWorkflow({ hooks: { before_run: "touch marker" } })],
 			]),
-			runner,
-			runAgent: checkMarkerAgent,
+			// biome-ignore lint/correctness/useYield: agent only needs side effects, no messages to yield
+			runAgent: async function* checkMarkerAgent() {
+				const wsDir = join(ctx.workspace.root, "test-owner_test-repo_1");
+				try {
+					await access(join(wsDir, "marker"));
+					markerExistedDuringRun = true;
+				} catch {
+					markerExistedDuringRun = false;
+				}
+			},
 		});
+		const { orchestrator, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -77,24 +56,12 @@ describe("Orchestrator dispatch hooks and completion", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
 		// The after_run hook writes a marker file outside the workspace root
 		// so it survives workspace cleanup by onFinally
-		const sentinelPath = join(workspace.root, "after_marker_sentinel");
+		const sentinelPath = join(tmpdir(), `after_marker_sentinel-${Date.now()}`);
 
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([
+		await using ctx = await createTestOrchestrator({
+			workflows: new Map([
 				[
 					REPO,
 					createTestWorkflow({
@@ -102,15 +69,16 @@ describe("Orchestrator dispatch hooks and completion", () => {
 					}),
 				],
 			]),
-			runner,
-			runAgent: noopAgent,
 		});
+		const { orchestrator, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
 		await orchestrator.settled();
 
 		await expect(access(sentinelPath)).resolves.toBeUndefined();
+		await rm(sentinelPath, { force: true });
 	});
 
 	it("before_run failure prevents dispatch", async () => {
@@ -120,30 +88,13 @@ describe("Orchestrator dispatch hooks and completion", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([
-				[
-					REPO,
-					createTestWorkflow({
-						hooks: { before_run: "exit 1" },
-					}),
-				],
+		await using ctx = await createTestOrchestrator({
+			workflows: new Map([
+				[REPO, createTestWorkflow({ hooks: { before_run: "exit 1" } })],
 			]),
-			runner,
-			runAgent: noopAgent,
 		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -170,23 +121,9 @@ describe("Orchestrator dispatch hooks and completion", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
+		await using ctx = await createTestOrchestrator();
+		const { orchestrator, db, runner, workspace } = ctx;
 		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
-		});
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -228,30 +165,13 @@ describe("Orchestrator dispatch hooks and completion", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([
-				[
-					REPO,
-					createTestWorkflow({
-						hooks: { after_run: "exit 1" },
-					}),
-				],
+		await using ctx = await createTestOrchestrator({
+			workflows: new Map([
+				[REPO, createTestWorkflow({ hooks: { after_run: "exit 1" } })],
 			]),
-			runner,
-			runAgent: noopAgent,
 		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -307,23 +227,9 @@ describe("Orchestrator dispatch hooks and completion", () => {
 			),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
+		await using ctx = await createTestOrchestrator();
+		const { orchestrator, db, runner, workspace } = ctx;
 		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
-		});
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -355,23 +261,9 @@ describe("Orchestrator dispatch hooks and completion", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
+		await using ctx = await createTestOrchestrator();
+		const { orchestrator, runner, workspace } = ctx;
 		const wsDir = await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
-		});
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();

--- a/server/orchestrator/__tests__/orchestrator.dispatch-multi-repo.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.dispatch-multi-repo.integration.test.ts
@@ -1,26 +1,17 @@
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
-import { githubCodeHostAdapter } from "../../code-hosts/github.ts";
 import { runs } from "../../db/schema.ts";
-import { createGitHubClient } from "../../github-client.ts";
-import { createRunRepository } from "../../run-repository.ts";
-import { createRunner } from "../../runner/runner.ts";
 import {
 	createGitHubIssue,
 	createSessionAgent,
 	createTestWorkflow,
 	GITHUB_API,
 	hangingAgent,
-	noopAgent,
 	REPO,
 } from "../../testing/support/fixtures.ts";
 import { githubHandlers, server } from "../../testing/support/msw.ts";
-import { createTestConfig } from "../../testing/support/test-config.ts";
-import { createTestDb } from "../../testing/support/test-db.ts";
-import { createTestWorkspaceRoot } from "../../testing/support/test-workspace.ts";
-import { githubTrackerAdapter } from "../../trackers/github.ts";
+import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
 import type { RepoWorkflow } from "../../workflow/workflow.ts";
-import { createOrchestrator } from "../orchestrator.ts";
 
 describe("Orchestrator dispatch multi-repo", () => {
 	it("ticking guard prevents concurrent ticks", async () => {
@@ -38,23 +29,12 @@ describe("Orchestrator dispatch multi-repo", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 5 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
+		await using ctx = await createTestOrchestrator({
+			maxConcurrency: 5,
 			runAgent: hangingAgent,
 		});
+		const { orchestrator, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		await Promise.all([orchestrator.tick(), orchestrator.tick()]);
 
@@ -97,26 +77,15 @@ describe("Orchestrator dispatch multi-repo", () => {
 			),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO2}#10`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 5 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
+		await using ctx = await createTestOrchestrator({
+			maxConcurrency: 5,
 			workflows: new Map<string, RepoWorkflow>([
 				[REPO, createTestWorkflow()],
 				[REPO2, createTestWorkflow()],
 			]),
-			runner,
-			runAgent: noopAgent,
 		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO2}#10`);
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -183,30 +152,17 @@ describe("Orchestrator dispatch multi-repo", () => {
 			),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-		await workspace.preCreateWorkspace(`${REPO2}#2`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 5 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({
-				workspace_root: workspace.root,
-				max_concurrent: 5,
-			}),
+		await using ctx = await createTestOrchestrator({
+			maxConcurrency: 5,
+			configOverrides: { max_concurrent: 5 },
 			workflows: new Map<string, RepoWorkflow>([
 				[REPO, createTestWorkflow()],
 				[REPO2, createTestWorkflow()],
 			]),
-			runner,
-			runAgent: noopAgent,
 		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
+		await workspace.preCreateWorkspace(`${REPO2}#2`);
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -255,25 +211,13 @@ describe("Orchestrator dispatch multi-repo", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
+		await using ctx = await createTestOrchestrator({
 			runAgent: createSessionAgent("test-sess-abc", [
 				{ type: "text", text: "Working on it" },
 			]),
 		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -305,14 +249,6 @@ describe("Orchestrator dispatch multi-repo", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
 		// biome-ignore lint/suspicious/noExplicitAny: decouple test fixture from SDK's message shape
 		async function* mixedMessageAgent(): AsyncGenerator<any> {
 			yield { type: "system" };
@@ -325,15 +261,11 @@ describe("Orchestrator dispatch multi-repo", () => {
 			};
 		}
 
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
+		await using ctx = await createTestOrchestrator({
 			runAgent: mixedMessageAgent,
 		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();

--- a/server/orchestrator/__tests__/orchestrator.dispatch-rollback.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.dispatch-rollback.integration.test.ts
@@ -1,21 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { githubCodeHostAdapter } from "../../code-hosts/github.ts";
-import { createGitHubClient } from "../../github-client.ts";
-import { createRunRepository } from "../../run-repository.ts";
-import { createRunner } from "../../runner/runner.ts";
-import {
-	createGitHubIssue,
-	createTestWorkflow,
-	noopAgent,
-	REPO,
-} from "../../testing/support/fixtures.ts";
+import { createGitHubIssue } from "../../testing/support/fixtures.ts";
 import { githubHandlers, server } from "../../testing/support/msw.ts";
-import { createTestConfig } from "../../testing/support/test-config.ts";
-import { createTestDb } from "../../testing/support/test-db.ts";
-import { createTestWorkspaceRoot } from "../../testing/support/test-workspace.ts";
-import { githubTrackerAdapter } from "../../trackers/github.ts";
-import type { RepoWorkflow } from "../../workflow/workflow.ts";
-import { createOrchestrator } from "../orchestrator.ts";
+import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
 
 describe("Orchestrator dispatch label rollback", () => {
 	it("recovers an issue stuck with agent:running label but no DB record", async () => {
@@ -35,22 +21,8 @@ describe("Orchestrator dispatch label rollback", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
-		});
+		await using ctx = await createTestOrchestrator();
+		const { orchestrator, runner } = ctx;
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();

--- a/server/orchestrator/__tests__/orchestrator.dispatch.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.dispatch.integration.test.ts
@@ -1,23 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { githubCodeHostAdapter } from "../../code-hosts/github.ts";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it, vi } from "vitest";
 import { runs } from "../../db/schema.ts";
-import { createGitHubClient } from "../../github-client.ts";
-import { createRunRepository } from "../../run-repository.ts";
-import { createRunner } from "../../runner/runner.ts";
 import {
 	createGitHubIssue,
-	createTestWorkflow,
+	GITHUB_API,
 	hangingAgent,
-	noopAgent,
 	REPO,
 } from "../../testing/support/fixtures.ts";
 import { githubHandlers, server } from "../../testing/support/msw.ts";
-import { createTestConfig } from "../../testing/support/test-config.ts";
-import { createTestDb } from "../../testing/support/test-db.ts";
-import { createTestWorkspaceRoot } from "../../testing/support/test-workspace.ts";
-import { githubTrackerAdapter } from "../../trackers/github.ts";
-import type { RepoWorkflow } from "../../workflow/workflow.ts";
-import { createOrchestrator } from "../orchestrator.ts";
+import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
 
 describe("Orchestrator dispatch", () => {
 	it("dispatches agent for a pending issue, swaps label, and creates DB record", async () => {
@@ -31,23 +22,9 @@ describe("Orchestrator dispatch", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
+		await using ctx = await createTestOrchestrator();
+		const { orchestrator, db, runner, workspace } = ctx;
 		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
-		});
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -86,23 +63,9 @@ describe("Orchestrator dispatch", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
+		await using ctx = await createTestOrchestrator();
+		const { orchestrator, runner, workspace } = ctx;
 		await workspace.preCreateWorkspace(`${REPO}#5`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
-		});
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -129,28 +92,15 @@ describe("Orchestrator dispatch", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
+		await using ctx = await createTestOrchestrator({
+			maxConcurrency: 5,
+			configOverrides: { max_concurrent: 1 },
+			runAgent: hangingAgent,
+		});
+		const { orchestrator, db, workspace } = ctx;
 		for (const num of [1, 2, 3]) {
 			await workspace.preCreateWorkspace(`${REPO}#${num}`);
 		}
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 5 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({
-				workspace_root: workspace.root,
-				max_concurrent: 1,
-			}),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: hangingAgent,
-		});
 
 		await orchestrator.tick();
 
@@ -184,28 +134,14 @@ describe("Orchestrator dispatch", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
+		await using ctx = await createTestOrchestrator({
+			maxConcurrency: 5,
+			configOverrides: { max_concurrent: 2 },
+		});
+		const { orchestrator, db, runner, workspace } = ctx;
 		for (const num of [42, 77, 99]) {
 			await workspace.preCreateWorkspace(`${REPO}#${num}`);
 		}
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 5 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({
-				workspace_root: workspace.root,
-				max_concurrent: 2,
-			}),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
-		});
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -258,23 +194,12 @@ describe("Orchestrator dispatch", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 5 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
+		await using ctx = await createTestOrchestrator({
+			maxConcurrency: 5,
 			runAgent: hangingAgent,
 		});
+		const { orchestrator, db, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		// First tick: dispatches the agent
 		await orchestrator.tick();
@@ -317,25 +242,13 @@ describe("Orchestrator dispatch", () => {
 
 		// DON'T pre-create workspace — let ensureWorkspace try git clone against
 		// MSW's fake URL, which will fail because it's not a real git remote
-		await using workspace = await createTestWorkspaceRoot();
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const codeHost = githubCodeHostAdapter(github);
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			// Override cloneUrl to a non-existent local path so git clone fails
-			// instantly instead of waiting for a network timeout
-			codeHost: { ...codeHost, cloneUrl: () => "/nonexistent/repo.git" },
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
+		await using ctx = await createTestOrchestrator({
+			codeHost: (defaults) => ({
+				...defaults,
+				cloneUrl: () => "/nonexistent/repo.git",
+			}),
 		});
+		const { orchestrator, db, runner } = ctx;
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -350,5 +263,81 @@ describe("Orchestrator dispatch", () => {
 
 		const allRuns = db.select().from(runs).all();
 		expect(allRuns).toHaveLength(0);
+	});
+
+	it("start() triggers polling and stop() halts it", async () => {
+		vi.useFakeTimers();
+
+		let tickCount = 0;
+
+		server.use(
+			...githubHandlers({
+				resolveIssues: () => {
+					tickCount++;
+					return [];
+				},
+			}),
+		);
+
+		await using ctx = await createTestOrchestrator({
+			configOverrides: { polling_interval_ms: 1000 },
+		});
+		const { orchestrator } = ctx;
+
+		orchestrator.start();
+
+		await vi.advanceTimersByTimeAsync(0);
+		expect(tickCount).toBe(2);
+
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(tickCount).toBe(4);
+
+		orchestrator.stop();
+
+		await vi.advanceTimersByTimeAsync(5000);
+		expect(tickCount).toBe(4);
+
+		vi.useRealTimers();
+	});
+
+	it("start() keeps polling when tick() throws on a label swap failure", async () => {
+		vi.useFakeTimers();
+
+		let tickCount = 0;
+
+		server.use(
+			...githubHandlers({
+				resolveIssues: () => {
+					tickCount++;
+					return [createGitHubIssue(1, ["agent"])];
+				},
+			}),
+		);
+		// Label delete always fails, so the initial swap (pending → running) throws
+		server.use(
+			http.delete(
+				`${GITHUB_API}/repos/${REPO}/issues/:number/labels/:label`,
+				() => new HttpResponse(null, { status: 500 }),
+			),
+		);
+
+		await using ctx = await createTestOrchestrator({
+			configOverrides: { polling_interval_ms: 1000 },
+		});
+		const { orchestrator, db } = ctx;
+
+		orchestrator.start();
+
+		await vi.advanceTimersByTimeAsync(0);
+		expect(tickCount).toBe(2);
+
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(tickCount).toBe(4);
+
+		const allRuns = db.select().from(runs).all();
+		expect(allRuns).toHaveLength(0);
+
+		orchestrator.stop();
+		vi.useRealTimers();
 	});
 });

--- a/server/orchestrator/__tests__/orchestrator.post-run.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.post-run.integration.test.ts
@@ -1,21 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { githubCodeHostAdapter } from "../../code-hosts/github.ts";
-import { createGitHubClient } from "../../github-client.ts";
-import { createRunRepository } from "../../run-repository.ts";
-import { createRunner } from "../../runner/runner.ts";
 import {
 	createGitHubIssue,
-	createTestWorkflow,
 	noopAgent,
 	REPO,
 } from "../../testing/support/fixtures.ts";
 import { githubHandlers, server } from "../../testing/support/msw.ts";
-import { createTestConfig } from "../../testing/support/test-config.ts";
-import { createTestDb, seedRun } from "../../testing/support/test-db.ts";
-import { createTestWorkspaceRoot } from "../../testing/support/test-workspace.ts";
-import { githubTrackerAdapter } from "../../trackers/github.ts";
-import type { RepoWorkflow } from "../../workflow/workflow.ts";
-import { createOrchestrator } from "../orchestrator.ts";
+import { seedRun } from "../../testing/support/test-db.ts";
+import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
 
 describe("Orchestrator post-run recovery", () => {
 	it("reconciles issue labeled agent:running in GitHub when DB run is already completed", async () => {
@@ -33,10 +24,9 @@ describe("Orchestrator post-run recovery", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
+		await using ctx = await createTestOrchestrator({ runAgent: noopAgent });
+		const { orchestrator, db, runner } = ctx;
 
-		const db = createTestDb();
-		const repo = createRunRepository(db);
 		seedRun(db, {
 			id: "completed-orphan",
 			agentName: "issue-1",
@@ -46,19 +36,6 @@ describe("Orchestrator post-run recovery", () => {
 			completedAt: new Date().toISOString(),
 			durationMs: 1000,
 			attempt: 1,
-		});
-
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
 		});
 
 		await orchestrator.tick();

--- a/server/orchestrator/__tests__/orchestrator.reconcile.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.reconcile.integration.test.ts
@@ -1,25 +1,15 @@
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
-import { githubCodeHostAdapter } from "../../code-hosts/github.ts";
 import { runs } from "../../db/schema.ts";
-import { createGitHubClient } from "../../github-client.ts";
-import { createRunRepository } from "../../run-repository.ts";
-import { createRunner } from "../../runner/runner.ts";
 import {
 	createGitHubIssue,
-	createTestWorkflow,
 	GITHUB_API,
 	hangingAgent,
 	noopAgent,
 	REPO,
 } from "../../testing/support/fixtures.ts";
 import { githubHandlers, server } from "../../testing/support/msw.ts";
-import { createTestConfig } from "../../testing/support/test-config.ts";
-import { createTestDb } from "../../testing/support/test-db.ts";
-import { createTestWorkspaceRoot } from "../../testing/support/test-workspace.ts";
-import { githubTrackerAdapter } from "../../trackers/github.ts";
-import type { RepoWorkflow } from "../../workflow/workflow.ts";
-import { createOrchestrator } from "../orchestrator.ts";
+import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
 
 describe("Orchestrator reconciliation", () => {
 	it("kills agent when issue no longer has the running label", async () => {
@@ -36,26 +26,13 @@ describe("Orchestrator reconciliation", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 5 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({
-				workspace_root: workspace.root,
-				max_concurrent: 5,
-			}),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
+		await using ctx = await createTestOrchestrator({
+			maxConcurrency: 5,
+			configOverrides: { max_concurrent: 5 },
 			runAgent: hangingAgent,
 		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		// First tick: dispatches the agent
 		await orchestrator.tick();
@@ -119,26 +96,13 @@ describe("Orchestrator reconciliation", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#2`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 5 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({
-				workspace_root: workspace.root,
-				max_concurrent: 5,
-			}),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
+		await using ctx = await createTestOrchestrator({
+			maxConcurrency: 5,
+			configOverrides: { max_concurrent: 5 },
 			runAgent: hangingAgent,
 		});
+		const { orchestrator, db, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#2`);
 
 		// Dispatch
 		await orchestrator.tick();
@@ -185,22 +149,10 @@ describe("Orchestrator reconciliation", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 5 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
+		await using ctx = await createTestOrchestrator({
+			maxConcurrency: 5,
 		});
+		const { orchestrator } = ctx;
 
 		// No running agents — tick should still fetch running issues to detect orphans
 		await orchestrator.tick();
@@ -238,26 +190,13 @@ describe("Orchestrator reconciliation", () => {
 			),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 5 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({
-				workspace_root: workspace.root,
-				max_concurrent: 5,
-			}),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
+		await using ctx = await createTestOrchestrator({
+			maxConcurrency: 5,
+			configOverrides: { max_concurrent: 5 },
 			runAgent: hangingAgent,
 		});
+		const { orchestrator, db, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		// First tick: dispatches the agent
 		await orchestrator.tick();
@@ -318,26 +257,13 @@ describe("Orchestrator reconciliation", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 5 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({
-				workspace_root: workspace.root,
-				max_concurrent: 5,
-			}),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
+		await using ctx = await createTestOrchestrator({
+			maxConcurrency: 5,
+			configOverrides: { max_concurrent: 5 },
 			runAgent: noopAgent,
 		});
+		const { orchestrator, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 
 		// Tick 1: dispatches the agent. Handler completes instantly (noopAgent),
 		// but onSettled blocks on PR creation (barrier).
@@ -368,12 +294,10 @@ describe("Orchestrator reconciliation", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 5 });
+		await using ctx = await createTestOrchestrator({
+			maxConcurrency: 5,
+		});
+		const { orchestrator, db } = ctx;
 
 		// Seed a "running" record with no actual process (simulates server restart)
 		db.insert(runs)
@@ -387,16 +311,6 @@ describe("Orchestrator reconciliation", () => {
 				attempt: 1,
 			})
 			.run();
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
-		});
 
 		await orchestrator.tick();
 

--- a/server/orchestrator/__tests__/orchestrator.retry-prompt.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.retry-prompt.integration.test.ts
@@ -1,20 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { githubCodeHostAdapter } from "../../code-hosts/github.ts";
-import { createGitHubClient } from "../../github-client.ts";
-import { createRunRepository } from "../../run-repository.ts";
-import { createRunner } from "../../runner/runner.ts";
 import {
 	createGitHubIssue,
 	createPromptSpyAgent,
 	REPO,
 } from "../../testing/support/fixtures.ts";
 import { githubHandlers, server } from "../../testing/support/msw.ts";
-import { createTestConfig } from "../../testing/support/test-config.ts";
-import { createTestDb, seedRun } from "../../testing/support/test-db.ts";
-import { createTestWorkspaceRoot } from "../../testing/support/test-workspace.ts";
-import { githubTrackerAdapter } from "../../trackers/github.ts";
+import { seedRun } from "../../testing/support/test-db.ts";
+import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
 import type { RepoWorkflow } from "../../workflow/workflow.ts";
-import { createOrchestrator } from "../orchestrator.ts";
 
 const failedRunDefaults = {
 	agentName: "issue-1",
@@ -35,15 +28,6 @@ describe("Orchestrator retry prompt fidelity", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		seedRun(db, { ...failedRunDefaults, id: "failed-prompt" });
-
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
 		const { spyAgent, getCaptured } = createPromptSpyAgent();
 
 		const workflow: RepoWorkflow = {
@@ -53,15 +37,13 @@ describe("Orchestrator retry prompt fidelity", () => {
 				"Fix issue #{{ issue.number }}: {{ issue.title }}\n\nDescription: {{ issue.description }}",
 		};
 
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, workflow]]),
-			runner,
+		await using ctx = await createTestOrchestrator({
+			workflows: new Map([[REPO, workflow]]),
 			runAgent: spyAgent,
 		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
+		seedRun(db, { ...failedRunDefaults, id: "failed-prompt" });
 
 		await orchestrator.retryRun("failed-prompt");
 		await runner.queue.waitForIdle();
@@ -80,15 +62,6 @@ describe("Orchestrator retry prompt fidelity", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		seedRun(db, { ...failedRunDefaults, id: "failed-meta" });
-
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
 		const { spyAgent, getCaptured } = createPromptSpyAgent();
 
 		const workflow: RepoWorkflow = {
@@ -98,15 +71,13 @@ describe("Orchestrator retry prompt fidelity", () => {
 				"Fix issue #{{ issue.number }} [{{ issue.labels }}]: {{ issue.title }}",
 		};
 
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, workflow]]),
-			runner,
+		await using ctx = await createTestOrchestrator({
+			workflows: new Map([[REPO, workflow]]),
 			runAgent: spyAgent,
 		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
+		seedRun(db, { ...failedRunDefaults, id: "failed-meta" });
 
 		await orchestrator.retryRun("failed-meta");
 		await runner.queue.waitForIdle();

--- a/server/orchestrator/__tests__/orchestrator.retry.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.retry.integration.test.ts
@@ -1,23 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { githubCodeHostAdapter } from "../../code-hosts/github.ts";
 import { runs } from "../../db/schema.ts";
-import { createGitHubClient } from "../../github-client.ts";
-import { createRunRepository } from "../../run-repository.ts";
-import { createRunner } from "../../runner/runner.ts";
 import {
 	createGitHubIssue,
 	createPromptSpyAgent,
-	createTestWorkflow,
-	noopAgent,
 	REPO,
 } from "../../testing/support/fixtures.ts";
 import { githubHandlers, server } from "../../testing/support/msw.ts";
-import { createTestConfig } from "../../testing/support/test-config.ts";
-import { createTestDb, seedRun } from "../../testing/support/test-db.ts";
-import { createTestWorkspaceRoot } from "../../testing/support/test-workspace.ts";
-import { githubTrackerAdapter } from "../../trackers/github.ts";
+import { seedRun } from "../../testing/support/test-db.ts";
+import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
 import type { RepoWorkflow } from "../../workflow/workflow.ts";
-import { createOrchestrator } from "../orchestrator.ts";
 
 const failedRunDefaults = {
 	agentName: "issue-1",
@@ -38,25 +29,10 @@ describe("Orchestrator retryRun", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
+		await using ctx = await createTestOrchestrator();
+		const { orchestrator, db, runner, workspace } = ctx;
 		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
 		seedRun(db, { ...failedRunDefaults, id: "failed-1" });
-
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
-		});
 
 		const result = await orchestrator.retryRun("failed-1");
 		expect(result).toEqual({ runId: expect.any(String) });
@@ -89,30 +65,17 @@ describe("Orchestrator retryRun", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
-		await workspace.preCreateWorkspace(`${REPO}#1`);
+		const { spyAgent, getCaptured } = createPromptSpyAgent();
 
-		const db = createTestDb();
-		const repo = createRunRepository(db);
+		await using ctx = await createTestOrchestrator({
+			runAgent: spyAgent,
+		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 		seedRun(db, {
 			...failedRunDefaults,
 			id: "failed-2",
 			sessionId: "sess-resume-me",
-		});
-
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const { spyAgent, getCaptured } = createPromptSpyAgent();
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: spyAgent,
 		});
 
 		await orchestrator.retryRun("failed-2");
@@ -131,20 +94,8 @@ describe("Orchestrator retryRun", () => {
 	it("rejects retry when run does not exist", async () => {
 		server.use(...githubHandlers());
 
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig(),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
-		});
+		await using ctx = await createTestOrchestrator();
+		const { orchestrator } = ctx;
 
 		const result = await orchestrator.retryRun("nonexistent-id");
 		expect(result).toEqual({ error: "Run not found" });
@@ -157,28 +108,13 @@ describe("Orchestrator retryRun", () => {
 			}),
 		);
 
-		await using workspace = await createTestWorkspaceRoot();
+		await using ctx = await createTestOrchestrator();
+		const { orchestrator, db, runner, workspace } = ctx;
 		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		const db = createTestDb();
-		const repo = createRunRepository(db);
 		seedRun(db, {
 			...failedRunDefaults,
 			id: "no-title",
 			issueTitle: null,
-		});
-
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ workspace_root: workspace.root }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
 		});
 
 		const result = await orchestrator.retryRun("no-title");
@@ -208,26 +144,13 @@ describe("Orchestrator retryRun", () => {
 	it("rejects retry when run is not failed", async () => {
 		server.use(...githubHandlers());
 
-		const db = createTestDb();
-		const repo = createRunRepository(db);
+		await using ctx = await createTestOrchestrator();
+		const { orchestrator, db } = ctx;
 		seedRun(db, {
 			...failedRunDefaults,
 			id: "completed-1",
 			status: "completed",
 			error: undefined,
-		});
-
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig(),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
 		});
 
 		const result = await orchestrator.retryRun("completed-1");
@@ -237,22 +160,9 @@ describe("Orchestrator retryRun", () => {
 	it("rejects retry when run has no sessionId", async () => {
 		server.use(...githubHandlers());
 
-		const db = createTestDb();
-		const repo = createRunRepository(db);
+		await using ctx = await createTestOrchestrator();
+		const { orchestrator, db } = ctx;
 		seedRun(db, { ...failedRunDefaults, id: "no-sess", sessionId: null });
-
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig(),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
-		});
 
 		const result = await orchestrator.retryRun("no-sess");
 		expect(result).toEqual({ error: "No session to resume" });
@@ -261,22 +171,11 @@ describe("Orchestrator retryRun", () => {
 	it("rejects retry when max retries exceeded", async () => {
 		server.use(...githubHandlers());
 
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		seedRun(db, { ...failedRunDefaults, id: "maxed-out", attempt: 4 });
-
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig({ max_retries: 3 }),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
+		await using ctx = await createTestOrchestrator({
+			configOverrides: { max_retries: 3 },
 		});
+		const { orchestrator, db } = ctx;
+		seedRun(db, { ...failedRunDefaults, id: "maxed-out", attempt: 4 });
 
 		const result = await orchestrator.retryRun("maxed-out");
 		expect(result).toEqual({ error: "Max retries exceeded" });
@@ -285,22 +184,9 @@ describe("Orchestrator retryRun", () => {
 	it("rejects retry when run has no issue key", async () => {
 		server.use(...githubHandlers());
 
-		const db = createTestDb();
-		const repo = createRunRepository(db);
+		await using ctx = await createTestOrchestrator();
+		const { orchestrator, db } = ctx;
 		seedRun(db, { ...failedRunDefaults, id: "no-issue", issueKey: null });
-
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig(),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
-		});
 
 		const result = await orchestrator.retryRun("no-issue");
 		expect(result).toEqual({ error: "No issue key" });
@@ -309,23 +195,12 @@ describe("Orchestrator retryRun", () => {
 	it("rejects retry when no workflow exists for the repo", async () => {
 		server.use(...githubHandlers());
 
-		const db = createTestDb();
-		const repo = createRunRepository(db);
-		seedRun(db, { ...failedRunDefaults, id: "no-workflow" });
-
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig(),
+		await using ctx = await createTestOrchestrator({
 			// Empty workflows map — no workflow for the repo
 			workflows: new Map<string, RepoWorkflow>(),
-			runner,
-			runAgent: noopAgent,
 		});
+		const { orchestrator, db } = ctx;
+		seedRun(db, { ...failedRunDefaults, id: "no-workflow" });
 
 		const result = await orchestrator.retryRun("no-workflow");
 		expect(result).toEqual({ error: "No workflow for repo" });
@@ -334,27 +209,14 @@ describe("Orchestrator retryRun", () => {
 	it("rejects retry when issue already has a running agent", async () => {
 		server.use(...githubHandlers());
 
-		const db = createTestDb();
-		const repo = createRunRepository(db);
+		await using ctx = await createTestOrchestrator();
+		const { orchestrator, db } = ctx;
 		seedRun(db, { ...failedRunDefaults, id: "failed-dup" });
 		seedRun(db, {
 			id: "running-1",
 			agentName: "issue-1",
 			status: "running",
 			issueKey: `${REPO}#1`,
-		});
-
-		const github = createGitHubClient("test-token");
-		const runner = createRunner({ repo, maxConcurrency: 2 });
-
-		const orchestrator = createOrchestrator({
-			runRepo: repo,
-			tracker: githubTrackerAdapter(github),
-			codeHost: githubCodeHostAdapter(github),
-			config: createTestConfig(),
-			workflows: new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
-			runner,
-			runAgent: noopAgent,
 		});
 
 		const result = await orchestrator.retryRun("failed-dup");

--- a/server/testing/support/test-orchestrator.ts
+++ b/server/testing/support/test-orchestrator.ts
@@ -1,0 +1,63 @@
+import { githubCodeHostAdapter } from "../../code-hosts/github.ts";
+import type { CodeHostAdapter } from "../../code-hosts/types.ts";
+import { createGitHubClient } from "../../github-client.ts";
+import { createOrchestrator } from "../../orchestrator/orchestrator.ts";
+import { createRunRepository } from "../../run-repository.ts";
+import { createRunner } from "../../runner/runner.ts";
+import { githubTrackerAdapter } from "../../trackers/github.ts";
+import type { RepoWorkflow } from "../../workflow/workflow.ts";
+import { createTestWorkflow, noopAgent, REPO } from "./fixtures.ts";
+import { createTestConfig } from "./test-config.ts";
+import { createTestDb } from "./test-db.ts";
+import { createTestWorkspaceRoot } from "./test-workspace.ts";
+
+type CreateTestOrchestratorOptions = {
+	runAgent?: Parameters<typeof createOrchestrator>[0]["runAgent"];
+	configOverrides?: Parameters<typeof createTestConfig>[0];
+	workflows?: Map<string, RepoWorkflow>;
+	maxConcurrency?: number;
+	codeHost?: (defaults: CodeHostAdapter) => CodeHostAdapter;
+};
+
+export async function createTestOrchestrator(
+	options: CreateTestOrchestratorOptions = {},
+) {
+	const workspace = await createTestWorkspaceRoot();
+	const db = createTestDb();
+	const repo = createRunRepository(db);
+	const github = createGitHubClient("test-token");
+	const runner = createRunner({
+		repo,
+		maxConcurrency: options.maxConcurrency ?? 2,
+	});
+
+	const defaultCodeHost = githubCodeHostAdapter(github);
+
+	const orchestrator = createOrchestrator({
+		runRepo: repo,
+		tracker: githubTrackerAdapter(github),
+		codeHost: options.codeHost
+			? options.codeHost(defaultCodeHost)
+			: defaultCodeHost,
+		config: createTestConfig({
+			workspace_root: workspace.root,
+			...options.configOverrides,
+		}),
+		workflows:
+			options.workflows ??
+			new Map<string, RepoWorkflow>([[REPO, createTestWorkflow()]]),
+		runner,
+		runAgent: options.runAgent ?? noopAgent,
+	});
+
+	return {
+		orchestrator,
+		db,
+		repo,
+		runner,
+		workspace,
+		async [Symbol.asyncDispose]() {
+			await workspace[Symbol.asyncDispose]();
+		},
+	};
+}


### PR DESCRIPTION
## Summary
- Extracts a shared `createTestOrchestrator()` helper into `server/testing/support/test-orchestrator.ts`, following the existing `createTestApi` / `createTestDb` patterns
- Updates all 9 orchestrator integration test files to use it, removing ~670 lines of duplicated setup scaffold
- No test cases or assertions changed — identical coverage (99.4%)

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (174/174)
- [x] Coverage unchanged at 99.4%

🤖 Generated with [Claude Code](https://claude.com/claude-code)