### PR TITLE
refactor: move repos under code host config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ tracker:
 
 code_host:
   kind: github
-
-repos:
-  - your-org/your-repo
+  repos:
+    - your-org/your-repo
 
 defaults:
   polling_interval_ms: 30000
@@ -69,7 +68,7 @@ This starts:
 
 ### Adding a New Repo
 
-1. Add the repo to the `repos` list in `config.yaml`
+1. Add the repo to the `code_host.repos` list in `config.yaml`
 2. Commit `.agents/workflow.yaml` to the repo with label, hooks, and prompt
 3. Create the label (e.g., `agent`) on the repo:
    ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,10 +35,9 @@ tracker:
 
 code_host:
   kind: github
-
-repos:
-  - org/repo-a
-  - org/repo-b
+  repos:
+    - org/repo-a
+    - org/repo-b
 
 defaults:
   polling_interval_ms: 30000

--- a/docs/shell-expansion-and-integrations-implementation-plan.md
+++ b/docs/shell-expansion-and-integrations-implementation-plan.md
@@ -161,7 +161,23 @@ Use this handoff template when a slice is interrupted:
 
 ## Slice 1 — Move Repos Under `code_host`
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Started:** 2026-04-30 on branch `plan/slice-01-code-host-repos`.
+
+**Completed changes:**
+
+- Moved repository configuration from top-level `repos` to `code_host.repos`.
+- Updated `Config` types, Zod parsing, server startup wiring, and test config helpers to use `code_host.repos`.
+- Chose no compatibility window for top-level `repos`; the parser rejects old top-level repo config.
+- Updated README and architecture config examples to show only the new nested shape.
+- Added focused config parser tests for accepted nested repos, missing `code_host.repos`, and rejected top-level `repos`.
+
+**Verification:**
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
 
 **Purpose:** Make the config shape match the settled model before adding more provider options.
 

--- a/server/__tests__/config.test.ts
+++ b/server/__tests__/config.test.ts
@@ -1,0 +1,70 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadConfig } from "../config.ts";
+
+type TestConfigFile = {
+	path: string;
+	[Symbol.dispose](): void;
+};
+
+function writeConfig(contents: string): TestConfigFile {
+	const dir = mkdtempSync(join(tmpdir(), "local-agents-config-"));
+	const path = join(dir, "config.yaml");
+	writeFileSync(path, contents);
+	return {
+		path,
+		[Symbol.dispose]() {
+			rmSync(dirname(path), { recursive: true, force: true });
+		},
+	};
+}
+
+describe("loadConfig", () => {
+	it("accepts repos under code_host", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: github
+code_host:
+  kind: github
+  repos:
+    - owner/repo
+defaults:
+  workspace_root: /tmp/workspaces
+`);
+
+		const config = loadConfig(configFile.path);
+
+		expect(config.code_host.repos).toEqual(["owner/repo"]);
+		expect(config.defaults.workspace_root).toBe("/tmp/workspaces");
+	});
+
+	it("rejects config without code_host repos", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: github
+code_host:
+  kind: github
+defaults:
+  workspace_root: /tmp/workspaces
+`);
+
+		expect(() => loadConfig(configFile.path)).toThrow();
+	});
+
+	it("rejects top-level repos", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: github
+code_host:
+  kind: github
+  repos:
+    - owner/repo
+repos:
+  - old-owner/old-repo
+`);
+
+		expect(() => loadConfig(configFile.path)).toThrow();
+	});
+});

--- a/server/config.ts
+++ b/server/config.ts
@@ -7,8 +7,8 @@ export type Config = {
 	};
 	code_host: {
 		kind: "github";
+		repos: string[];
 	};
-	repos: string[];
 	defaults: {
 		polling_interval_ms: number;
 		max_concurrent: number;
@@ -18,34 +18,36 @@ export type Config = {
 	};
 };
 
-const configSchema = z.object({
-	tracker: z.object({
-		kind: z.literal("github"),
-	}),
-	code_host: z.object({
-		kind: z.literal("github"),
-	}),
-	repos: z.array(z.string()).min(1),
-	defaults: z
-		.object({
-			polling_interval_ms: z.number().default(30000),
-			max_concurrent: z.number().default(2),
-			max_retries: z.number().default(3),
-			model: z.string().default("claude-sonnet-4-6"),
-			workspace_root: z.string().default("/tmp/local-agent-workspaces"),
-		})
-		.optional()
-		.transform(
-			(v) =>
-				v ?? {
-					polling_interval_ms: 30000,
-					max_concurrent: 2,
-					max_retries: 3,
-					model: "claude-sonnet-4-6",
-					workspace_root: "/tmp/local-agent-workspaces",
-				},
-		),
-});
+const configSchema = z
+	.object({
+		tracker: z.object({
+			kind: z.literal("github"),
+		}),
+		code_host: z.object({
+			kind: z.literal("github"),
+			repos: z.array(z.string()).min(1),
+		}),
+		defaults: z
+			.object({
+				polling_interval_ms: z.number().default(30000),
+				max_concurrent: z.number().default(2),
+				max_retries: z.number().default(3),
+				model: z.string().default("claude-sonnet-4-6"),
+				workspace_root: z.string().default("/tmp/local-agent-workspaces"),
+			})
+			.optional()
+			.transform(
+				(v) =>
+					v ?? {
+						polling_interval_ms: 30000,
+						max_concurrent: 2,
+						max_retries: 3,
+						model: "claude-sonnet-4-6",
+						workspace_root: "/tmp/local-agent-workspaces",
+					},
+			),
+	})
+	.strict();
 
 export function loadConfig(filePath: string): Config {
 	const raw = readFileSync(filePath, "utf-8");

--- a/server/server.ts
+++ b/server/server.ts
@@ -32,7 +32,7 @@ const runner = createRunner({
 });
 
 // Fetch workflows from all repos, then start
-const workflowCache = createWorkflowCache(codeHost, config.repos);
+const workflowCache = createWorkflowCache(codeHost, config.code_host.repos);
 await workflowCache.refresh();
 
 const orchestrator = createOrchestrator({
@@ -79,7 +79,7 @@ const httpServer = serve({ fetch: app.fetch, port: env.PORT }, (info) => {
 	logger.info(
 		{
 			port: info.port,
-			repos: config.repos,
+			repos: config.code_host.repos,
 			activeRepos: [...workflowCache.workflows.keys()],
 			interval: config.defaults.polling_interval_ms,
 		},

--- a/server/testing/support/test-config.ts
+++ b/server/testing/support/test-config.ts
@@ -5,8 +5,10 @@ export function createTestConfig(
 ): Config {
 	return {
 		tracker: { kind: "github" },
-		code_host: { kind: "github" },
-		repos: ["test-owner/test-repo"],
+		code_host: {
+			kind: "github",
+			repos: ["test-owner/test-repo"],
+		},
 		defaults: {
 			polling_interval_ms: 100,
 			max_concurrent: 2,


### PR DESCRIPTION
## Summary
- Move repository configuration from top-level `repos` to `code_host.repos`.
- Update server startup, test config helpers, README, and architecture examples to use the nested config shape.
- Reject old top-level `repos` config and add parser tests for the new behavior.
- Mark Slice 1 as ready for review in the implementation ledger.

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test
- push hook: pnpm test:coverage

## Notes
- No compatibility window for top-level `repos`; old config is intentionally rejected.