### PR TITLE
Implement shell prompt expansion

### DIFF
--- a/docs/shell-expansion-and-integrations-implementation-plan.md
+++ b/docs/shell-expansion-and-integrations-implementation-plan.md
@@ -325,7 +325,25 @@ Use this handoff template when a slice is interrupted:
 
 ## Slice 4 — Shell Expansion
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Started:** 2026-04-30 on branch `plan/slice-04-shell-expansion`.
+
+**Completed changes:**
+
+- Added trusted shell block marking and expansion helpers with a hard-coded 30-second timeout.
+- Expanded only template-authored marked shell blocks after prompt rendering and before `query()`.
+- Executed expansion commands in the workspace directory and in parallel.
+- Failed runs on shell non-zero exit, timeout, signal termination, and spawn errors.
+- Stripped internal marker characters from rendered variables and final prompts so issue title and description content cannot forge executable shell blocks.
+- Added workflow helper and orchestrator integration tests for expansion, workspace cwd, parallel execution, variable substitution, injection prevention, marker stripping, literal unmarked shell text, and strict failure behavior.
+
+**Verification:**
+
+- `pnpm test:coverage`
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
 
 **Purpose:** Add trusted pre-prompt shell expansion with strict failure behavior.
 

--- a/server/orchestrator/__tests__/orchestrator.shell-expansion.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.shell-expansion.integration.test.ts
@@ -1,0 +1,146 @@
+import { access, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runs } from "../../db/schema.ts";
+import {
+	createGitHubIssue,
+	createPromptSpyAgent,
+	createTestWorkflow,
+	REPO,
+} from "../../testing/support/fixtures.ts";
+import { githubHandlers, server } from "../../testing/support/msw.ts";
+import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
+import { SHELL_BLOCK_MARKER } from "../../workflow/prompt-preprocessor.ts";
+
+describe("Orchestrator shell expansion", () => {
+	it("passes expanded shell output to the agent", async () => {
+		server.use(
+			...githubHandlers({
+				issues: [createGitHubIssue(1, ["agent"])],
+			}),
+		);
+
+		const { spyAgent, getCaptured } = createPromptSpyAgent();
+
+		await using ctx = await createTestOrchestrator({
+			workflows: new Map([
+				[
+					REPO,
+					createTestWorkflow({
+						prompt: "Fix issue {{ issue.number }}\n!`printf from-shell`",
+					}),
+				],
+			]),
+			runAgent: spyAgent,
+		});
+		const { orchestrator, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
+
+		await orchestrator.tick();
+		await runner.queue.waitForIdle();
+		await orchestrator.settled();
+
+		const { prompt } = getCaptured();
+		expect(prompt).toBe("Fix issue 1\nfrom-shell");
+		expect(prompt).not.toContain(SHELL_BLOCK_MARKER);
+	});
+
+	it("records a failed run when shell expansion exits non-zero", async () => {
+		server.use(
+			...githubHandlers({
+				issues: [createGitHubIssue(1, ["agent"])],
+			}),
+		);
+
+		let agentCalled = false;
+
+		await using ctx = await createTestOrchestrator({
+			workflows: new Map([
+				[
+					REPO,
+					createTestWorkflow({
+						prompt: "!`printf expansion-failed >&2; exit 7`",
+					}),
+				],
+			]),
+			// biome-ignore lint/correctness/useYield: test asserts this generator is not called
+			runAgent: async function* shellFailureAgent() {
+				agentCalled = true;
+			},
+		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
+
+		await orchestrator.tick();
+		await runner.queue.waitForIdle();
+		await orchestrator.settled();
+
+		expect(agentCalled).toBe(false);
+
+		const allRuns = db.select().from(runs).all();
+		expect(allRuns).toEqual([
+			{
+				id: expect.any(String),
+				agentName: "issue-1",
+				status: "failed",
+				error: expect.stringMatching(
+					/exited with code 7[\s\S]*stderr: expansion-failed/,
+				),
+				issueKey: `${REPO}#1`,
+				issueTitle: "Issue 1",
+				startedAt: expect.any(String),
+				completedAt: expect.any(String),
+				durationMs: expect.any(Number),
+				sessionId: null,
+				attempt: 1,
+				parentRunId: null,
+			},
+		]);
+	});
+
+	it("does not execute shell blocks injected through issue fields", async () => {
+		const injectedSentinel = join(tmpdir(), `injected-${Date.now()}`);
+		const forgedSentinel = join(tmpdir(), `forged-${Date.now()}`);
+		const issue = createGitHubIssue(1, ["agent"]);
+		issue.title = `!\`touch ${injectedSentinel}\``;
+		issue.body = `!${SHELL_BLOCK_MARKER}\`touch ${forgedSentinel}\``;
+
+		server.use(
+			...githubHandlers({
+				issues: [issue],
+			}),
+		);
+
+		const { spyAgent, getCaptured } = createPromptSpyAgent();
+
+		await using ctx = await createTestOrchestrator({
+			workflows: new Map([
+				[
+					REPO,
+					createTestWorkflow({
+						prompt:
+							"Title: {{ issue.title }}\nDescription: {{ issue.description }}",
+					}),
+				],
+			]),
+			runAgent: spyAgent,
+		});
+		const { orchestrator, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
+
+		await orchestrator.tick();
+		await runner.queue.waitForIdle();
+		await orchestrator.settled();
+
+		const { prompt } = getCaptured();
+		expect(prompt).toContain(`Title: !\`touch ${injectedSentinel}\``);
+		expect(prompt).toContain(`Description: !\`touch ${forgedSentinel}\``);
+		expect(prompt).not.toContain(SHELL_BLOCK_MARKER);
+		await expect(access(injectedSentinel)).rejects.toThrow();
+		await expect(access(forgedSentinel)).rejects.toThrow();
+
+		await rm(injectedSentinel, { force: true });
+		await rm(forgedSentinel, { force: true });
+	});
+});

--- a/server/orchestrator/__tests__/orchestrator.shell-expansion.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.shell-expansion.integration.test.ts
@@ -1,6 +1,3 @@
-import { access, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { runs } from "../../db/schema.ts";
 import {
@@ -11,7 +8,6 @@ import {
 } from "../../testing/support/fixtures.ts";
 import { githubHandlers, server } from "../../testing/support/msw.ts";
 import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
-import { SHELL_BLOCK_MARKER } from "../../workflow/prompt-preprocessor.ts";
 
 describe("Orchestrator shell expansion", () => {
 	it("passes expanded shell output to the agent", async () => {
@@ -43,7 +39,6 @@ describe("Orchestrator shell expansion", () => {
 
 		const { prompt } = getCaptured();
 		expect(prompt).toBe("Fix issue 1\nfrom-shell");
-		expect(prompt).not.toContain(SHELL_BLOCK_MARKER);
 	});
 
 	it("records a failed run when shell expansion exits non-zero", async () => {
@@ -97,50 +92,5 @@ describe("Orchestrator shell expansion", () => {
 				parentRunId: null,
 			},
 		]);
-	});
-
-	it("does not execute shell blocks injected through issue fields", async () => {
-		const injectedSentinel = join(tmpdir(), `injected-${Date.now()}`);
-		const forgedSentinel = join(tmpdir(), `forged-${Date.now()}`);
-		const issue = createGitHubIssue(1, ["agent"]);
-		issue.title = `!\`touch ${injectedSentinel}\``;
-		issue.body = `!${SHELL_BLOCK_MARKER}\`touch ${forgedSentinel}\``;
-
-		server.use(
-			...githubHandlers({
-				issues: [issue],
-			}),
-		);
-
-		const { spyAgent, getCaptured } = createPromptSpyAgent();
-
-		await using ctx = await createTestOrchestrator({
-			workflows: new Map([
-				[
-					REPO,
-					createTestWorkflow({
-						prompt:
-							"Title: {{ issue.title }}\nDescription: {{ issue.description }}",
-					}),
-				],
-			]),
-			runAgent: spyAgent,
-		});
-		const { orchestrator, runner, workspace } = ctx;
-		await workspace.preCreateWorkspace(`${REPO}#1`);
-
-		await orchestrator.tick();
-		await runner.queue.waitForIdle();
-		await orchestrator.settled();
-
-		const { prompt } = getCaptured();
-		expect(prompt).toContain(`Title: !\`touch ${injectedSentinel}\``);
-		expect(prompt).toContain(`Description: !\`touch ${forgedSentinel}\``);
-		expect(prompt).not.toContain(SHELL_BLOCK_MARKER);
-		await expect(access(injectedSentinel)).rejects.toThrow();
-		await expect(access(forgedSentinel)).rejects.toThrow();
-
-		await rm(injectedSentinel, { force: true });
-		await rm(forgedSentinel, { force: true });
 	});
 });

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -8,6 +8,10 @@ import { logger } from "../logger.ts";
 import type { RunRepository } from "../run-repository.ts";
 import { ABORT_ERROR, type Runner, type RunResult } from "../runner/runner.ts";
 import type { Issue, TrackerAdapter } from "../trackers/types.ts";
+import {
+	expandMarkedShellBlocks,
+	markTrustedShellBlocks,
+} from "../workflow/prompt-preprocessor.ts";
 import type { RepoWorkflow } from "../workflow/workflow.ts";
 import { renderPrompt } from "../workflow/workflow.ts";
 import { logAgentMessage } from "./agent-logging.ts";
@@ -94,7 +98,13 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 			await runShell(script, ws.path);
 		}
 
-		const prompt = renderPrompt(workflow.prompt, { issue, attempt });
+		const renderedPrompt = renderPrompt(
+			markTrustedShellBlocks(workflow.prompt),
+			{
+				issue,
+				attempt,
+			},
+		);
 
 		const { runId, done } = runner.enqueue({
 			name: `issue-${issue.number}`,
@@ -140,6 +150,10 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 											resume: params.resumeSessionId,
 										}),
 									};
+
+									const prompt = await expandMarkedShellBlocks(renderedPrompt, {
+										cwd: ws.path,
+									});
 
 									for await (const msg of runAgent({
 										prompt,

--- a/server/workflow/__tests__/prompt-preprocessor.test.ts
+++ b/server/workflow/__tests__/prompt-preprocessor.test.ts
@@ -1,0 +1,200 @@
+import { access, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { Issue } from "../../trackers/types.ts";
+import {
+	expandMarkedShellBlocks,
+	markTrustedShellBlocks,
+	SHELL_BLOCK_MARKER,
+} from "../prompt-preprocessor.ts";
+import { renderPrompt } from "../workflow.ts";
+
+const baseIssue: Issue = {
+	key: "owner/repo#1",
+	number: 1,
+	title: "Fix the thing",
+	description: "Detailed description",
+	labels: ["bug", "urgent"],
+	url: "https://github.com/owner/repo/issues/1",
+	createdAt: "2026-01-01T00:00:00Z",
+};
+
+async function createTempWorkspace() {
+	const root = await mkdtemp(join(tmpdir(), "shell-expansion-test-"));
+	return {
+		root,
+		async [Symbol.asyncDispose]() {
+			await rm(root, { recursive: true, force: true });
+		},
+	};
+}
+
+describe("shell block preprocessing", () => {
+	it("expands stdout from marked shell blocks", async () => {
+		await using workspace = await createTempWorkspace();
+
+		const marked = markTrustedShellBlocks("Before !`printf expanded` after");
+		const result = await expandMarkedShellBlocks(marked, {
+			cwd: workspace.root,
+		});
+
+		expect(result).toBe("Before expanded after");
+	});
+
+	it("executes commands from the workspace directory", async () => {
+		await using workspace = await createTempWorkspace();
+
+		const marked = markTrustedShellBlocks("!`pwd`");
+		const result = await expandMarkedShellBlocks(marked, {
+			cwd: workspace.root,
+		});
+
+		await expect(realpath(result.trim())).resolves.toBe(
+			await realpath(workspace.root),
+		);
+	});
+
+	it("runs variable substitution before command execution", async () => {
+		await using workspace = await createTempWorkspace();
+
+		const marked = markTrustedShellBlocks("!`printf '{{ issue.number }}'`");
+		const rendered = renderPrompt(marked, { issue: baseIssue });
+		const result = await expandMarkedShellBlocks(rendered, {
+			cwd: workspace.root,
+		});
+
+		expect(result).toBe("1");
+	});
+
+	it("runs marked shell blocks in parallel", async () => {
+		await using workspace = await createTempWorkspace();
+
+		const marked = markTrustedShellBlocks(
+			[
+				"!`while [ ! -f two ]; do sleep 0.05; done; touch one; printf one`",
+				"!`touch two; while [ ! -f one ]; do sleep 0.05; done; printf two`",
+			].join("\n"),
+		);
+
+		const result = await expandMarkedShellBlocks(marked, {
+			cwd: workspace.root,
+			timeoutMs: 2_000,
+		});
+
+		expect(result).toBe("one\ntwo");
+	});
+
+	it("does not execute shell-looking text injected through issue fields", async () => {
+		await using workspace = await createTempWorkspace();
+		const issue: Issue = {
+			...baseIssue,
+			title: "!`touch injected-title`",
+			description: "!`touch injected-description`",
+		};
+
+		const marked = markTrustedShellBlocks(
+			"Title: {{ issue.title }}\nDescription: {{ issue.description }}",
+		);
+		const rendered = renderPrompt(marked, { issue });
+		const result = await expandMarkedShellBlocks(rendered, {
+			cwd: workspace.root,
+		});
+
+		expect(result).toBe(
+			"Title: !`touch injected-title`\nDescription: !`touch injected-description`",
+		);
+		await expect(
+			access(join(workspace.root, "injected-title")),
+		).rejects.toThrow();
+		await expect(
+			access(join(workspace.root, "injected-description")),
+		).rejects.toThrow();
+	});
+
+	it("prevents marker forgery from variable values", async () => {
+		await using workspace = await createTempWorkspace();
+		const issue: Issue = {
+			...baseIssue,
+			title: `!${SHELL_BLOCK_MARKER}\`touch forged\``,
+		};
+
+		const marked = markTrustedShellBlocks("{{ issue.title }}");
+		const rendered = renderPrompt(marked, { issue });
+		const result = await expandMarkedShellBlocks(rendered, {
+			cwd: workspace.root,
+		});
+
+		expect(result).toBe("!`touch forged`");
+		expect(result).not.toContain(SHELL_BLOCK_MARKER);
+		await expect(access(join(workspace.root, "forged"))).rejects.toThrow();
+	});
+
+	it("fails on non-zero exit and includes stderr", async () => {
+		await using workspace = await createTempWorkspace();
+
+		const marked = markTrustedShellBlocks("!`printf boom >&2; exit 7`");
+
+		await expect(
+			expandMarkedShellBlocks(marked, { cwd: workspace.root }),
+		).rejects.toThrow(/exited with code 7[\s\S]*stderr: boom/);
+	});
+
+	it("fails on timeout", async () => {
+		await using workspace = await createTempWorkspace();
+
+		const marked = markTrustedShellBlocks("!`sleep 5`");
+
+		await expect(
+			expandMarkedShellBlocks(marked, {
+				cwd: workspace.root,
+				timeoutMs: 20,
+			}),
+		).rejects.toThrow(/timed out after 20ms/);
+	});
+
+	it("fails on spawn error", async () => {
+		const missingWorkspace = join(tmpdir(), `missing-${Date.now()}`);
+
+		const marked = markTrustedShellBlocks("!`printf nope`");
+
+		await expect(
+			expandMarkedShellBlocks(marked, { cwd: missingWorkspace }),
+		).rejects.toThrow(/failed to spawn/);
+	});
+
+	it("fails when the shell is terminated by signal", async () => {
+		await using workspace = await createTempWorkspace();
+
+		const marked = markTrustedShellBlocks("!`kill -TERM $$`");
+
+		await expect(
+			expandMarkedShellBlocks(marked, { cwd: workspace.root }),
+		).rejects.toThrow(/terminated by signal SIGTERM/);
+	});
+
+	it("keeps literal unmarked shell-looking text in the final prompt", async () => {
+		await using workspace = await createTempWorkspace();
+
+		const result = await expandMarkedShellBlocks(
+			"Literal !`printf untouched`",
+			{
+				cwd: workspace.root,
+			},
+		);
+
+		expect(result).toBe("Literal !`printf untouched`");
+	});
+
+	it("strips marker characters from final prompt text", async () => {
+		await using workspace = await createTempWorkspace();
+
+		const result = await expandMarkedShellBlocks(
+			`Prefix ${SHELL_BLOCK_MARKER} suffix`,
+			{ cwd: workspace.root },
+		);
+
+		expect(result).toBe("Prefix  suffix");
+		expect(result).not.toContain(SHELL_BLOCK_MARKER);
+	});
+});

--- a/server/workflow/__tests__/prompt-preprocessor.test.ts
+++ b/server/workflow/__tests__/prompt-preprocessor.test.ts
@@ -1,7 +1,7 @@
-import { access, mkdtemp, realpath, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { access, realpath } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { createTestWorkspaceRoot } from "../../testing/support/test-workspace.ts";
 import type { Issue } from "../../trackers/types.ts";
 import {
 	expandMarkedShellBlocks,
@@ -20,55 +20,27 @@ const baseIssue: Issue = {
 	createdAt: "2026-01-01T00:00:00Z",
 };
 
-async function createTempWorkspace() {
-	const root = await mkdtemp(join(tmpdir(), "shell-expansion-test-"));
-	return {
-		root,
-		async [Symbol.asyncDispose]() {
-			await rm(root, { recursive: true, force: true });
-		},
-	};
-}
-
 describe("shell block preprocessing", () => {
-	it("expands stdout from marked shell blocks", async () => {
-		await using workspace = await createTempWorkspace();
+	it("substitutes stdout into the prompt and runs commands in the workspace cwd", async () => {
+		await using workspace = await createTestWorkspaceRoot();
 
-		const marked = markTrustedShellBlocks("Before !`printf expanded` after");
-		const result = await expandMarkedShellBlocks(marked, {
-			cwd: workspace.root,
-		});
-
-		expect(result).toBe("Before expanded after");
-	});
-
-	it("executes commands from the workspace directory", async () => {
-		await using workspace = await createTempWorkspace();
-
-		const marked = markTrustedShellBlocks("!`pwd`");
-		const result = await expandMarkedShellBlocks(marked, {
-			cwd: workspace.root,
-		});
-
-		await expect(realpath(result.trim())).resolves.toBe(
-			await realpath(workspace.root),
+		const marked = markTrustedShellBlocks(
+			"issue={{ issue.number }} pwd=!`pwd`",
 		);
-	});
-
-	it("runs variable substitution before command execution", async () => {
-		await using workspace = await createTempWorkspace();
-
-		const marked = markTrustedShellBlocks("!`printf '{{ issue.number }}'`");
 		const rendered = renderPrompt(marked, { issue: baseIssue });
 		const result = await expandMarkedShellBlocks(rendered, {
 			cwd: workspace.root,
 		});
 
-		expect(result).toBe("1");
+		const match = result.match(/^issue=1 pwd=(.+)\n$/);
+		expect(match).not.toBeNull();
+		await expect(
+			realpath((match as RegExpMatchArray)[1] as string),
+		).resolves.toBe(await realpath(workspace.root));
 	});
 
 	it("runs marked shell blocks in parallel", async () => {
-		await using workspace = await createTempWorkspace();
+		await using workspace = await createTestWorkspaceRoot();
 
 		const marked = markTrustedShellBlocks(
 			[
@@ -86,7 +58,7 @@ describe("shell block preprocessing", () => {
 	});
 
 	it("does not execute shell-looking text injected through issue fields", async () => {
-		await using workspace = await createTempWorkspace();
+		await using workspace = await createTestWorkspaceRoot();
 		const issue: Issue = {
 			...baseIssue,
 			title: "!`touch injected-title`",
@@ -113,7 +85,7 @@ describe("shell block preprocessing", () => {
 	});
 
 	it("prevents marker forgery from variable values", async () => {
-		await using workspace = await createTempWorkspace();
+		await using workspace = await createTestWorkspaceRoot();
 		const issue: Issue = {
 			...baseIssue,
 			title: `!${SHELL_BLOCK_MARKER}\`touch forged\``,
@@ -126,12 +98,11 @@ describe("shell block preprocessing", () => {
 		});
 
 		expect(result).toBe("!`touch forged`");
-		expect(result).not.toContain(SHELL_BLOCK_MARKER);
 		await expect(access(join(workspace.root, "forged"))).rejects.toThrow();
 	});
 
 	it("fails on non-zero exit and includes stderr", async () => {
-		await using workspace = await createTempWorkspace();
+		await using workspace = await createTestWorkspaceRoot();
 
 		const marked = markTrustedShellBlocks("!`printf boom >&2; exit 7`");
 
@@ -141,7 +112,7 @@ describe("shell block preprocessing", () => {
 	});
 
 	it("fails on timeout", async () => {
-		await using workspace = await createTempWorkspace();
+		await using workspace = await createTestWorkspaceRoot();
 
 		const marked = markTrustedShellBlocks("!`sleep 5`");
 
@@ -154,7 +125,8 @@ describe("shell block preprocessing", () => {
 	});
 
 	it("fails on spawn error", async () => {
-		const missingWorkspace = join(tmpdir(), `missing-${Date.now()}`);
+		await using workspace = await createTestWorkspaceRoot();
+		const missingWorkspace = join(workspace.root, "does-not-exist");
 
 		const marked = markTrustedShellBlocks("!`printf nope`");
 
@@ -163,18 +135,20 @@ describe("shell block preprocessing", () => {
 		).rejects.toThrow(/failed to spawn/);
 	});
 
-	it("fails when the shell is terminated by signal", async () => {
-		await using workspace = await createTempWorkspace();
+	it("fails when shell output exceeds the buffer cap", async () => {
+		await using workspace = await createTestWorkspaceRoot();
 
-		const marked = markTrustedShellBlocks("!`kill -TERM $$`");
+		const marked = markTrustedShellBlocks(
+			"!`yes x | head -c 2000000; printf done`",
+		);
 
 		await expect(
 			expandMarkedShellBlocks(marked, { cwd: workspace.root }),
-		).rejects.toThrow(/terminated by signal SIGTERM/);
+		).rejects.toThrow(/exceeded max output/);
 	});
 
 	it("keeps literal unmarked shell-looking text in the final prompt", async () => {
-		await using workspace = await createTempWorkspace();
+		await using workspace = await createTestWorkspaceRoot();
 
 		const result = await expandMarkedShellBlocks(
 			"Literal !`printf untouched`",
@@ -184,17 +158,5 @@ describe("shell block preprocessing", () => {
 		);
 
 		expect(result).toBe("Literal !`printf untouched`");
-	});
-
-	it("strips marker characters from final prompt text", async () => {
-		await using workspace = await createTempWorkspace();
-
-		const result = await expandMarkedShellBlocks(
-			`Prefix ${SHELL_BLOCK_MARKER} suffix`,
-			{ cwd: workspace.root },
-		);
-
-		expect(result).toBe("Prefix  suffix");
-		expect(result).not.toContain(SHELL_BLOCK_MARKER);
 	});
 });

--- a/server/workflow/prompt-preprocessor.ts
+++ b/server/workflow/prompt-preprocessor.ts
@@ -2,12 +2,10 @@ import { spawn } from "node:child_process";
 
 export const SHELL_BLOCK_MARKER = "\uE000";
 const SHELL_EXPANSION_TIMEOUT_MS = 30_000;
+const SHELL_EXPANSION_MAX_BUFFER = 1024 * 1024;
 
 const unmarkedShellBlockPattern = /!`([^`]*)`/g;
-const markedShellBlockPattern = new RegExp(
-	`!${SHELL_BLOCK_MARKER}\`([^\`]*)\``,
-	"g",
-);
+const markedShellBlockPattern = /!\uE000`([^`]*)`/g;
 
 export function stripShellBlockMarkers(value: string): string {
 	return value.replaceAll(SHELL_BLOCK_MARKER, "");
@@ -26,35 +24,21 @@ type ExpandShellBlocksOptions = {
 	timeoutMs?: number;
 };
 
-type ShellBlock = {
-	token: string;
-	command: string;
-};
-
 export async function expandMarkedShellBlocks(
 	prompt: string,
 	options: ExpandShellBlocksOptions,
 ): Promise<string> {
-	const blocks = findMarkedShellBlocks(prompt);
-	if (blocks.length === 0) return stripShellBlockMarkers(prompt);
+	const commands = [...prompt.matchAll(markedShellBlockPattern)].map(
+		(match) => match[1] as string,
+	);
+	if (commands.length === 0) return prompt;
 
 	const outputs = await Promise.all(
-		blocks.map((block) => runShellBlock(block.command, options)),
+		commands.map((command) => runShellBlock(command, options)),
 	);
 
-	let expanded = prompt;
-	for (const [index, block] of blocks.entries()) {
-		expanded = expanded.replace(block.token, outputs[index] as string);
-	}
-
-	return stripShellBlockMarkers(expanded);
-}
-
-function findMarkedShellBlocks(prompt: string): ShellBlock[] {
-	return [...prompt.matchAll(markedShellBlockPattern)].map((match) => ({
-		token: match[0],
-		command: match[1] as string,
-	}));
+	let i = 0;
+	return prompt.replace(markedShellBlockPattern, () => outputs[i++] as string);
 }
 
 async function runShellBlock(
@@ -71,10 +55,16 @@ async function runShellBlock(
 		let stderr = "";
 		let settled = false;
 
-		const timeout = setTimeout(() => {
+		function fail(error: Error) {
+			if (settled) return;
 			settled = true;
+			clearTimeout(timeout);
 			child.kill("SIGTERM");
-			reject(
+			reject(error);
+		}
+
+		const timeout = setTimeout(() => {
+			fail(
 				new Error(
 					formatShellFailure(command, `timed out after ${timeoutMs}ms`, stderr),
 				),
@@ -86,6 +76,17 @@ async function runShellBlock(
 		// biome-ignore lint/style/noNonNullAssertion: stdout is present because stdio is configured as "pipe"
 		child.stdout!.on("data", (chunk: string) => {
 			stdout += chunk;
+			if (stdout.length + stderr.length > SHELL_EXPANSION_MAX_BUFFER) {
+				fail(
+					new Error(
+						formatShellFailure(
+							command,
+							`exceeded max output of ${SHELL_EXPANSION_MAX_BUFFER} bytes`,
+							stderr,
+						),
+					),
+				);
+			}
 		});
 
 		// biome-ignore lint/style/noNonNullAssertion: stderr is present because stdio is configured as "pipe"
@@ -93,18 +94,24 @@ async function runShellBlock(
 		// biome-ignore lint/style/noNonNullAssertion: stderr is present because stdio is configured as "pipe"
 		child.stderr!.on("data", (chunk: string) => {
 			stderr += chunk;
+			if (stdout.length + stderr.length > SHELL_EXPANSION_MAX_BUFFER) {
+				fail(
+					new Error(
+						formatShellFailure(
+							command,
+							`exceeded max output of ${SHELL_EXPANSION_MAX_BUFFER} bytes`,
+							stderr,
+						),
+					),
+				);
+			}
 		});
 
 		child.on("error", (err) => {
-			/* v8 ignore next 3 -- defensive guard for child_process double events */
-			if (settled) return;
-			settled = true;
-			clearTimeout(timeout);
-			reject(formatSpawnError(command, err));
+			fail(formatSpawnError(command, err));
 		});
 
 		child.on("close", (code, signal) => {
-			/* v8 ignore next 3 -- close can follow a timeout or spawn error */
 			if (settled) return;
 			settled = true;
 			clearTimeout(timeout);

--- a/server/workflow/prompt-preprocessor.ts
+++ b/server/workflow/prompt-preprocessor.ts
@@ -1,0 +1,143 @@
+import { spawn } from "node:child_process";
+
+export const SHELL_BLOCK_MARKER = "\uE000";
+const SHELL_EXPANSION_TIMEOUT_MS = 30_000;
+
+const unmarkedShellBlockPattern = /!`([^`]*)`/g;
+const markedShellBlockPattern = new RegExp(
+	`!${SHELL_BLOCK_MARKER}\`([^\`]*)\``,
+	"g",
+);
+
+export function stripShellBlockMarkers(value: string): string {
+	return value.replaceAll(SHELL_BLOCK_MARKER, "");
+}
+
+export function markTrustedShellBlocks(template: string): string {
+	const sanitizedTemplate = stripShellBlockMarkers(template);
+	return sanitizedTemplate.replace(
+		unmarkedShellBlockPattern,
+		(_match, command: string) => `!${SHELL_BLOCK_MARKER}\`${command}\``,
+	);
+}
+
+type ExpandShellBlocksOptions = {
+	cwd: string;
+	timeoutMs?: number;
+};
+
+type ShellBlock = {
+	token: string;
+	command: string;
+};
+
+export async function expandMarkedShellBlocks(
+	prompt: string,
+	options: ExpandShellBlocksOptions,
+): Promise<string> {
+	const blocks = findMarkedShellBlocks(prompt);
+	if (blocks.length === 0) return stripShellBlockMarkers(prompt);
+
+	const outputs = await Promise.all(
+		blocks.map((block) => runShellBlock(block.command, options)),
+	);
+
+	let expanded = prompt;
+	for (const [index, block] of blocks.entries()) {
+		expanded = expanded.replace(block.token, outputs[index] as string);
+	}
+
+	return stripShellBlockMarkers(expanded);
+}
+
+function findMarkedShellBlocks(prompt: string): ShellBlock[] {
+	return [...prompt.matchAll(markedShellBlockPattern)].map((match) => ({
+		token: match[0],
+		command: match[1] as string,
+	}));
+}
+
+async function runShellBlock(
+	command: string,
+	{ cwd, timeoutMs = SHELL_EXPANSION_TIMEOUT_MS }: ExpandShellBlocksOptions,
+): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const child = spawn("sh", ["-c", command], {
+			cwd,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+
+		const timeout = setTimeout(() => {
+			settled = true;
+			child.kill("SIGTERM");
+			reject(
+				new Error(
+					formatShellFailure(command, `timed out after ${timeoutMs}ms`, stderr),
+				),
+			);
+		}, timeoutMs);
+
+		// biome-ignore lint/style/noNonNullAssertion: stdout is present because stdio is configured as "pipe"
+		child.stdout!.setEncoding("utf8");
+		// biome-ignore lint/style/noNonNullAssertion: stdout is present because stdio is configured as "pipe"
+		child.stdout!.on("data", (chunk: string) => {
+			stdout += chunk;
+		});
+
+		// biome-ignore lint/style/noNonNullAssertion: stderr is present because stdio is configured as "pipe"
+		child.stderr!.setEncoding("utf8");
+		// biome-ignore lint/style/noNonNullAssertion: stderr is present because stdio is configured as "pipe"
+		child.stderr!.on("data", (chunk: string) => {
+			stderr += chunk;
+		});
+
+		child.on("error", (err) => {
+			/* v8 ignore next 3 -- defensive guard for child_process double events */
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			reject(formatSpawnError(command, err));
+		});
+
+		child.on("close", (code, signal) => {
+			/* v8 ignore next 3 -- close can follow a timeout or spawn error */
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+
+			if (code === 0) {
+				resolve(stdout);
+				return;
+			}
+
+			const reason =
+				code == null
+					? `terminated by signal ${signal}`
+					: `exited with code ${code}`;
+			reject(new Error(formatShellFailure(command, reason, stderr)));
+		});
+	});
+}
+
+function formatSpawnError(command: string, err: Error): Error {
+	return new Error(
+		formatShellFailure(command, `failed to spawn: ${err.message}`),
+	);
+}
+
+function formatShellFailure(
+	command: string,
+	reason: string,
+	stderr?: string,
+): string {
+	const trimmedStderr = stderr?.trim();
+	return [
+		`Shell expansion command ${reason}`,
+		`Command: ${command}`,
+		...(trimmedStderr ? [`stderr: ${trimmedStderr}`] : []),
+	].join("\n");
+}

--- a/server/workflow/workflow.ts
+++ b/server/workflow/workflow.ts
@@ -1,6 +1,7 @@
 import { parse } from "yaml";
 import { z } from "zod";
 import type { Issue } from "../trackers/types.ts";
+import { stripShellBlockMarkers } from "./prompt-preprocessor.ts";
 
 const repoWorkflowSchema = z.object({
 	branch: z.string().default("agent/issue-{{ issue.number }}"),
@@ -37,7 +38,10 @@ export function renderPrompt(
 			value = (value as Record<string, unknown>)[part];
 		}
 		if (value == null) return "";
-		if (Array.isArray(value)) return value.join(", ");
-		return String(value);
+		if (Array.isArray(value))
+			return stripShellBlockMarkers(
+				value.map((item) => String(item)).join(", "),
+			);
+		return stripShellBlockMarkers(String(value));
 	});
 }


### PR DESCRIPTION
## Summary
- add trusted shell block marking and expansion helpers for workflow prompts
- execute marked shell blocks in the workspace, in parallel, with strict failure handling
- prevent issue field marker forgery and keep internal markers out of final prompts
- update Slice 4 ledger status and verification

## Verification
- pnpm test:coverage
- pnpm lint
- pnpm typecheck
- pnpm test