### PR TITLE
refactor: use logical tracker states

### DIFF
--- a/docs/shell-expansion-and-integrations-implementation-plan.md
+++ b/docs/shell-expansion-and-integrations-implementation-plan.md
@@ -268,7 +268,24 @@ Use this handoff template when a slice is interrupted:
 
 ## Slice 3 — Tracker State Refactor
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Started:** 2026-04-30 on branch `plan/slice-03-tracker-state`.
+
+**Completed changes:**
+
+- Introduced `TrackerState = "pending" | "running" | "awaiting_review"`.
+- Renamed `TrackerAdapter.swapLabel` to `transitionState` and updated orchestrator/decorator usage.
+- Moved GitHub label mapping into `server/trackers/github.ts`.
+- Replaced orchestrator-owned issue-key parsing with `tracker.parseIssueKey`.
+- Added GitHub tracker tests for logical-state label mapping and issue-key parsing.
+- Added an orchestrator dispatch test proving logical tracker states are passed to the tracker.
+
+**Verification:**
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
 
 **Purpose:** Make tracker state platform-neutral before adding Jira.
 

--- a/server/orchestrator/__tests__/orchestrator.dispatch.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.dispatch.integration.test.ts
@@ -9,8 +9,49 @@ import {
 } from "../../testing/support/fixtures.ts";
 import { githubHandlers, server } from "../../testing/support/msw.ts";
 import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
