### PR TITLE
docs: record shell expansion baseline

### DIFF
--- a/docs/design-shell-expansion-and-integrations-decisions.md
+++ b/docs/design-shell-expansion-and-integrations-decisions.md
@@ -1,0 +1,430 @@
+# Design Decisions: Shell Expansion, Multi-Phase Workflows, GitLab & Jira
+
+This document captures the Q&A trail and decisions made while reviewing [design-shell-expansion-and-integrations.md](./design-shell-expansion-and-integrations.md). Several aspects of the original proposal materially changed; this is the source of truth for what we're actually building.
+
+---
+
+## Table of decisions
+
+| # | Topic | Decision |
+|---|---|---|
+| 1 | Shell-block failure | Strict: non-zero exit, timeout, or spawn error all hard-fail the run. Consumer owns command correctness. |
+| 2 | Multi-phase model | Simple: phases = staged prompts. Drop `completion_signal` and `max_iterations` from the schema. |
+| 3 | Phase retry | Resume the failed phase using its in-flight session ID. Skip already-completed phases. |
+| 4 | Hooks vs phases | Hooks bracket the whole dispatch, not each phase. `before_run` once, `after_run` once. |
+| 5 | Tracker API rename | Orchestrator speaks logical state names (`pending`, `running`, `awaiting_review`). Adapters own platform mapping. |
+| 6 | Issue key format | Native per platform (`owner/repo#42`, `PROJ-42`). `parseIssueKey` moves onto the adapter. |
+| 7 | Workflow location | One global `./workflow.yaml` in the local-agents application repo. Not per-target-repo. |
+| 8 | Single workflow only | No multi-workflow, no per-repo workflow override. |
+| 9 | Repo config shape | Singular `code_host` owns the `repos` list. Plain string list. `tracker.project` is global. For Jira, enforce exactly one repo. |
+| 10 | Shell timeout | Hard-coded 30s. No override knob. |
+| 11 | Jira status names | Defaults match Jira out-of-the-box (`To Do`/`In Progress`/`In Review`). Optional override. |
+| 12 | Authentication | Jira basic auth (`JIRA_EMAIL` + `JIRA_API_TOKEN`). GitLab `PRIVATE-TOKEN` header (`GITLAB_TOKEN`). Startup-time validation. |
+| 13 | Phase observability | One run row per dispatch. Add `phaseIndex` column. Canonical-log markers for phase boundaries. |
+| 14 | Implementation order | Refactors first (workflow relocation, tracker rename), then features. |
+
+---
+
+## Detailed Q&A
+
+### Q1 — Shell-block failure behaviour
+
+**Question:** What happens when a `` !`shell command` `` block fails (non-zero exit, timeout, spawn error)?
+
+**Options:**
+- **A.** Strict — any non-zero exit fails the run.
+- **B.** Lenient — capture stdout+stderr, never fail the run.
+- **C.** Hybrid — non-zero substitutes captured output; timeout/spawn errors hard-fail.
+
+**Decision:** **A — strict.**
+
+**Rationale:** Shell blocks are consumer-controlled. Consumers own their workflow and must put commands in that work as expected. The system shouldn't carry weight to handle edge cases caused by malformed commands. `Promise.all` (fail-fast) is the right primitive.
+
+**Consequences:**
+- The doc's `grep` example needs `|| true` to handle "no matches" exit code 1.
+- The doc's `npm test 2>&1 | tail -5` example needs to be dropped or restructured (would exceed the 30s timeout).
+
+---
+
+### Q2 — Multi-phase workflows: how much machinery?
+
+**Question:** Does multi-phase need `completion_signal` and `max_iterations`, or are staged prompts enough?
+
+**Options:**
+- **Simple model** — each phase = one prompt → one `query()` call. Agent runs to natural completion. Optional `resume_previous: true` to share session.
+- **Complex model (original doc)** — adds `completion_signal` (substring match) and `max_iterations` (re-invoke until signal produced).
+
+**Decision:** **Simple model.**
+
+**Rationale:**
+1. The Claude Agent SDK already handles "agent runs until satisfied" via its tool-use loop. An outer retry loop driven by substring-matching agent prose is duct tape on top of native control flow.
+2. `completion_signal` is brittle: false positives on quoted text, false negatives on paraphrasing.
+3. `max_iterations` re-invokes the agent without meaningful new input.
+4. If a phase isn't producing the desired result, the fix is a better prompt — not retrying the same prompt N times.
+
+**Replacement for `completion_signal`:** under strict shell-block mode, a phase's prompt can include a precondition shell block (e.g., `` !`test -f PLAN.md` ``) that hard-fails the run if the prior phase didn't deliver its output.
+
+---
+
+### Q3 — Phase retry semantics
+
+**Question:** When phase 2 of 3 fails, what should `retryRun` do?
+
+**Options:**
+- **A.** Restart from phase 1 (redoes work).
+- **B.** Restart from the failed phase, fresh session.
+- **C.** Restart from the failed phase, resume the in-flight session.
+
+**Decision:** **C.**
+
+**Rationale:**
+- Today's single-prompt retry already resumes the failed run's session. Multi-phase is a generalisation: "resume whatever was running when we failed" — for single-prompt that's the only session; for multi-phase that's the failed phase's session.
+- Consumer mental model is "retry = continue from where it broke".
+- Implementation: persist `phaseIndex` alongside the existing `sessionId` on the run row.
+
+**Edge cases:**
+- Phase 2 had `resume_previous: true` and failed before any messages → session ID is still phase 1's. Re-resume that session, run phase 2's prompt against it. Identical to a forward run.
+- Phase 2 had no `resume_previous` and failed before any messages → no session for phase 2. Start phase 2 fresh.
+- Workspace state (commits, branch) carries through retries (already true today).
+
+---
+
+### Q4 — Hook timing across phases
+
+**Question:** Do `before_run` and `after_run` bracket each phase, or the whole dispatch?
+
+**Decision:** **Bracket the whole dispatch.** `before_run` runs once before phase 1; `after_run` runs once after the final phase succeeds.
+
+**Rationale:** Hooks are workflow concerns, not phase concerns. They handle workspace setup (e.g., `git config user.email`) and run-completion (e.g., `npm run lint:fix`) — naturally once-per-dispatch operations. Per-phase setup, if ever needed, can live as inline shell blocks at the top of a phase's prompt.
+
+---
+
+### Q5 — Tracker API rename: logical states vs platform strings
+
+**Question:** When the orchestrator transitions an issue's state, does it pass logical state names (`pending`, `running`, `awaiting_review`) or platform-specific strings (`agent`, `agent:running`, `agent:awaiting-review`)?
+
+**Decision:** **Logical state names. Adapters own platform mapping.**
+
+**Concrete changes:**
+- `TrackerAdapter.swapLabel` → `TrackerAdapter.transitionState`. Signature takes `from: TrackerState` and `to: TrackerState`.
+- `type TrackerState = "pending" | "running" | "awaiting_review"`.
+- The `LABELS` constant moves from `orchestrator.ts:18-22` into `server/trackers/github.ts`. Stays hardcoded — not configurable for now.
+- The Jira adapter holds a `Record<TrackerState, string>` resolved from config at construction time.
+- Rename `completed` → `awaiting_review` everywhere. `completed` was misleading: the issue isn't completed, the agent finished and a human still has to review.
+
+**Rationale:** Single Responsibility — the orchestrator's job is "issue is pending → claim it → run agent → mark for review". It shouldn't care what label/status string each platform uses.
+
+---
+
+### Q6 — Issue key format for Jira
+
+**Question:** How do Jira issue keys look in the system — `PROJ#42` (matches existing parser) or `PROJ-42` (Jira-native)?
+
+**Decision:** **Native per platform. `owner/repo#42` for GitHub, `PROJ-42` for Jira.**
+
+**Implementation:** `parseIssueKey(key): { repo, number }` moves onto `TrackerAdapter`. Each adapter knows its own format. Orchestrator's private `parseIssueKey` function (`orchestrator.ts:24-30`) is removed; calls become `tracker.parseIssueKey(...)`.
+
+**Rationale:**
+- Dashboard displays match what users see in their tracker UI.
+- Log lines / canonical logs become grep-friendly.
+- Workspace directory names are clean (`PROJ-42` survives `sanitizeKey` unchanged).
+- 6-line parser is trivial to relocate.
+- Generalises to future adapters (Linear `ENG-123`, etc.).
+
+---
+
+### Q7 — Workflow file location
+
+**Question:** Where does `workflow.yaml` live?
+
+**Original (doc):** Per-target-repo at `.agents/workflow.yaml`, fetched via `codeHost.fetchFile`.
+
+**Decision:** **One global `workflow.yaml` in the local-agents application repo.**
+
+**Rationale:**
+- Per-target-repo workflows assume the operator can commit files into every target repo (might not own them).
+- Per-target-repo means clutter and drift across repos.
+- The local-agents application should own its own configuration.
+- Target repos are *work surfaces*, not config storage.
+
+**Layout:**
+```
+local-agents/
+  config.yaml
+  workflow.yaml
+```
+
+**Path is hard-coded** at `./workflow.yaml` (relative to the orchestrator's working directory). No config knob.
+
+---
+
+### Q8 — Single workflow only
+
+**Question:** Do we support multiple workflows referenced by name, with per-repo overrides?
+
+**Decision:** **No. One global workflow applies to every repo.**
+
+**Rationale:** Speculative complexity. No consumer has asked for it. When someone hits a real need (e.g., different `branch` patterns per repo), we add per-repo overrides at that point.
+
+**Note:** Multi-phase still works — phases live *inside* the single workflow file. Multi-phase ≠ multi-workflow.
+
+---
+
+### Q9 — Repo configuration shape
+
+**Question:** When tracker and code host use different identifiers (Jira `PROJ` vs GitLab `myorg/project`), how do you express the link in config?
+
+**Initial proposal (rejected):** Per-entry `tracker_project` field on each repo, with a top-level `default_project` fallback.
+
+**Decision:** **Strip the per-entry override entirely. Use singular `code_host.repos` as the code repo allow-list, and a single global `tracker.project` for Jira. For Jira, enforce exactly one repo per orchestrator instance.**
+
+The config key is `code_host`, not `code_hosts`, because only one code host provider is configured at a time. The existing top-level `repos` field moves under `code_host`.
+
+**Final config shape:**
+
+```yaml
+# GitHub-only (today's setup, unchanged)
+tracker:
+  kind: github
+
+code_host:
+  kind: github
+  repos:
+    - nhollas/target-dummy
+    - nhollas/another-repo
+```
+
+```yaml
+# Jira + GitLab
+tracker:
+  kind: jira
+  base_url: https://yourco.atlassian.net
+  project: PROJ                       # required, singular, global
+  statuses:                            # optional, defaults shown
+    pending: "To Do"
+    running: "In Progress"
+    awaiting_review: "In Review"
+
+code_host:
+  kind: gitlab
+  base_url: https://gitlab.example.com
+  repos:
+    - myorg/payments-api               # exactly one entry when tracker.kind=jira
+```
+
+**How adapters derive their identifier:**
+- **GitHub adapter:** per-repo `tracker_project = repo` (each repo's issues live in itself).
+- **Jira adapter:** global `tracker_project = config.tracker.project`.
+
+**Why one repo for Jira:** A Jira issue knows its project (`PROJ`) but not which repo it's about. With multiple repos under one Jira project, the orchestrator can't tell which to clone for any given issue. Restricting to 1:1 sidesteps the ambiguity. When a real consumer needs multi-repo Jira, we revisit with a deliberate disambiguation mechanism.
+
+**Schema validation:** Discriminated union on `tracker.kind`. Missing/extra fields fail at startup with a clear error.
+
+```typescript
+const trackerSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("github") }),
+  z.object({
+    kind: z.literal("jira"),
+    base_url: z.string().url(),
+    project: z.string().min(1),
+    statuses: z.object({
+      pending: z.string().default("To Do"),
+      running: z.string().default("In Progress"),
+      awaiting_review: z.string().default("In Review"),
+    }).default({}),
+  }),
+]);
+```
+
+---
+
+### Q10 — Shell-block timeout
+
+**Question:** What's the timeout, and is it configurable?
+
+**Decision:** **Hard-coded 30 seconds. No override.**
+
+**Rationale:** Matches the strict-mode spirit. Shell blocks are quick context, not heavy work. If a command needs longer, it's the wrong abstraction — restructure (precompute in `before_run`, write to file, then `!`cat result.txt``).
+
+---
+
+### Q11 — Jira status names
+
+**Question:** Defaults for the three logical states, or require explicit configuration?
+
+**Decision:** **Defaults that match Jira's out-of-the-box workflow. Optional override.**
+
+**Defaults:**
+- `pending: "To Do"`
+- `running: "In Progress"`
+- `awaiting_review: "In Review"`
+
+Consumers with custom Jira workflows override via the `statuses` field.
+
+---
+
+### Q12 — Authentication
+
+**Decisions:**
+
+**Jira:** Basic auth using email + API token.
+- Env vars: `JIRA_EMAIL`, `JIRA_API_TOKEN`.
+- Header sent: `Authorization: Basic <base64(email:token)>`.
+- Only auth method Jira Cloud supports for REST API v3.
+
+**GitLab:** `PRIVATE-TOKEN: <token>` header.
+- Env var: `GITLAB_TOKEN` (PAT, project token, or group token with `api` scope).
+- More universally compatible than `Authorization: Bearer` (works for all token types, both cloud and self-hosted).
+
+**Validation:** Required env vars are validated at startup based on configured adapter `kind`. Missing = startup error. Same pattern as today's `GITHUB_TOKEN` check.
+
+---
+
+### Q13 — Multi-phase observability
+
+**Question:** How are multi-phase runs represented in the database and dashboard?
+
+**Options:**
+- **A.** One row per dispatch with a `phaseIndex` column tracking current phase.
+- **B.** One row per phase, chained via `parentRunId`.
+
+**Decision:** **A.**
+
+**Rationale:**
+- Multi-phase is conceptually one agent claim on one issue. Phases are sub-units.
+- Existing concurrency control and label/state ownership are designed around "one issue = one dispatch". Phases-as-rows breaks that.
+- Reusing `parentRunId` for phases conflates retries (we tried again) with phases (we did the next sub-step).
+- Keeps runs-table volume bounded.
+
+**Schema change:**
+```typescript
+runs.phaseIndex: integer("phase_index").default(0)  // 0 = single-prompt or first phase
+```
+
+**Canonical-log markers** the orchestrator emits per phase:
+- `phase.started` with `{ name, index, total }` at phase start
+- `phase.completed` with `{ name, index, durationMs }` at phase end
+- `phase.failed` with `{ name, index, error }` on error
+
+The dashboard already renders agent messages from the run; phase markers slot in alongside without UI changes.
+
+**Retry chains** still use `parentRunId`. A 3-phase run that failed at phase 2 and was retried produces two rows tagged to the same issue, the second chained as the parent — but each row represents one dispatch attempt, not one phase.
+
+---
+
+### Q14 — Implementation order
+
+**Decision:** Refactors first to unblock features cleanly. Each item is its own PR.
+
+| # | Work | Type | Depends on |
+|---|---|---|---|
+| 1 | Workflow file relocation | Refactor | — |
+| 2 | Tracker state rename | Refactor | — |
+| 3 | Shell expansion | Feature | — |
+| 4 | Multi-phase workflows | Feature | 3, schema |
+| 5 | GitLab adapter | Feature | — |
+| 6 | Jira adapter | Feature | 2 |
+
+**Refactor 1 (workflow relocation):**
+- `server/workflow/workflow-cache.ts` becomes a one-shot loader (`loadWorkflow(path): RepoWorkflow`).
+- Polling/refresh/last-known-good logic deleted.
+- `codeHost` no longer passed to the workflow loader.
+- Server bootstrap (`server.ts:35`) shrinks correspondingly.
+
+**Refactor 2 (tracker rename):**
+- `TrackerAdapter.swapLabel` → `TrackerAdapter.transitionState`.
+- `LABELS` constant moves into `server/trackers/github.ts`.
+- Rename `completed` → `awaiting_review` everywhere.
+- Add `TrackerAdapter.parseIssueKey`.
+- Pure refactor — no behaviour change in single-tracker GitHub setup.
+
+**Items 3, 5, 6 are independent** and could be done in any order or parallelised after the refactors.
+
+**Item 4 depends on item 3** (phase preconditions use shell blocks).
+
+---
+
+## Final consolidated schemas
+
+### `config.yaml`
+
+```yaml
+tracker:
+  kind: github | jira
+  # When kind=jira:
+  base_url: https://yourco.atlassian.net    # required
+  project: PROJ                              # required, global
+  statuses:                                  # optional, defaults shown
+    pending: "To Do"
+    running: "In Progress"
+    awaiting_review: "In Review"
+
+code_host:
+  kind: github | gitlab
+  # When kind=gitlab:
+  base_url: https://gitlab.example.com       # optional, defaults to https://gitlab.com
+  repos:
+    - owner/repo                              # plain string list
+    # For Jira: exactly one entry
+
+defaults:
+  polling_interval_ms: 30000
+  max_concurrent: 2
+  max_retries: 3
+  model: claude-sonnet-4-6
+  workspace_root: /tmp/local-agent-workspaces
+```
+
+### `workflow.yaml`
+
+```yaml
+branch: "agent/issue-{{ issue.number }}"
+base_branch: main
+
+hooks:
+  after_create: "npm install"
+  before_run: "git config user.email bot@example.com"
+  after_run: "npm run lint:fix"
+
+# Single-prompt:
+prompt: |
+  Fix issue {{ issue.number }}...
+  !`git log --oneline -5`
+
+# OR multi-phase (mutually exclusive with `prompt`):
+phases:
+  - name: plan
+    prompt: |
+      Analyse issue {{ issue.number }}, write plan to PLAN.md.
+      !`git log --oneline -5`
+  - name: implement
+    resume_previous: true
+    prompt: |
+      Read PLAN.md and implement.
+      !`test -f PLAN.md`        # precondition; strict-mode hard-fails if missing
+  - name: review
+    prompt: |
+      Review the diff against the plan.
+      !`git diff {{ workflow.base_branch }}...HEAD`
+```
+
+### Environment variables
+
+| Var | Required when | Purpose |
+|---|---|---|
+| `GITHUB_TOKEN` | tracker.kind=github OR code_host.kind=github | GitHub PAT |
+| `JIRA_EMAIL` | tracker.kind=jira | Atlassian account email |
+| `JIRA_API_TOKEN` | tracker.kind=jira | Jira Cloud API token |
+| `GITLAB_TOKEN` | code_host.kind=gitlab | GitLab PAT/PrAT/GAT with `api` scope |
+
+---
+
+## Open items
+
+These were discussed but defer until needed:
+
+- **Multi-repo Jira.** Currently 1:1 enforced. Add a deliberate disambiguation mechanism (e.g., per-repo `tracker_project` override, issue title parsing, or custom Jira field) when a real consumer asks.
+- **Multi-workflow.** Single global workflow for now. Add per-repo workflow override when a real consumer asks.
+- **Per-block shell timeout override.** Hard-coded 30s for now. Add `!{timeout=N}` syntax or global config knob if needed.
+- **Configurable GitHub label strings.** `LABELS` stays hardcoded inside the GitHub adapter. Make configurable when asked.
+- **Workflow file watch.** One-shot load at startup. Add filesystem watch / SIGHUP reload if developer ergonomics demand it.

--- a/docs/design-shell-expansion-and-integrations.md
+++ b/docs/design-shell-expansion-and-integrations.md
@@ -1,0 +1,430 @@
+# Design: Shell Expansion, Multi-Phase Workflows, GitLab & Jira
+
+This document is the implementation-facing design for shell expansion, multi-phase workflows, GitLab code hosting, and Jira tracking.
+
+It has been reconciled with the Q&A decisions captured in [design-shell-expansion-and-integrations-decisions.md](./design-shell-expansion-and-integrations-decisions.md). If there is a conflict, the decisions document explains the rationale, but this file should describe the design to implement.
+
+The living execution checklist is [shell-expansion-and-integrations-implementation-plan.md](./shell-expansion-and-integrations-implementation-plan.md).
+
+## Motivation
+
+The current orchestrator dispatches a single Claude agent per issue with a statically-rendered prompt. That works for straightforward tasks, but it falls short when the agent needs dynamic context, when a task benefits from staged prompts, or when teams use GitLab and Jira instead of GitHub.
+
+The settled design adds:
+
+- pre-prompt shell expansion for dynamic context
+- simple multi-phase workflows as staged prompts
+- GitLab as a code host
+- Jira as a tracker
+- a global workflow file owned by the local-agents application
+
+## Key Decisions
+
+| Topic | Decision |
+|---|---|
+| Workflow location | One global `./workflow.yaml` in this application repo. Target repos do not carry `.agents/workflow.yaml`. |
+| Workflow count | One workflow applies to every configured repo. No per-repo workflow selection for now. |
+| Shell expansion | Execute trusted template-authored `` !`command` `` blocks before sending the prompt to the agent. |
+| Shell failures | Non-zero exit, timeout, and spawn errors all fail the run. |
+| Shell timeout | Hard-coded 30 seconds. No override syntax or config knob. |
+| Multi-phase model | Phases are staged prompts. No outer completion signal or iteration loop. |
+| Hooks | Hooks bracket the whole dispatch. They do not run per phase. |
+| Retry | A retry resumes the failed phase using the in-flight session ID and skips completed phases. |
+| Tracker states | The orchestrator uses logical states. Adapters map those states to labels or statuses. |
+| Issue keys | Use platform-native keys: `owner/repo#42` for GitHub and `PROJ-42` for Jira. |
+| Code host config | Use singular `code_host`, because one provider is configured at a time. Its `repos` list defines the code repos agents may work in. |
+| Jira repo mapping | For Jira, enforce exactly one configured code-host repo per orchestrator instance. |
+
+## Configuration Model
+
+`config.yaml` owns service configuration and the code-host repo list.
+
+The config key is singular: `code_host`, not `code_hosts`. The application configures one code host provider at a time, and `code_host.repos` is the allow-list of repositories the orchestrator may clone, work in, and open PRs/MRs against. The existing top-level `repos` field should move under `code_host` as part of this change.
+
+```yaml
+tracker:
+  kind: github | jira
+  # Required when kind=jira:
+  base_url: https://yourco.atlassian.net
+  project: PROJ
+  statuses:
+    pending: "To Do"
+    running: "In Progress"
+    awaiting_review: "In Review"
+
+code_host:
+  kind: github | gitlab
+  # Optional when kind=gitlab; defaults to https://gitlab.com:
+  base_url: https://gitlab.example.com
+  repos:
+    - owner/repo
+
+defaults:
+  polling_interval_ms: 30000
+  max_concurrent: 2
+  max_retries: 3
+  model: claude-sonnet-4-6
+  workspace_root: /tmp/local-agent-workspaces
+```
+
+Validation rules:
+
+- `tracker.kind: github` does not accept Jira-only fields.
+- `tracker.kind: jira` requires `base_url` and `project`.
+- `tracker.kind: jira` requires `code_host.repos` to contain exactly one repo.
+- `code_host.repos` is a plain string list. There is no object form yet.
+
+## Global Workflow
+
+The workflow lives at `./workflow.yaml`, relative to the orchestrator working directory.
+
+```yaml
+branch: "agent/issue-{{ issue.number }}"
+base_branch: main
+
+hooks:
+  after_create: "pnpm install"
+  before_run: "git config user.email bot@example.com"
+  after_run: "pnpm lint:fix"
+
+prompt: |
+  Fix issue {{ issue.key }}.
+  !`git log --oneline -5`
+```
+
+The workflow can use either `prompt` or `phases`, but not both.
+
+```yaml
+branch: "agent/issue-{{ issue.number }}"
+base_branch: main
+
+phases:
+  - name: plan
+    prompt: |
+      Analyse issue {{ issue.key }} and write the plan to PLAN.md.
+      !`git log --oneline -5`
+
+  - name: implement
+    resume_previous: true
+    prompt: |
+      Read PLAN.md and implement the plan.
+      !`test -f PLAN.md`
+
+  - name: review
+    prompt: |
+      Review the diff against the plan.
+      !`git diff {{ workflow.base_branch }}...HEAD`
+```
+
+Workflow loading becomes a one-shot local file load at startup:
+
+- `server/workflow/workflow-cache.ts` should be replaced or reduced to `loadWorkflow(path): RepoWorkflow`.
+- Polling refresh and last-known-good workflow cache logic should be removed.
+- `codeHost.fetchFile()` is no longer used to load workflows from target repos.
+- Restarting the orchestrator is required to pick up workflow file changes.
+
+## 1. Shell Expansion
+
+### What
+
+Prompt templates may include shell blocks using this syntax:
+
+```markdown
+## Recent commits
+!`git log --oneline -10`
+
+## Open TODOs
+!`grep -rn "TODO" src/ --include="*.ts" | head -20 || true`
+```
+
+Each block is executed in the cloned workspace directory and replaced with stdout before the agent receives the prompt.
+
+Variable substitution runs before command execution, so commands can reference issue data:
+
+```markdown
+!`git log --oneline --grep="{{ issue.key }}" -10`
+```
+
+### Security Model
+
+Issue titles and descriptions are attacker-controlled. The expansion pipeline must prevent issue content from injecting executable shell blocks.
+
+Pipeline:
+
+1. Before template substitution, mark shell blocks authored in the raw workflow template by inserting a hidden marker between `!` and the backtick.
+2. Run `{{ }}` substitution.
+3. Execute only marked shell blocks.
+4. Leave unmarked `` !`...` `` text as literal prompt text.
+5. Strip the marker from variable values before substitution to prevent marker forgery.
+6. Ensure no marker character reaches the final agent prompt.
+
+The full prompt pipeline is:
+
+```text
+mark shell blocks -> render template variables -> expand marked shell blocks -> agent
+```
+
+### Execution Rules
+
+- Commands run in the workspace directory.
+- Commands run in parallel with `Promise.all`.
+- Timeout is 30 seconds.
+- Non-zero exit fails the run.
+- Timeout fails the run.
+- Spawn error fails the run.
+- stderr should be included in the surfaced error when available.
+- There is no sandboxing beyond the marker system.
+
+### Implementation
+
+| File | Role |
+|---|---|
+| `server/workflow/prompt-preprocessor.ts` | New shell block marker and expansion helpers. |
+| `server/workflow/workflow.ts` | Integrate marking into workflow prompt parsing/rendering as needed. |
+| `server/orchestrator/orchestrator.ts` | Expand shell blocks after prompt rendering and before `query()`. |
+
+## 2. Multi-Phase Workflows
+
+### What
+
+Multi-phase workflows are ordered prompts within one dispatch. Each phase runs one Claude Agent SDK `query()` call and lets the agent run to natural completion.
+
+The schema intentionally stays simple:
+
+```typescript
+type WorkflowPhase = {
+  name: string;
+  prompt: string;
+  resume_previous?: boolean;
+};
+```
+
+There is no external signal matching and no orchestrator-level loop that re-invokes a phase. If a phase needs a precondition, express it as a strict shell block in the next phase.
+
+### Execution
+
+For each phase:
+
+1. Render variables.
+2. Expand shell blocks.
+3. Run the agent with `query()`.
+4. Capture the resulting session ID.
+5. Emit phase boundary log markers.
+
+By default, each phase starts a fresh session. If `resume_previous: true`, the phase resumes the previous phase's session.
+
+### Retry
+
+Retries resume from the failed phase:
+
+- completed phases are skipped
+- the failed phase is retried
+- the failed phase's in-flight session ID is resumed when available
+- workspace and branch state carry through retries
+
+Persist `phaseIndex` alongside the run's existing `sessionId`. For single-prompt workflows, `phaseIndex` remains `0`.
+
+### Hooks
+
+Hooks bracket the whole dispatch:
+
+- `after_create` runs when the workspace is created
+- `before_run` runs once before the first phase or single prompt
+- `after_run` runs once after the final phase or single prompt succeeds
+
+Per-phase setup should be expressed with shell blocks in phase prompts.
+
+### Observability
+
+Use one run row per dispatch. Phases are sub-units of that dispatch, not separate runs.
+
+Schema addition:
+
+```typescript
+runs.phaseIndex: integer("phase_index").default(0)
+```
+
+Canonical log markers:
+
+- `phase.started` with `{ name, index, total }`
+- `phase.completed` with `{ name, index, durationMs }`
+- `phase.failed` with `{ name, index, error }`
+
+Retry chains continue to use `parentRunId`.
+
+## 3. GitLab Code Host Integration
+
+### What
+
+Add a `CodeHostAdapter` implementation for GitLab, backed by a thin REST client.
+
+### Adapter Mapping
+
+| CodeHostAdapter method | GitLab implementation |
+|---|---|
+| `fetchFile(repo, path, ref)` | `GET /api/v4/projects/:id/repository/files/:path?ref=:ref` |
+| `cloneUrl(repo)` | `https://{base_url}/{repo}.git` |
+| `createChangeRequest(repo, head, base, title, body)` | List MRs with `source_branch=head`; return existing or create one. |
+
+The `repo` parameter is the GitLab project path, for example `group/subgroup/project`. URL-encode it as the GitLab project ID.
+
+### Config
+
+```yaml
+code_host:
+  kind: gitlab
+  base_url: https://gitlab.example.com
+  repos:
+    - myorg/payments-api
+```
+
+`base_url` defaults to `https://gitlab.com`.
+
+### Authentication
+
+Use:
+
+```text
+PRIVATE-TOKEN: <GITLAB_TOKEN>
+```
+
+`GITLAB_TOKEN` is required at startup when `code_host.kind` is `gitlab`.
+
+### Implementation
+
+| File | Role |
+|---|---|
+| `server/gitlab-client.ts` | Typed REST client for GitLab API v4. |
+| `server/code-hosts/gitlab.ts` | GitLab `CodeHostAdapter`. |
+| `server/config.ts` | Accept `code_host.kind: "gitlab"` and optional `base_url`. |
+| `server/env.ts` | Validate `GITLAB_TOKEN` when GitLab is configured. |
+| `server/server.ts` | Instantiate GitLab adapter when configured. |
+
+## 4. Tracker Integration
+
+### Tracker Adapter Shape
+
+The orchestrator uses logical tracker states:
+
+```typescript
+type TrackerState = "pending" | "running" | "awaiting_review";
+```
+
+Adapters own all platform-specific mapping:
+
+```typescript
+type TrackerAdapter = {
+  fetchIssue(repo: string, issueNumber: number): Promise<Issue>;
+  fetchActiveIssues(repo: string, state: TrackerState): Promise<Issue[]>;
+  transitionState(
+    repo: string,
+    issueNumber: number,
+    from: TrackerState,
+    to: TrackerState,
+  ): Promise<void>;
+  parseIssueKey(key: string): { repo: string; number: number };
+};
+```
+
+The orchestrator should not know GitHub label names or Jira status names.
+
+### GitHub
+
+Move the GitHub label mapping into `server/trackers/github.ts`:
+
+| Logical state | GitHub label |
+|---|---|
+| `pending` | `agent` |
+| `running` | `agent:running` |
+| `awaiting_review` | `agent:awaiting-review` |
+
+GitHub issue keys remain `owner/repo#42`.
+
+### Jira
+
+Add a Jira Cloud tracker adapter backed by a thin REST client.
+
+Jira maps logical states to status names:
+
+| Logical state | Default Jira status |
+|---|---|
+| `pending` | `To Do` |
+| `running` | `In Progress` |
+| `awaiting_review` | `In Review` |
+
+Statuses are configurable:
+
+```yaml
+tracker:
+  kind: jira
+  base_url: https://yourco.atlassian.net
+  project: PROJ
+  statuses:
+    pending: "Backlog"
+    running: "Doing"
+    awaiting_review: "Code Review"
+```
+
+When `statuses` is omitted, use the defaults above.
+
+Jira issue keys are native Jira keys, for example `PROJ-42`.
+
+### Jira Adapter Mapping
+
+| TrackerAdapter method | Jira implementation |
+|---|---|
+| `fetchIssue(repo, number)` | `GET /rest/api/3/issue/{project}-{number}` |
+| `fetchActiveIssues(repo, state)` | JQL by configured project and mapped status, ordered by creation time. |
+| `transitionState(repo, number, from, to)` | Resolve the transition whose target status matches `to`, then POST it. |
+| `parseIssueKey(key)` | Parse native Jira keys such as `PROJ-42`. |
+
+For Jira, `repo` means the global `tracker.project` value.
+
+Because Jira issues do not identify the code repo they belong to, Jira support is limited to one configured code-host repo per orchestrator instance.
+
+### Jira Authentication
+
+Use Jira Cloud basic auth:
+
+```text
+Authorization: Basic <base64(JIRA_EMAIL:JIRA_API_TOKEN)>
+```
+
+`JIRA_EMAIL` and `JIRA_API_TOKEN` are required at startup when `tracker.kind` is `jira`.
+
+### Implementation
+
+| File | Role |
+|---|---|
+| `server/jira-client.ts` | Typed REST client for Jira API v3. |
+| `server/trackers/jira.ts` | Jira `TrackerAdapter`. |
+| `server/config.ts` | Accept `tracker.kind: "jira"`, `base_url`, `project`, and optional `statuses`. |
+| `server/env.ts` | Validate `JIRA_EMAIL` and `JIRA_API_TOKEN` when Jira is configured. |
+| `server/server.ts` | Instantiate Jira adapter when configured. |
+
+## Implementation Order
+
+Use [shell-expansion-and-integrations-implementation-plan.md](./shell-expansion-and-integrations-implementation-plan.md)
+as the execution ledger. It owns slice status, dependencies, verification notes, and
+the exact branch sequence.
+
+At a high level, implement the foundation refactors first, then features:
+
+1. Move repo configuration under `code_host.repos`.
+2. Replace per-repo workflow loading with one local `./workflow.yaml`.
+3. Move tracker state and issue-key parsing behind tracker adapters.
+4. Add shell expansion.
+5. Add multi-phase workflows.
+6. Add GitLab code-host support.
+7. Add Jira tracker support.
+8. Refresh user-facing docs after behavior lands.
+
+## Deferred Items
+
+These are intentionally out of scope until a real consumer need appears:
+
+- multi-repo Jira disambiguation
+- multiple workflows or per-repo workflow overrides
+- per-block shell timeout override
+- configurable GitHub label strings
+- workflow file watch or reload without restart

--- a/docs/shell-expansion-and-integrations-implementation-plan.md
+++ b/docs/shell-expansion-and-integrations-implementation-plan.md
@@ -1,0 +1,520 @@
+# Living Implementation Plan: Shell Expansion, Multi-Phase Workflows, GitLab & Jira
+
+This is the execution plan for [design-shell-expansion-and-integrations.md](./design-shell-expansion-and-integrations.md). The design doc describes what to build; this plan tracks how to slice and verify the work.
+
+Keep this document current as implementation proceeds. When a slice starts, update its status. When scope changes, update the slice before changing code. When a slice completes, record the verification commands that passed and any deferred follow-up.
+
+## Status Key
+
+| Status | Meaning |
+|---|---|
+| Not started | No implementation work has begun. |
+| In progress | Code is being changed for this slice. |
+| Blocked | Work cannot continue without a decision or prerequisite. |
+| Ready for review | Code and tests are complete; final checks passed. |
+| Done | Reviewed and merged. |
+
+## Global Quality Gates
+
+Every implementation slice must preserve the existing repo standards:
+
+- Read the code and tests in the area before editing. Existing test helpers are the conventions.
+- Keep the slice small enough to review independently.
+- Update docs in the same slice when behavior or config changes.
+- Add or update focused tests in the same layer as the behavior being changed.
+- Keep GitHub-only behavior working unless the slice explicitly changes it.
+- Do not leave compatibility gaps between config, server startup, orchestrator behavior, dashboard assumptions, and docs.
+- Run `pnpm lint`, `pnpm typecheck`, and `pnpm test` before marking a slice ready for review.
+- Run `pnpm test:coverage` before the first slice starts and after feature slices that add behavior. Coverage should stay level or improve.
+- Run narrower tests while iterating, but do not use narrow tests as the final gate.
+
+Recommended final verification block for every slice:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+```
+
+Coverage checkpoint:
+
+```bash
+pnpm test:coverage
+```
+
+## Operating Model
+
+This work should not be implemented as one long-running agent session. Use the plan as a sequence of independently reviewable slices.
+
+Recommended workflow:
+
+1. Create one branch per slice.
+2. Start one Codex thread per slice, or continue in the current thread only while the context is still fresh.
+3. Keep only one implementation slice in progress on a branch at a time.
+4. Commit each slice when its quality gates pass.
+5. Update this plan before and after implementation work in the same branch.
+6. Open or review each slice independently before starting dependent slices.
+
+Branch naming convention:
+
+```text
+plan/slice-01-code-host-repos
+plan/slice-02-global-workflow
+plan/slice-03-tracker-state
+plan/slice-04-shell-expansion
+plan/slice-05-multi-phase
+plan/slice-06-gitlab
+plan/slice-07-jira
+plan/slice-08-docs-refresh
+```
+
+Commit strategy:
+
+- Commit at the end of each slice after `pnpm lint`, `pnpm typecheck`, and `pnpm test` pass.
+- Prefer one clean commit per slice unless the slice is large enough to justify multiple reviewable commits.
+- Do not commit half-passing work unless intentionally creating a checkpoint branch for handoff.
+- If a context window is getting tight, stop at a clean boundary: update the slice progress notes, record failing/passing commands, and commit only if the work is coherent.
+
+Parallelism:
+
+- Slices 1, 2, and 3 should be done sequentially because they reshape shared config, workflow loading, and tracker contracts.
+- Slice 4 depends on the config/workflow foundations being stable enough to integrate prompt expansion.
+- Slice 5 depends on Slice 4.
+- Slice 6 can be implemented after Slice 1 and can run in parallel with Slice 4 if it stays inside GitLab code-host files and config wiring.
+- Slice 7 depends on Slice 3 and should not run in parallel with tracker contract changes.
+- Slice 8 should be last, after behavior has landed.
+
+Multiple Codex instances are useful when each instance owns a disjoint slice on its own branch. Avoid two instances editing the same branch unless one is only reviewing.
+
+## Progress Discipline
+
+Every implementation thread should update this document. Treat it as the project ledger, not just a plan.
+
+When starting a slice:
+
+- Change `Status` from `Not started` to `In progress`.
+- Add an `Owner / thread` line if helpful.
+- Add a short `Started` note with date and branch.
+
+When pausing a slice:
+
+- Leave the status as `In progress` or `Blocked`.
+- Add a `Progress notes` subsection with what changed, what remains, and exact verification status.
+- Record any failing command output in summary form, not as a large pasted log.
+
+When completing a slice:
+
+- Change `Status` to `Ready for review`.
+- Add a `Completed changes` subsection.
+- Add a `Verification` subsection listing the exact commands that passed.
+- After merge, change `Status` to `Done`.
+
+Use this handoff template when a slice is interrupted:
+
+```markdown
+**Progress notes:**
+
+- Branch:
+- Files changed:
+- Completed:
+- Remaining:
+- Verification:
+- Known risks:
+```
+
+## Slice 0 — Baseline And Planning Hygiene
+
+**Status:** Ready for review
+
+**Started:** 2026-04-30 on branch `plan/slice-00-baseline-planning`.
+
+**Completed changes:**
+
+- Confirmed `design-shell-expansion-and-integrations.md` is the implementation spec and points to this living plan as the execution ledger.
+- Kept `design-shell-expansion-and-integrations-decisions.md` as the rationale trail and corrected the rejected per-repo workflow path to `.agents/workflow.yaml`.
+- Aligned the design doc implementation-order section with this plan's slice sequence.
+- Recorded the baseline coverage checkpoint: 100% statements, 100% branches, 100% functions, 100% lines.
+
+**Verification:**
+
+- `pnpm install`
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:coverage`
+
+**Purpose:** Establish the baseline before code changes and make sure docs do not contradict the settled design.
+
+**Scope:**
+
+- Confirm [design-shell-expansion-and-integrations.md](./design-shell-expansion-and-integrations.md) is the implementation spec.
+- Keep [design-shell-expansion-and-integrations-decisions.md](./design-shell-expansion-and-integrations-decisions.md) as the rationale trail.
+- Record baseline coverage before implementation begins.
+
+**Quality gates:**
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:coverage`
+- No stale references in implementation docs to rejected design choices such as `completion_signal`, `max_iterations`, `PROJ#42`, top-level `repos`, or per-target-repo workflow loading.
+
+## Slice 1 — Move Repos Under `code_host`
+
+**Status:** Not started
+
+**Purpose:** Make the config shape match the settled model before adding more provider options.
+
+**Scope:**
+
+- Move config from top-level `repos` to `code_host.repos`.
+- Keep the config key singular: `code_host`.
+- Update `Config` types, Zod schema, config loading, test config helpers, server bootstrap, and docs.
+- Decide whether to support a short deprecation window for top-level `repos`; if supported, warn loudly and normalize internally.
+
+**Natural code areas:**
+
+- `server/config.ts`
+- `server/server.ts`
+- `server/testing/support/test-config.ts`
+- `README.md`
+- `docs/architecture.md`
+
+**Tests:**
+
+- Config parser accepts `code_host.repos`.
+- Config parser rejects missing `code_host.repos`.
+- If no compatibility window is chosen, parser rejects top-level `repos`.
+- Server startup and test helpers pass repos through from `code_host.repos`.
+
+**Quality gates:**
+
+- Existing GitHub-only orchestration tests still pass.
+- Public docs show only the new config shape.
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+
+## Slice 2 — Global Local `workflow.yaml`
+
+**Status:** Not started
+
+**Purpose:** Replace per-target-repo workflow fetching with one workflow file owned by local-agents.
+
+**Scope:**
+
+- Replace workflow cache behavior with a one-shot local file loader.
+- Load `./workflow.yaml` relative to the orchestrator working directory.
+- Remove polling refresh and last-known-good workflow cache behavior.
+- Stop using `codeHost.fetchFile()` for workflow loading.
+- Update startup wiring and tests.
+
+**Natural code areas:**
+
+- `server/workflow/workflow-cache.ts`
+- `server/workflow/workflow.ts`
+- `server/server.ts`
+- `server/orchestrator/orchestrator.ts`
+- `server/workflow/__tests__/workflow-cache.integration.test.ts`
+- Orchestrator test helpers that currently pass workflow maps.
+
+**Tests:**
+
+- Loads a local workflow successfully.
+- Fails startup or loader call clearly when `workflow.yaml` is missing.
+- Fails clearly when local workflow YAML is invalid.
+- Dispatch uses the same loaded workflow for every configured repo.
+- Existing hook behavior is unchanged for single-prompt workflows.
+
+**Quality gates:**
+
+- No remaining production dependency on target repo `.agents/workflow.yaml`.
+- `docs/architecture.md` no longer describes per-repo workflow caching as current behavior.
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+
+## Slice 3 — Tracker State Refactor
+
+**Status:** Not started
+
+**Purpose:** Make tracker state platform-neutral before adding Jira.
+
+**Scope:**
+
+- Introduce `TrackerState = "pending" | "running" | "awaiting_review"`.
+- Rename `TrackerAdapter.swapLabel` to `transitionState`.
+- Move GitHub label mapping into `server/trackers/github.ts`.
+- Rename the misleading `completed` logical state to `awaiting_review`.
+- Add `TrackerAdapter.parseIssueKey`.
+- Move GitHub issue key parsing out of the orchestrator and into the GitHub tracker adapter.
+
+**Natural code areas:**
+
+- `server/trackers/types.ts`
+- `server/trackers/github.ts`
+- `server/trackers/decorator.ts`
+- `server/orchestrator/orchestrator.ts`
+- `server/orchestrator/__tests__/*`
+- `server/trackers/__tests__/*`
+
+**Tests:**
+
+- GitHub adapter maps logical states to existing labels.
+- Orchestrator calls `transitionState` with logical states, not label strings.
+- `parseIssueKey` parses `owner/repo#42`.
+- Existing retry paths use adapter-owned parsing.
+- Existing canonical logging still records useful transition information.
+
+**Quality gates:**
+
+- No behavior change for GitHub-only users.
+- No orchestrator-owned GitHub label constants remain.
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+
+## Slice 4 — Shell Expansion
+
+**Status:** Not started
+
+**Purpose:** Add trusted pre-prompt shell expansion with strict failure behavior.
+
+**Scope:**
+
+- Add shell block marking and expansion helpers.
+- Execute only template-authored marked blocks.
+- Run commands in the workspace directory.
+- Run commands in parallel with a 30-second timeout.
+- Fail the run on non-zero exit, timeout, or spawn error.
+- Ensure marker characters cannot be injected through issue content and never reach the agent prompt.
+- Integrate expansion after prompt rendering and before `query()`.
+
+**Natural code areas:**
+
+- `server/workflow/prompt-preprocessor.ts`
+- `server/workflow/workflow.ts`
+- `server/orchestrator/orchestrator.ts`
+- `server/workflow/__tests__/*`
+- `server/orchestrator/__tests__/*`
+
+**Tests:**
+
+- Expands stdout from marked shell blocks.
+- Executes commands from the workspace directory.
+- Runs variable substitution before command execution.
+- Does not execute `` !`...` `` injected through issue title or description.
+- Strips or prevents marker forgery from variable values.
+- Fails on non-zero exit.
+- Fails on timeout.
+- Fails on spawn error.
+- Keeps literal unmarked shell-looking text in the final prompt.
+- Orchestrator passes expanded prompt to the agent.
+
+**Quality gates:**
+
+- Security tests cover attacker-controlled issue fields.
+- Strict failure behavior is asserted in integration tests, not just unit tests.
+- `pnpm test:coverage`
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+
+## Slice 5 — Multi-Phase Workflow Schema And Runner
+
+**Status:** Not started
+
+**Purpose:** Add simple staged prompts without completion signals or orchestrator-level iteration loops.
+
+**Scope:**
+
+- Extend workflow schema to support mutually exclusive `prompt` or `phases`.
+- Define phase fields: `name`, `prompt`, optional `resume_previous`.
+- Add phase sequencing.
+- Expand shell blocks per phase.
+- Resume the previous phase session when requested.
+- Keep hooks bracketing the whole dispatch.
+- Add `runs.phaseIndex` with a migration.
+- Emit `phase.started`, `phase.completed`, and `phase.failed` canonical log markers.
+- Retry from the failed phase using the failed phase session ID where available.
+
+**Natural code areas:**
+
+- `server/workflow/workflow.ts`
+- `server/orchestrator/orchestrator.ts`
+- `server/orchestrator/phase-runner.ts`
+- `server/db/schema.ts`
+- Drizzle migration files
+- `server/orchestrator/__tests__/*`
+- `server/api/__tests__/*` if run serialization changes.
+
+**Tests:**
+
+- Schema accepts single-prompt workflow.
+- Schema accepts phased workflow.
+- Schema rejects workflows with both `prompt` and `phases`.
+- Schema rejects workflows with neither.
+- Phases run sequentially.
+- Each phase receives a freshly rendered and shell-expanded prompt.
+- `resume_previous` passes the previous session ID.
+- Hooks run once around the whole dispatch, not per phase.
+- `phaseIndex` updates as phases progress.
+- Retry skips completed phases and resumes the failed phase.
+- Retry starts failed phase fresh when no failed-phase session ID exists.
+- Phase log markers are emitted with name, index, and total.
+
+**Quality gates:**
+
+- No `completion_signal` or `max_iterations` fields in schema or tests.
+- Existing single-prompt workflows continue to behave as before.
+- Migration is generated and covered by DB tests where practical.
+- `pnpm test:coverage`
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+
+## Slice 6 — GitLab Code Host Adapter
+
+**Status:** Not started
+
+**Purpose:** Add GitLab as a code host while preserving the `CodeHostAdapter` contract.
+
+**Scope:**
+
+- Add a GitLab API client.
+- Add `server/code-hosts/gitlab.ts`.
+- Support `code_host.kind: gitlab`.
+- Support optional `code_host.base_url`, defaulting to `https://gitlab.com`.
+- Validate `GITLAB_TOKEN` at startup when GitLab is configured.
+- Use `PRIVATE-TOKEN` auth.
+- URL-encode GitLab project paths.
+- Make MR creation idempotent by returning an existing MR for the source branch when present.
+
+**Natural code areas:**
+
+- `server/gitlab-client.ts`
+- `server/code-hosts/gitlab.ts`
+- `server/config.ts`
+- `server/env.ts`
+- `server/server.ts`
+- `server/code-hosts/__tests__/*`
+- `server/testing/support/msw.ts`
+
+**Tests:**
+
+- Config accepts GitLab code host.
+- Missing `GITLAB_TOKEN` fails startup when GitLab is configured.
+- `cloneUrl` uses configured base URL.
+- File fetch calls the correct GitLab API path and decodes file content.
+- MR creation checks for an existing MR before creating.
+- Project paths with slashes are encoded correctly.
+
+**Quality gates:**
+
+- GitHub code host tests remain unchanged or equivalent.
+- Adapter behavior is covered with MSW or equivalent HTTP-level tests.
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+
+## Slice 7 — Jira Tracker Adapter
+
+**Status:** Not started
+
+**Purpose:** Add Jira Cloud as a tracker on top of the platform-neutral tracker state model.
+
+**Scope:**
+
+- Add a Jira API client.
+- Add `server/trackers/jira.ts`.
+- Support `tracker.kind: jira`.
+- Require `tracker.base_url` and `tracker.project`.
+- Support optional `tracker.statuses` with defaults.
+- Enforce exactly one `code_host.repos` entry when tracker kind is Jira.
+- Validate `JIRA_EMAIL` and `JIRA_API_TOKEN` at startup when Jira is configured.
+- Use Jira native issue keys, e.g. `PROJ-42`.
+- Implement adapter-owned `parseIssueKey`.
+- Fetch active issues with JQL by project and mapped status.
+- Transition issues by resolving and posting the transition whose target status matches the logical state.
+
+**Natural code areas:**
+
+- `server/jira-client.ts`
+- `server/trackers/jira.ts`
+- `server/config.ts`
+- `server/env.ts`
+- `server/server.ts`
+- `server/trackers/__tests__/*`
+- `server/testing/support/msw.ts`
+
+**Tests:**
+
+- Config accepts Jira tracker with required fields.
+- Config applies default Jira statuses.
+- Config accepts custom Jira statuses.
+- Config rejects Jira with zero or multiple `code_host.repos`.
+- Missing Jira env vars fail startup when Jira is configured.
+- `parseIssueKey` accepts `PROJ-42` and rejects malformed keys.
+- Active issue fetch builds escaped or otherwise safe JQL.
+- Transition resolves available Jira transitions and posts the correct one.
+- Jira issues map to the single configured code-host repo in orchestrator flow.
+
+**Quality gates:**
+
+- Jira status mapping stays inside the Jira adapter.
+- The orchestrator continues to use only `TrackerState`.
+- GitHub tracker tests still pass.
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+
+## Slice 8 — Documentation And Architecture Refresh
+
+**Status:** Not started
+
+**Purpose:** Bring user-facing docs in line with the implemented system.
+
+**Scope:**
+
+- Update `README.md` setup and configuration examples.
+- Update `docs/architecture.md` to describe global workflow loading, logical tracker states, and code-host repos.
+- Keep the design and decisions docs linked.
+- Add migration notes for users moving from top-level `repos` and per-repo `.agents/workflow.yaml`.
+
+**Tests:**
+
+- Documentation examples match the current config schema.
+- Commands and file paths in docs are accurate.
+
+**Quality gates:**
+
+- `rg` finds no stale current-state references to per-repo workflow caching, top-level `repos`, `completion_signal`, `max_iterations`, `PROJ#42`, or logical state `completed`.
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+
+## Release-Level Acceptance
+
+The overall work is complete when:
+
+- GitHub-only behavior still works with the new config shape and global workflow file.
+- Shell expansion is implemented with strict failure and injection protection.
+- Multi-phase workflows work with retry from failed phase.
+- GitLab can clone/fetch/create MRs through `CodeHostAdapter`.
+- Jira can poll/transition issues through `TrackerAdapter`.
+- Jira configuration enforces one code-host repo.
+- Dashboard/API behavior remains coherent for single-prompt and phased runs.
+- Docs describe the implemented behavior, not rejected designs.
+- `pnpm lint`, `pnpm typecheck`, `pnpm test`, and final `pnpm test:coverage` pass.
+
+## Deferred Scope
+
+Do not include these in the initial implementation:
+
+- multiple code host providers at once
+- multiple tracker providers at once
+- multi-repo Jira disambiguation
+- per-repo workflow selection
+- configurable GitHub label strings
+- per-block shell timeout overrides
+- workflow file hot reload


### PR DESCRIPTION
## Summary
- Add the shell expansion/integrations design, decisions, and living implementation plan docs.
- Mark Slice 0 as ready for review with baseline notes.
- Record baseline coverage at 100% statements, branches, functions, and lines.

## Verification
- pnpm install
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:coverage

## Notes
- This PR is Slice 0 only. No runtime behavior changed.