### PR TITLE
feat: production-readiness — shutdown, retry, idempotency, health check

### DIFF
--- a/server/__tests__/github-client.integration.test.ts
+++ b/server/__tests__/github-client.integration.test.ts
@@ -1,0 +1,135 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../github-client.ts";
+import { GITHUB_API, REPO } from "../testing/support/fixtures.ts";
+import { server } from "../testing/support/msw.ts";
+
+describe("GitHub client retry", () => {
+	it("retries on 500 and succeeds on the next attempt", async () => {
+		let attempts = 0;
+		server.use(
+			http.get(`${GITHUB_API}/user`, () => {
+				attempts++;
+				if (attempts === 1) {
+					return new HttpResponse(null, { status: 500 });
+				}
+				return HttpResponse.json({ login: "test-user" });
+			}),
+		);
+
+		const client = createGitHubClient("test-token", { baseDelayMs: 1 });
+		const user = await client.getAuthenticatedUser();
+
+		expect(user).toEqual({ login: "test-user" });
+		expect(attempts).toBe(2);
+	});
+
+	it("uses exponential backoff on 429 without Retry-After header", async () => {
+		let attempts = 0;
+		server.use(
+			http.get(`${GITHUB_API}/user`, () => {
+				attempts++;
+				if (attempts === 1) {
+					return new HttpResponse(null, { status: 429 });
+				}
+				return HttpResponse.json({ login: "test-user" });
+			}),
+		);
+
+		const client = createGitHubClient("test-token", { baseDelayMs: 1 });
+		const user = await client.getAuthenticatedUser();
+
+		expect(user).toEqual({ login: "test-user" });
+		expect(attempts).toBe(2);
+	});
+
+	it("retries on 429 and respects Retry-After header", async () => {
+		let attempts = 0;
+		server.use(
+			http.get(`${GITHUB_API}/user`, () => {
+				attempts++;
+				if (attempts === 1) {
+					return new HttpResponse(null, {
+						status: 429,
+						headers: { "Retry-After": "0" },
+					});
+				}
+				return HttpResponse.json({ login: "test-user" });
+			}),
+		);
+
+		const client = createGitHubClient("test-token", { baseDelayMs: 1 });
+		const user = await client.getAuthenticatedUser();
+
+		expect(user).toEqual({ login: "test-user" });
+		expect(attempts).toBe(2);
+	});
+
+	it("throws after exhausting all retry attempts", async () => {
+		server.use(
+			http.get(`${GITHUB_API}/user`, () => {
+				return new HttpResponse(null, { status: 500 });
+			}),
+		);
+
+		const client = createGitHubClient("test-token", {
+			maxAttempts: 2,
+			baseDelayMs: 1,
+		});
+
+		await expect(client.getAuthenticatedUser()).rejects.toThrow(
+			"GitHub API GET /user failed (500)",
+		);
+	});
+
+	it("does not retry on 4xx errors", async () => {
+		let attempts = 0;
+		server.use(
+			http.get(`${GITHUB_API}/repos/${REPO}/issues/999`, () => {
+				attempts++;
+				return new HttpResponse("Not Found", { status: 404 });
+			}),
+		);
+
+		const client = createGitHubClient("test-token", { baseDelayMs: 1 });
+
+		await expect(client.getIssue(REPO, 999)).rejects.toThrow("failed (404)");
+		expect(attempts).toBe(1);
+	});
+
+	it("retries on network errors", async () => {
+		let attempts = 0;
+		server.use(
+			http.get(`${GITHUB_API}/user`, () => {
+				attempts++;
+				if (attempts === 1) {
+					return HttpResponse.error();
+				}
+				return HttpResponse.json({ login: "test-user" });
+			}),
+		);
+
+		const client = createGitHubClient("test-token", { baseDelayMs: 1 });
+		const user = await client.getAuthenticatedUser();
+
+		expect(user).toEqual({ login: "test-user" });
+		expect(attempts).toBe(2);
+	});
+
+	it("throws after exhausting all attempts on network errors", async () => {
+		server.use(
+			http.get(`${GITHUB_API}/user`, () => {
+				return HttpResponse.error();
+			}),
+		);
+
+		const client = createGitHubClient("test-token", {
+			maxAttempts: 2,
+			baseDelayMs: 1,
+		});
+
+		await expect(client.getAuthenticatedUser()).rejects.toThrow(
+			"GitHub API GET /user failed after 2 attempts",
+		);
+	});
+});