+import type { TrackerAdapter, TrackerState } from "../../trackers/types.ts";
 
 describe("Orchestrator dispatch", () => {
+	it("calls tracker transitions with logical states", async () => {
+		const transitions: { from: TrackerState; to: TrackerState }[] = [];
+		const issue = {
+			key: `${REPO}#1`,
+			number: 1,
+			title: "Issue 1",
+			description: "Description for issue 1",
+			labels: ["agent"],
+			url: `https://github.com/${REPO}/issues/1`,
+			createdAt: "2025-01-01T00:00:00Z",
+		};
+
+		const tracker: TrackerAdapter = {
+			fetchIssue: async () => issue,
+			fetchActiveIssues: async (_repo, state) =>
+				state === "pending" ? [issue] : [],
+			transitionState: async (_repo, _issueNumber, from, to) => {
+				transitions.push({ from, to });
+			},
+			parseIssueKey: (key) => {
+				const hashIndex = key.lastIndexOf("#");
+				return {
+					repo: key.slice(0, hashIndex),
+					number: Number.parseInt(key.slice(hashIndex + 1), 10),
+				};
+			},
+		};
+
+		await using ctx = await createTestOrchestrator({
+			runAgent: hangingAgent,
+			tracker: () => tracker,
+		});
+		const { orchestrator, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
+
+		await orchestrator.tick();
+
+		expect(transitions).toEqual([{ from: "pending", to: "running" }]);
+	});
+
 	it("dispatches agent for a pending issue, swaps label, and creates DB record", async () => {
 		const labelOps: { method: string; label: string }[] = [];
 

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -15,20 +15,6 @@ import { ensureWorkspace, removeWorkspace } from "./workspace.ts";
 
 const exec = promisify(execFile);
 
-const LABELS = {
-	pending: "agent",
-	running: "agent:running",
-	completed: "agent:awaiting-review",
-} as const;
-
-function parseIssueKey(key: string): { repo: string; number: number } {
-	const hashIndex = key.lastIndexOf("#");
-	return {
-		repo: key.slice(0, hashIndex),
-		number: Number.parseInt(key.slice(hashIndex + 1), 10),
-	};
-}
-
 async function runShell(script: string, cwd: string): Promise<void> {
 	await exec("sh", ["-c", script], { cwd });
 }
@@ -212,11 +198,11 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 									`Closes ${issue.key}`,
 								);
 
-								await tracker.swapLabel(
+								await tracker.transitionState(
 									repo,
 									issue.number,
-									LABELS.running,
-									LABELS.completed,
+									"running",
+									"awaiting_review",
 								);
 							} catch (err) {
 								canonicalLog.append(
@@ -224,11 +210,11 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 									`on_complete_failed: ${canonicalLog.errorMessage(err)}`,
 								);
 								await tracker
-									.swapLabel(
+									.transitionState(
 										repo,
 										issue.number,
-										LABELS.running,
-										LABELS.completed,
+										"running",
+										"awaiting_review",
 									)
 									.catch((labelErr) =>
 										canonicalLog.append(
@@ -249,11 +235,11 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 
 						if (result.status === "failed" && retriesExhausted) {
 							await tracker
-								.swapLabel(repo, issue.number, LABELS.running, LABELS.pending)
+								.transitionState(repo, issue.number, "running", "pending")
 								.catch((err) =>
 									canonicalLog.append(
 										"warnings",
-										`label_rollback_failed: ${canonicalLog.errorMessage(err)}`,
+										`state_rollback_failed: ${canonicalLog.errorMessage(err)}`,
 									),
 								);
 						}
@@ -285,7 +271,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		const [pendingResults, runningResults] = await Promise.all([
 			Promise.allSettled(
 				entries.map(async ([repo, workflow]) => {
-					const issues = await tracker.fetchActiveIssues(repo, LABELS.pending);
+					const issues = await tracker.fetchActiveIssues(repo, "pending");
 					return issues.map(
 						(issue): TaggedIssue => ({ issue, repo, workflow }),
 					);
@@ -293,7 +279,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 			),
 			Promise.allSettled(
 				entries.map(async ([repo]) => {
-					const issues = await tracker.fetchActiveIssues(repo, LABELS.running);
+					const issues = await tracker.fetchActiveIssues(repo, "running");
 					return { repo, keys: new Set(issues.map((i) => i.key)) };
 				}),
 			),
@@ -334,7 +320,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 
 	async function reconcileStaleRuns(state: TickState) {
 		for (const [key, runIds] of state.runningByIssue) {
-			const { repo } = parseIssueKey(key);
+			const { repo } = tracker.parseIssueKey(key);
 			const repoKeys = state.stillRunning.get(repo);
 			if (repoKeys && !repoKeys.has(key)) {
 				logger.info({ key }, "orchestrator.reconcile_terminal");
@@ -353,10 +339,10 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		for (const [repo, keys] of state.stillRunning) {
 			for (const key of keys) {
 				if (state.runningByIssue.has(key)) continue;
-				const { number } = parseIssueKey(key);
+				const { number } = tracker.parseIssueKey(key);
 				logger.info({ key }, "orchestrator.reconcile_orphan");
 				await tracker
-					.swapLabel(repo, number, LABELS.running, LABELS.pending)
+					.transitionState(repo, number, "running", "pending")
 					.catch((err) =>
 						logger.warn({ key, err }, "orchestrator.orphan_recovery_failed"),
 					);
@@ -371,19 +357,14 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 			if (state.runningByIssue.has(issue.key)) continue;
 			if (runningCount >= defaults.max_concurrent) break;
 
-			await tracker.swapLabel(
-				repo,
-				issue.number,
-				LABELS.pending,
-				LABELS.running,
-			);
+			await tracker.transitionState(repo, issue.number, "pending", "running");
 
 			try {
 				await prepareAndDispatch({ issue, repo, workflow, attempt: 1 });
 			} catch (err) {
 				logger.warn({ issue: issue.key, err }, "orchestrator.dispatch_failed");
 				await tracker
-					.swapLabel(repo, issue.number, LABELS.running, LABELS.pending)
+					.transitionState(repo, issue.number, "running", "pending")
 					.catch((rollbackErr) =>
 						logger.warn(
 							{ issue: issue.key, err: rollbackErr },
@@ -430,7 +411,9 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 			return { error: "Issue already has a running agent" };
 		}
 
-		const { repo, number: issueNumber } = parseIssueKey(failedRun.issueKey);
+		const { repo, number: issueNumber } = tracker.parseIssueKey(
+			failedRun.issueKey,
+		);
 		const workflow = workflows.get(repo);
 		if (!workflow) return { error: "No workflow for repo" };
 

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -219,7 +219,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 									.catch((labelErr) =>
 										canonicalLog.append(
 											"warnings",
-											`label_recovery_failed: ${canonicalLog.errorMessage(labelErr)}`,
+											`state_recovery_failed: ${canonicalLog.errorMessage(labelErr)}`,
 										),
 									);
 							}

--- a/server/testing/support/test-orchestrator.ts
+++ b/server/testing/support/test-orchestrator.ts
@@ -5,6 +5,7 @@ import { createOrchestrator } from "../../orchestrator/orchestrator.ts";
 import { createRunRepository } from "../../run-repository.ts";
 import { createRunner } from "../../runner/runner.ts";
 import { githubTrackerAdapter } from "../../trackers/github.ts";
+import type { TrackerAdapter } from "../../trackers/types.ts";
 import type { RepoWorkflow } from "../../workflow/workflow.ts";
 import { createTestWorkflow, noopAgent, REPO } from "./fixtures.ts";
 import { createTestConfig } from "./test-config.ts";
@@ -17,6 +18,7 @@ type CreateTestOrchestratorOptions = {
 	workflows?: Map<string, RepoWorkflow>;
 	maxConcurrency?: number;
 	codeHost?: (defaults: CodeHostAdapter) => CodeHostAdapter;
+	tracker?: (defaults: TrackerAdapter) => TrackerAdapter;
 };
 
 export async function createTestOrchestrator(
@@ -32,10 +34,11 @@ export async function createTestOrchestrator(
 	});
 
 	const defaultCodeHost = githubCodeHostAdapter(github);
+	const defaultTracker = githubTrackerAdapter(github);
 
 	const orchestrator = createOrchestrator({
 		runRepo: repo,
-		tracker: githubTrackerAdapter(github),
+		tracker: options.tracker ? options.tracker(defaultTracker) : defaultTracker,
 		codeHost: options.codeHost
 			? options.codeHost(defaultCodeHost)
 			: defaultCodeHost,

--- a/server/trackers/__tests__/decorator.test.ts
+++ b/server/trackers/__tests__/decorator.test.ts
@@ -35,18 +35,30 @@ describe("decorateTracker", () => {
 
 	describe("transitionState", () => {
 		it("delegates to inner tracker on success", async () => {
-			const calls: { repo: string; issueNumber: number }[] = [];
+			const calls: {
+				repo: string;
+				issueNumber: number;
+				from: string;
+				to: string;
+			}[] = [];
 
 			const decorated = decorateTracker(
 				createFakeTracker({
-					transitionState: async (repo, issueNumber) => {
-						calls.push({ repo, issueNumber });
+					transitionState: async (repo, issueNumber, from, to) => {
+						calls.push({ repo, issueNumber, from, to });
 					},
 				}),
 			);
 
 			await decorated.transitionState("owner/repo", 42, "pending", "running");
-			expect(calls).toEqual([{ repo: "owner/repo", issueNumber: 42 }]);
+			expect(calls).toEqual([
+				{
+					repo: "owner/repo",
+					issueNumber: 42,
+					from: "pending",
+					to: "running",
+				},
+			]);
 		});
 
 		it("re-throws when inner transitionState fails", async () => {

--- a/server/trackers/__tests__/decorator.test.ts
+++ b/server/trackers/__tests__/decorator.test.ts
@@ -10,7 +10,8 @@ function createFakeTracker(
 			throw new Error("not implemented");
 		},
 		fetchActiveIssues: async () => [],
-		swapLabel: async () => {},
+		transitionState: async () => {},
+		parseIssueKey: () => ({ repo: "owner/repo", number: 1 }),
 		...overrides,
 	};
 }
@@ -32,34 +33,49 @@ describe("decorateTracker", () => {
 		});
 	});
 
-	describe("swapLabel", () => {
+	describe("transitionState", () => {
 		it("delegates to inner tracker on success", async () => {
 			const calls: { repo: string; issueNumber: number }[] = [];
 
 			const decorated = decorateTracker(
 				createFakeTracker({
-					swapLabel: async (repo, issueNumber) => {
+					transitionState: async (repo, issueNumber) => {
 						calls.push({ repo, issueNumber });
 					},
 				}),
 			);
 
-			await decorated.swapLabel("owner/repo", 42, "old", "new");
+			await decorated.transitionState("owner/repo", 42, "pending", "running");
 			expect(calls).toEqual([{ repo: "owner/repo", issueNumber: 42 }]);
 		});
 
-		it("re-throws when inner swapLabel fails", async () => {
+		it("re-throws when inner transitionState fails", async () => {
 			const decorated = decorateTracker(
 				createFakeTracker({
-					swapLabel: async () => {
+					transitionState: async () => {
 						throw new Error("GitHub API 500");
 					},
 				}),
 			);
 
 			await expect(
-				decorated.swapLabel("owner/repo", 1, "old", "new"),
+				decorated.transitionState("owner/repo", 1, "pending", "running"),
 			).rejects.toThrow("GitHub API 500");
+		});
+	});
+
+	describe("parseIssueKey", () => {
+		it("delegates to inner tracker", () => {
+			const decorated = decorateTracker(
+				createFakeTracker({
+					parseIssueKey: () => ({ repo: "owner/repo", number: 42 }),
+				}),
+			);
+
+			expect(decorated.parseIssueKey("owner/repo#42")).toEqual({
+				repo: "owner/repo",
+				number: 42,
+			});
 		});
 	});
 });

--- a/server/trackers/__tests__/github.integration.test.ts
+++ b/server/trackers/__tests__/github.integration.test.ts
@@ -183,6 +183,9 @@ describe("githubTrackerAdapter", () => {
 			const github = createGitHubClient("test-token");
 			const tracker = githubTrackerAdapter(github);
 
+			expect(() => tracker.parseIssueKey("owner/repo")).toThrow(
+				"Invalid GitHub issue key",
+			);
 			expect(() => tracker.parseIssueKey("owner/repo#42abc")).toThrow(
 				"Invalid GitHub issue key",
 			);

--- a/server/trackers/__tests__/github.integration.test.ts
+++ b/server/trackers/__tests__/github.integration.test.ts
@@ -30,7 +30,7 @@ describe("githubTrackerAdapter", () => {
 			const github = createGitHubClient("test-token");
 			const tracker = githubTrackerAdapter(github, ["open", "closed"]);
 
-			const issues = await tracker.fetchActiveIssues(REPO, "agent");
+			const issues = await tracker.fetchActiveIssues(REPO, "pending");
 			expect(issues).toEqual([
 				{
 					key: `${REPO}#10`,
@@ -67,7 +67,7 @@ describe("githubTrackerAdapter", () => {
 			const github = createGitHubClient("test-token");
 			const tracker = githubTrackerAdapter(github, ["open", "closed"]);
 
-			const issues = await tracker.fetchActiveIssues(REPO, "agent");
+			const issues = await tracker.fetchActiveIssues(REPO, "pending");
 			expect(issues).toEqual([
 				{
 					key: `${REPO}#1`,
@@ -108,7 +108,7 @@ describe("githubTrackerAdapter", () => {
 			const github = createGitHubClient("test-token");
 			const tracker = githubTrackerAdapter(github);
 
-			const issues = await tracker.fetchActiveIssues(REPO, "agent");
+			const issues = await tracker.fetchActiveIssues(REPO, "pending");
 			expect(issues).toEqual([
 				{
 					key: `${REPO}#5`,
@@ -120,6 +120,72 @@ describe("githubTrackerAdapter", () => {
 					createdAt: "2025-01-01T00:00:00Z",
 				},
 			]);
+		});
+	});
+
+	describe("transitionState", () => {
+		it("maps logical states to GitHub labels", async () => {
+			const labelOps: { method: string; label: string }[] = [];
+
+			server.use(
+				http.get(`${GITHUB_API}/user`, () =>
+					HttpResponse.json({ login: "test-user" }),
+				),
+				http.delete(
+					`${GITHUB_API}/repos/${REPO}/issues/:number/labels/:label`,
+					({ params }) => {
+						labelOps.push({
+							method: "delete",
+							label: String(params["label"]),
+						});
+						return new HttpResponse(null, { status: 204 });
+					},
+				),
+				http.post(
+					`${GITHUB_API}/repos/${REPO}/issues/:number/labels`,
+					async ({ request }) => {
+						const body = (await request.json()) as { labels: string[] };
+						labelOps.push({ method: "add", label: body.labels[0] ?? "" });
+						return HttpResponse.json([]);
+					},
+				),
+			);
+
+			const github = createGitHubClient("test-token");
+			const tracker = githubTrackerAdapter(github);
+
+			await tracker.transitionState(REPO, 42, "running", "awaiting_review");
+
+			expect(labelOps).toContainEqual({
+				method: "delete",
+				label: "agent:running",
+			});
+			expect(labelOps).toContainEqual({
+				method: "add",
+				label: "agent:awaiting-review",
+			});
+			expect(labelOps).toHaveLength(2);
+		});
+	});
+
+	describe("parseIssueKey", () => {
+		it("parses GitHub issue keys", () => {
+			const github = createGitHubClient("test-token");
+			const tracker = githubTrackerAdapter(github);
+
+			expect(tracker.parseIssueKey("owner/repo#42")).toEqual({
+				repo: "owner/repo",
+				number: 42,
+			});
+		});
+
+		it("rejects malformed GitHub issue keys", () => {
+			const github = createGitHubClient("test-token");
+			const tracker = githubTrackerAdapter(github);
+
+			expect(() => tracker.parseIssueKey("owner/repo#42abc")).toThrow(
+				"Invalid GitHub issue key",
+			);
 		});
 	});
 });

--- a/server/trackers/decorator.ts
+++ b/server/trackers/decorator.ts
@@ -16,9 +16,9 @@ export function decorateTracker(inner: TrackerAdapter): TrackerAdapter {
 			}
 		},
 
-		async fetchActiveIssues(repo, label) {
+		async fetchActiveIssues(repo, state) {
 			try {
-				const issues = await inner.fetchActiveIssues(repo, label);
+				const issues = await inner.fetchActiveIssues(repo, state);
 				canonicalLog.set({
 					tracker_active_issues_count: issues.length,
 				});
@@ -29,17 +29,21 @@ export function decorateTracker(inner: TrackerAdapter): TrackerAdapter {
 			}
 		},
 
-		async swapLabel(repo, issueNumber, remove, add) {
+		async transitionState(repo, issueNumber, from, to) {
 			try {
-				await inner.swapLabel(repo, issueNumber, remove, add);
-				canonicalLog.append("label_swaps", { from: remove, to: add });
+				await inner.transitionState(repo, issueNumber, from, to);
+				canonicalLog.append("state_transitions", { from, to });
 			} catch (err) {
 				canonicalLog.append(
 					"warnings",
-					`label_swap_failed: ${repo}#${issueNumber}`,
+					`state_transition_failed: ${repo}#${issueNumber}`,
 				);
 				throw err;
 			}
+		},
+
+		parseIssueKey(key) {
+			return inner.parseIssueKey(key);
 		},
 	};
 }

--- a/server/trackers/github.ts
+++ b/server/trackers/github.ts
@@ -1,8 +1,14 @@
 import type { GitHubClient, GitHubIssue } from "../github-client.ts";
 import { decorateTracker } from "./decorator.ts";
-import type { Issue, TrackerAdapter } from "./types.ts";
+import type { Issue, TrackerAdapter, TrackerState } from "./types.ts";
 
 type IssueState = "open" | "closed" | "all";
+
+const LABELS: Record<TrackerState, string> = {
+	pending: "agent",
+	running: "agent:running",
+	awaiting_review: "agent:awaiting-review",
+};
 
 function mapGitHubIssue(repo: string, i: GitHubIssue): Issue {
 	return {
@@ -20,7 +26,11 @@ export function githubTrackerAdapter(
 	client: GitHubClient,
 	activeStates: IssueState[] = ["open"],
 ): TrackerAdapter {
-	const usernamePromise = client.getAuthenticatedUser().then((u) => u.login);
+	let usernamePromise: Promise<string> | undefined;
+	function getUsername(): Promise<string> {
+		usernamePromise ??= client.getAuthenticatedUser().then((u) => u.login);
+		return usernamePromise;
+	}
 
 	return decorateTracker({
 		async fetchIssue(repo: string, issueNumber: number): Promise<Issue> {
@@ -28,8 +38,12 @@ export function githubTrackerAdapter(
 			return mapGitHubIssue(repo, i);
 		},
 
-		async fetchActiveIssues(repo: string, label: string): Promise<Issue[]> {
-			const username = await usernamePromise;
+		async fetchActiveIssues(
+			repo: string,
+			state: TrackerState,
+		): Promise<Issue[]> {
+			const username = await getUsername();
+			const label = LABELS[state];
 
 			const batches = await Promise.all(
 				activeStates.map((state) =>
@@ -54,16 +68,33 @@ export function githubTrackerAdapter(
 				.map((i) => mapGitHubIssue(repo, i));
 		},
 
-		async swapLabel(
+		async transitionState(
 			repo: string,
 			issueNumber: number,
-			remove: string,
-			add: string,
+			from: TrackerState,
+			to: TrackerState,
 		): Promise<void> {
 			await Promise.all([
-				client.removeIssueLabel(repo, issueNumber, remove),
-				client.addIssueLabels(repo, issueNumber, [add]),
+				client.removeIssueLabel(repo, issueNumber, LABELS[from]),
+				client.addIssueLabels(repo, issueNumber, [LABELS[to]]),
 			]);
+		},
+
+		parseIssueKey(key: string): { repo: string; number: number } {
+			const hashIndex = key.lastIndexOf("#");
+			if (hashIndex <= 0 || hashIndex === key.length - 1) {
+				throw new Error(`Invalid GitHub issue key: ${key}`);
+			}
+
+			const rawNumber = key.slice(hashIndex + 1);
+			if (!/^\d+$/.test(rawNumber)) {
+				throw new Error(`Invalid GitHub issue key: ${key}`);
+			}
+
+			return {
+				repo: key.slice(0, hashIndex),
+				number: Number.parseInt(rawNumber, 10),
+			};
 		},
 	});
 }

--- a/server/trackers/types.ts
+++ b/server/trackers/types.ts
@@ -8,13 +8,16 @@ export type Issue = {
 	createdAt: string; // ISO 8601
 };
 
+export type TrackerState = "pending" | "running" | "awaiting_review";
+
 export type TrackerAdapter = {
 	fetchIssue(repo: string, issueNumber: number): Promise<Issue>;
-	fetchActiveIssues(repo: string, label: string): Promise<Issue[]>;
-	swapLabel(
+	fetchActiveIssues(repo: string, state: TrackerState): Promise<Issue[]>;
+	transitionState(
 		repo: string,
 		issueNumber: number,
-		remove: string,
-		add: string,
+		from: TrackerState,
+		to: TrackerState,
 	): Promise<void>;
+	parseIssueKey(key: string): { repo: string; number: number };
 };


### PR DESCRIPTION
## Summary
- Introduce logical `TrackerState` values and rename `swapLabel` to `transitionState`.
- Move GitHub label mapping and issue-key parsing into the GitHub tracker adapter.
- Update orchestrator and tracker decorator to use logical states and adapter-owned parsing.
- Add tests for GitHub state mapping, issue-key parsing, decorator delegation, and orchestrator logical-state transitions.

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test
- push hook: pnpm test:coverage

## Notes
- Includes follow-up refinements in `05771b6` and `b8d7546` on top of the main slice commit.