--- a/server/api/__tests__/api.test.ts
+++ b/server/api/__tests__/api.test.ts
@@ -1,14 +1,38 @@
 import { describe, expect, it } from "vitest";
 import { createTestApi } from "../../testing/support/test-api.ts";
+import type { HealthCheck } from "../api.ts";
 
 describe("GET /health", () => {
-	it("returns OK", async () => {
+	it("returns 200 with healthy status when all checks pass", async () => {
 		const { app } = createTestApi();
 
 		const res = await app.request("/health");
 
 		expect(res.status).toBe(200);
-		expect(await res.text()).toBe("OK");
+		expect(await res.json()).toEqual({
+			status: "healthy",
+			checks: { database: { status: "pass" } },
+		});
+	});
+
+	it("returns 503 with unhealthy status when a check fails", async () => {
+		const unhealthyCheck: HealthCheck = () => ({
+			status: "unhealthy",
+			checks: {
+				database: { status: "fail", message: "connection refused" },
+			},
+		});
+		const { app } = createTestApi({ checkHealth: unhealthyCheck });
+
+		const res = await app.request("/health");
+
+		expect(res.status).toBe(503);
+		expect(await res.json()).toEqual({
+			status: "unhealthy",
+			checks: {
+				database: { status: "fail", message: "connection refused" },
+			},
+		});
 	});
 });
 

--- a/server/api/__tests__/runs.test.ts
+++ b/server/api/__tests__/runs.test.ts
@@ -267,7 +267,9 @@ describe("POST /runs/:id/kill", () => {
 
 describe("POST /runs/:id/retry", () => {
 	it("returns 201 with new runId on successful retry", async () => {
-		const { app, db } = createTestApi(async () => ({ runId: "new-run-1" }));
+		const { app, db } = createTestApi({
+			retryRun: async () => ({ runId: "new-run-1" }),
+		});
 		seedRun(db, { id: "failed-1", status: "failed" });
 
 		const res = await app.request("/runs/failed-1/retry", { method: "POST" });
@@ -277,9 +279,9 @@ describe("POST /runs/:id/retry", () => {
 	});
 
 	it("returns 400 when retryRun returns an error", async () => {
-		const { app, db } = createTestApi(async () => ({
-			error: "Run is not failed",
-		}));
+		const { app, db } = createTestApi({
+			retryRun: async () => ({ error: "Run is not failed" }),
+		});
 		seedRun(db, { id: "completed-1", status: "completed" });
 
 		const res = await app.request("/runs/completed-1/retry", {

--- a/server/api/api.ts
+++ b/server/api/api.ts
@@ -27,14 +27,23 @@ export type RetryFn = (
 	failedRunId: string,
 ) => Promise<{ runId: string } | { error: string }>;
 
+type HealthCheckResult = {
+	status: "healthy" | "unhealthy";
+	checks: Record<string, { status: "pass" | "fail"; message?: string }>;
+};
+
+export type HealthCheck = () => HealthCheckResult;
+
 export function createApi({
 	runner,
 	repo,
 	retryRun,
+	checkHealth,
 }: {
 	runner: Runner;
 	repo: RunRepository;
 	retryRun: RetryFn;
+	checkHealth: HealthCheck;
 }) {
 	const app = new Hono<AppEnv>();
 	app.onError(problemDetailsHandler);
@@ -111,7 +120,10 @@ export function createApi({
 		},
 	);
 
-	app.get("/health", (c) => c.text("OK"));
+	app.get("/health", (c) => {
+		const result = checkHealth();
+		return c.json(result, result.status === "healthy" ? 200 : 503);
+	});
 
 	return app;
 }

--- a/server/db/db.ts
+++ b/server/db/db.ts
@@ -6,6 +6,7 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 export type Db = ReturnType<typeof drizzle>;
 
 let db: Db | undefined;
+let sqlite: InstanceType<typeof Database> | undefined;
 
 /**
  * Get or create the shared Drizzle database instance.
@@ -16,8 +17,14 @@ export function getDb(dbPath?: string): Db {
 	const resolvedPath =
 		dbPath ?? `${process.env["DATA_DIR"] ?? ".data"}/gateway.db`;
 	mkdirSync(dirname(resolvedPath), { recursive: true });
-	const sqlite = new Database(resolvedPath);
+	sqlite = new Database(resolvedPath);
 	sqlite.pragma("journal_mode = WAL");
 	db = drizzle(sqlite);
 	return db;
+}
+
+export function closeDb(): void {
+	sqlite?.close();
+	sqlite = undefined;
+	db = undefined;
 }

--- a/server/github-client.ts
+++ b/server/github-client.ts
@@ -1,6 +1,17 @@
 import { z } from "zod";
 
 const BASE_URL = "https://api.github.com";
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 1_000;
+
+function isRetryableStatus(status: number): boolean {
+	return status === 429 || status >= 500;
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 const githubUserSchema = z.object({ login: z.string() });
 
@@ -59,7 +70,28 @@ export type GitHubClient = {
 	): Promise<void>;
 };
 
-export function createGitHubClient(token: string): GitHubClient {
+type GitHubClientOptions = {
+	maxAttempts?: number;
+	baseDelayMs?: number;
+	requestTimeoutMs?: number;
+};
+
+export function createGitHubClient(
+	token: string,
+	options?: GitHubClientOptions,
+): GitHubClient {
+	const maxAttempts = Math.max(1, options?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+	const baseDelayMs = options?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+	const requestTimeoutMs = options?.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+	function retryDelay(response: Response, attempt: number): number {
+		if (response.status === 429) {
+			const retryAfter = response.headers.get("Retry-After");
+			if (retryAfter) return Number.parseInt(retryAfter, 10) * 1000;
+		}
+		return baseDelayMs * 2 ** (attempt - 1);
+	}
+
 	async function request<T extends z.ZodType>(
 		path: string,
 		options: { method?: string; body?: Record<string, unknown>; schema: T },
@@ -77,6 +109,7 @@ export function createGitHubClient(token: string): GitHubClient {
 		} = {},
 	) {
 		const { method = "GET", body, schema } = options;
+		const url = `${BASE_URL}${path}`;
 
 		const headers: Record<string, string> = {
 			Authorization: `Bearer ${token}`,
@@ -93,19 +126,45 @@ export function createGitHubClient(token: string): GitHubClient {
 			init.body = JSON.stringify(body);
 		}
 
-		const response = await fetch(`${BASE_URL}${path}`, init);
+		let lastError: unknown;
 
-		if (!response.ok) {
+		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			let response: Response;
+			try {
+				response = await fetch(url, {
+					...init,
+					signal: AbortSignal.timeout(requestTimeoutMs),
+				});
+			} catch (err) {
+				lastError = err;
+				if (attempt < maxAttempts) {
+					await sleep(baseDelayMs * 2 ** (attempt - 1));
+					continue;
+				}
+				throw new Error(
+					`GitHub API ${method} ${path} failed after ${maxAttempts} attempts: ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
+
+			if (response.ok) {
+				if (!schema) return;
+				const text = await response.text();
+				return schema.parse(JSON.parse(text));
+			}
+
+			if (isRetryableStatus(response.status) && attempt < maxAttempts) {
+				await sleep(retryDelay(response, attempt));
+				continue;
+			}
+
 			const text = await response.text();
 			throw new Error(
 				`GitHub API ${method} ${path} failed (${response.status}): ${text}`,
 			);
 		}
 
-		if (!schema) return;
-
-		const text = await response.text();
-		return schema.parse(JSON.parse(text));
+		/* v8 ignore next -- defensive: loop always returns or throws */
+		throw lastError;
 	}
 
 	return {

--- a/server/runner/__tests__/runner.integration.test.ts
+++ b/server/runner/__tests__/runner.integration.test.ts
@@ -68,6 +68,52 @@ describe("Runner integration", () => {
 		await runner.queue.waitForIdle();
 	});
 
+	it("records a running status even when the queue is at capacity", async () => {
+		const runner = createRunner({ repo, maxConcurrency: 1 });
+		let resolveBlocker!: (result: RunResult) => void;
+
+		// Fill the single slot with a blocking job
+		runner.enqueue({
+			name: "blocker",
+			issueKey: "owner/repo#1",
+			issueTitle: "Blocker",
+			handler: () =>
+				new Promise((r) => {
+					resolveBlocker = r;
+				}),
+		});
+
+		// Second job sits in the pending queue — not yet executing
+		const { runId } = runner.enqueue({
+			name: "queued-job",
+			issueKey: "owner/repo#2",
+			issueTitle: "Queued issue",
+			handler: async () => ({ status: "completed" as const, durationMs: 0 }),
+		});
+
+		expect(runner.queue.pendingCount).toBe(1);
+
+		// DB record must exist even though the job hasn't started executing
+		const run = getRun(db, runId);
+		expect(run).toEqual({
+			id: runId,
+			agentName: "queued-job",
+			status: "running",
+			error: null,
+			issueKey: "owner/repo#2",
+			issueTitle: "Queued issue",
+			startedAt: expect.any(String),
+			completedAt: null,
+			durationMs: null,
+			sessionId: null,
+			attempt: 1,
+			parentRunId: null,
+		});
+
+		resolveBlocker({ status: "completed", durationMs: 0 });
+		await runner.queue.waitForIdle();
+	});
+
 	it("marks run as completed with duration on success", async () => {
 		const runner = createRunner({ repo, maxConcurrency: 1 });
 

--- a/server/runner/runner.ts
+++ b/server/runner/runner.ts
@@ -88,29 +88,32 @@ export function createRunner(config: RunnerConfig): Runner {
 		const controller = new AbortController();
 		activeRuns.set(runId, controller);
 
+		// Insert DB record and emit event immediately so reconciliation
+		// sees the run even when the queue is at capacity.
+		const startedAt = new Date().toISOString();
+
+		repo.insertRun({
+			id: runId,
+			agentName: job.name,
+			issueKey: job.issueKey,
+			issueTitle: job.issueTitle,
+			startedAt,
+			attempt: job.attempt ?? 1,
+			parentRunId: job.parentRunId ?? null,
+		});
+
+		emitEvent(
+			runId,
+			job.name,
+			{
+				type: "run:started",
+				data: { issueKey: job.issueKey, issueTitle: job.issueTitle },
+			},
+			startedAt,
+		);
+
 		queue.enqueue(async () => {
-			const startTime = Date.now();
-			const startedAt = new Date(startTime).toISOString();
-
-			repo.insertRun({
-				id: runId,
-				agentName: job.name,
-				issueKey: job.issueKey,
-				issueTitle: job.issueTitle,
-				startedAt,
-				attempt: job.attempt ?? 1,
-				parentRunId: job.parentRunId ?? null,
-			});
-
-			emitEvent(
-				runId,
-				job.name,
-				{
-					type: "run:started",
-					data: { issueKey: job.issueKey, issueTitle: job.issueTitle },
-				},
-				startedAt,
-			);
+			const executionStart = Date.now();
 
 			let sessionCaptured = false;
 			const setSessionId = (id: string) => {
@@ -131,7 +134,7 @@ export function createRunner(config: RunnerConfig): Runner {
 					resolve({
 						status: "failed",
 						error: ABORT_ERROR,
-						durationMs: Date.now() - startTime,
+						durationMs: Date.now() - executionStart,
 					});
 				});
 			});

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,8 +1,8 @@
 import { serve } from "@hono/node-server";
-import { createApi } from "./api/api.ts";
+import { createApi, type HealthCheck } from "./api/api.ts";
 import { githubCodeHostAdapter } from "./code-hosts/github.ts";
 import { loadConfig } from "./config.ts";
-import { getDb } from "./db/db.ts";
+import { closeDb, getDb } from "./db/db.ts";
 import { migrate } from "./db/migrate.ts";
 import { loadEnv } from "./env.ts";
 import { createGitHubClient } from "./github-client.ts";
@@ -44,17 +44,38 @@ const orchestrator = createOrchestrator({
 	runner,
 });
 
+const checkHealth: HealthCheck = () => {
+	const checks: Record<string, { status: "pass" | "fail"; message?: string }> =
+		{};
+
+	try {
+		repo.getRuns({ limit: 1 });
+		checks["database"] = { status: "pass" };
+	} catch (err) {
+		checks["database"] = {
+			status: "fail",
+			message: err instanceof Error ? err.message : String(err),
+		};
+	}
+
+	const allHealthy = Object.values(checks).every((c) => c.status === "pass");
+	return { status: allHealthy ? "healthy" : "unhealthy", checks };
+};
+
 const app = createApi({
 	runner,
 	repo,
 	retryRun: orchestrator.retryRun,
+	checkHealth,
 });
 
 // Start polling + workflow refresh
 workflowCache.start();
 orchestrator.start();
 
-serve({ fetch: app.fetch, port: env.PORT }, (info) => {
+const DRAIN_TIMEOUT_MS = 30_000;
+
+const httpServer = serve({ fetch: app.fetch, port: env.PORT }, (info) => {
 	logger.info(
 		{
 			port: info.port,
@@ -65,3 +86,33 @@ serve({ fetch: app.fetch, port: env.PORT }, (info) => {
 		"orchestrator.started",
 	);
 });
+
+let shuttingDown = false;
+
+async function shutdown(signal: string) {
+	if (shuttingDown) return;
+	shuttingDown = true;
+	logger.info({ signal }, "shutdown.start");
+
+	orchestrator.stop();
+	workflowCache.stop();
+	httpServer.close();
+
+	// Drain in-flight runs with a timeout
+	const drainResult = await Promise.race([
+		orchestrator.settled().then(() => "drained" as const),
+		new Promise<"timeout">((resolve) =>
+			setTimeout(() => resolve("timeout"), DRAIN_TIMEOUT_MS),
+		),
+	]);
+
+	if (drainResult === "timeout") {
+		logger.warn("shutdown.drain_timeout");
+	}
+
+	closeDb();
+	logger.info("shutdown.complete");
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/server/testing/support/test-api.ts
+++ b/server/testing/support/test-api.ts
@@ -1,16 +1,25 @@
-import { createApi, type RetryFn } from "../../api/api.ts";
+import { createApi, type HealthCheck, type RetryFn } from "../../api/api.ts";
 import { createRunRepository } from "../../run-repository.ts";
 import { createRunner } from "../../runner/runner.ts";
 import { createTestDb } from "./test-db.ts";
 
-export function createTestApi(retryRun?: RetryFn) {
+const healthyCheck: HealthCheck = () => ({
+	status: "healthy",
+	checks: { database: { status: "pass" } },
+});
+
+export function createTestApi(opts?: {
+	retryRun?: RetryFn;
+	checkHealth?: HealthCheck;
+}) {
 	const db = createTestDb();
 	const repo = createRunRepository(db);
 	const runner = createRunner({ repo, maxConcurrency: 2 });
 	const app = createApi({
 		runner,
 		repo,
-		retryRun: retryRun ?? (async () => ({ error: "not implemented" })),
+		retryRun: opts?.retryRun ?? (async () => ({ error: "not implemented" })),
+		checkHealth: opts?.checkHealth ?? healthyCheck,
 	});
 	return { app, db, runner };
 }

--- a/server/testing/support/test-orchestrator.ts
+++ b/server/testing/support/test-orchestrator.ts
@@ -25,7 +25,7 @@ export async function createTestOrchestrator(
 	const workspace = await createTestWorkspaceRoot();
 	const db = createTestDb();
 	const repo = createRunRepository(db);
-	const github = createGitHubClient("test-token");
+	const github = createGitHubClient("test-token", { maxAttempts: 1 });
 	const runner = createRunner({
 		repo,
 		maxConcurrency: options.maxConcurrency ?? 2,

--- a/server/workflow/__tests__/workflow-cache.integration.test.ts
+++ b/server/workflow/__tests__/workflow-cache.integration.test.ts
@@ -26,7 +26,7 @@ describe("Workflow cache integration", () => {
 			),
 		);
 
-		const github = createGitHubClient("test-token");
+		const github = createGitHubClient("test-token", { maxAttempts: 1 });
 		const codeHost = githubCodeHostAdapter(github);
 		const cache = createWorkflowCache(codeHost, [REPO]);
 
@@ -47,7 +47,7 @@ describe("Workflow cache integration", () => {
 			),
 		);
 
-		const github = createGitHubClient("test-token");
+		const github = createGitHubClient("test-token", { maxAttempts: 1 });
 		const codeHost = githubCodeHostAdapter(github);
 		const cache = createWorkflowCache(codeHost, [REPO]);
 
@@ -66,7 +66,7 @@ describe("Workflow cache integration", () => {
 			}),
 		);
 
-		const github = createGitHubClient("test-token");
+		const github = createGitHubClient("test-token", { maxAttempts: 1 });
 		const codeHost = githubCodeHostAdapter(github);
 		const cache = createWorkflowCache(codeHost, [REPO]);
 
@@ -103,7 +103,7 @@ base_branch: "develop"
 			),
 		);
 
-		const github = createGitHubClient("test-token");
+		const github = createGitHubClient("test-token", { maxAttempts: 1 });
 		const codeHost = githubCodeHostAdapter(github);
 		const cache = createWorkflowCache(codeHost, [REPO, REPO2]);
 
@@ -135,7 +135,7 @@ base_branch: "develop"
 			}),
 		);
 
-		const github = createGitHubClient("test-token");
+		const github = createGitHubClient("test-token", { maxAttempts: 1 });
 		const codeHost = githubCodeHostAdapter(github);
 		const cache = createWorkflowCache(codeHost, [REPO]);
 
@@ -165,7 +165,7 @@ base_branch: "develop"
 			}),
 		);
 
-		const github = createGitHubClient("test-token");
+		const github = createGitHubClient("test-token", { maxAttempts: 1 });
 		const codeHost = githubCodeHostAdapter(github);
 		const cache = createWorkflowCache(codeHost, [REPO]);
 


### PR DESCRIPTION
## Summary
- **Graceful shutdown**: wire SIGTERM/SIGINT to stop orchestrator + workflow cache, drain in-flight runs (30s timeout), close HTTP server and DB
- **GitHub client retry + timeout**: 30s per-request timeout, 3-attempt exponential backoff on 5xx/429/network errors, respects Retry-After header
- **Idempotent dispatch**: move DB insert before `queue.enqueue()` in runner so reconciliation sees runs even when the queue is at capacity, closing a dispatch race condition
- **Health check**: replace always-OK `/health` with structured JSON that verifies DB connectivity, returning 503 when unhealthy

## Test plan
- [x] Retry: 500 recovery, 429 with/without Retry-After, 4xx no-retry, network error recovery, exhausted attempts
- [x] Idempotency: DB record exists when queue is at capacity (new test)
- [x] Health check: 200 healthy, 503 unhealthy responses
- [x] All 172 existing + new tests pass
- [x] Coverage at 97.65% branches (threshold: 97.5%)
- [x] `pnpm typecheck` and `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)