### PR TITLE
Add multi-phase workflow runner

### DIFF
--- a/docs/shell-expansion-and-integrations-implementation-plan.md
+++ b/docs/shell-expansion-and-integrations-implementation-plan.md
@@ -389,7 +389,25 @@ Use this handoff template when a slice is interrupted:
 
 ## Slice 5 — Multi-Phase Workflow Schema And Runner
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Started:** 2026-04-30 on branch `plan/slice-05-multi-phase`.
+
+**Completed changes:**
+
+- Extended workflow parsing to accept either a single `prompt` or ordered `phases`, rejecting both/neither.
+- Added phase normalization so single-prompt workflows continue through the same execution path as a one-phase workflow.
+- Added `server/orchestrator/phase-runner.ts` for sequential phase execution with per-phase shell expansion, session capture, resume handling, and phase markers.
+- Added `runs.phaseIndex` plus a Drizzle migration and updated run serialization/test expectations.
+- Updated retry to start at the failed phase, resume the failed phase session when available, and run fresh when no failed-phase session exists.
+- Added focused multi-phase integration tests for sequencing, shell expansion, `resume_previous`, hooks, failure markers, phase progress, and retry behavior.
+
+**Verification:**
+
+- `pnpm test:coverage`
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
 
 **Purpose:** Add simple staged prompts without completion signals or orchestrator-level iteration loops.
 

--- a/drizzle/0003_careless_shiver_man.sql
+++ b/drizzle/0003_careless_shiver_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `runs` ADD `phase_index` integer DEFAULT 0 NOT NULL;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,172 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "f64a9455-8cbb-4b55-891f-f20317c82efa",
+	"prevId": "6dbf3c0e-3781-4c13-87f7-3834913b7898",
+	"tables": {
+		"run_events": {
+			"name": "run_events",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"data": {
+					"name": "data",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_run_events_run_id": {
+					"name": "idx_run_events_run_id",
+					"columns": ["run_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"runs": {
+			"name": "runs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"issue_key": {
+					"name": "issue_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"issue_title": {
+					"name": "issue_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"parent_run_id": {
+					"name": "parent_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phase_index": {
+					"name": "phase_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
 			"when": 1774701011961,
 			"tag": "0002_happy_echo",
 			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "6",
+			"when": 1777569002300,
+			"tag": "0003_careless_shiver_man",
+			"breakpoints": true
 		}
 	]
 }

--- a/server/api/__tests__/runs.test.ts
+++ b/server/api/__tests__/runs.test.ts
@@ -36,6 +36,7 @@ describe("GET /runs", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 			{
 				id: "middle",
@@ -50,6 +51,7 @@ describe("GET /runs", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 			{
 				id: "oldest",
@@ -64,6 +66,7 @@ describe("GET /runs", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});
@@ -99,6 +102,7 @@ describe("GET /runs", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});
@@ -139,6 +143,7 @@ describe("GET /runs", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});
@@ -167,6 +172,7 @@ describe("GET /runs", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});
@@ -213,6 +219,7 @@ describe("GET /runs/:id", () => {
 			sessionId: null,
 			attempt: 1,
 			parentRunId: null,
+			phaseIndex: 0,
 			events: [
 				{
 					id: "evt-1",

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -19,6 +19,7 @@ export const runs = sqliteTable("runs", {
 	sessionId: text("session_id"),
 	attempt: integer("attempt").notNull().default(1),
 	parentRunId: text("parent_run_id"),
+	phaseIndex: integer("phase_index").notNull().default(0),
 });
 
 export const runEvents = sqliteTable(
@@ -41,11 +42,21 @@ export type RunEventType =
 	| "run:started"
 	| "run:output"
 	| "run:tool_use"
+	| "phase.started"
+	| "phase.completed"
+	| "phase.failed"
 	| "run:completed"
 	| "run:failed";
 
 export type RunStartedData = { issueKey: string; issueTitle: string };
 export type RunOutputData = Record<string, unknown>;
 export type RunToolUseData = { tool: string; target: string };
+export type PhaseStartedData = { name: string; index: number; total: number };
+export type PhaseCompletedData = {
+	name: string;
+	index: number;
+	durationMs: number;
+};
+export type PhaseFailedData = { name: string; index: number; error: string };
 export type RunCompletedData = { durationMs: number };
 export type RunFailedData = { error: string; durationMs: number };

--- a/server/event-bus.ts
+++ b/server/event-bus.ts
@@ -16,13 +16,16 @@ type RunEventBase = {
 	createdAt: string;
 };
 
+export type PhaseEvent =
+	| { type: "phase.started"; data: PhaseStartedData }
+	| { type: "phase.completed"; data: PhaseCompletedData }
+	| { type: "phase.failed"; data: PhaseFailedData };
+
 export type RunEvent =
 	| (RunEventBase & { type: "run:started"; data: RunStartedData })
 	| (RunEventBase & { type: "run:output"; data: RunOutputData })
 	| (RunEventBase & { type: "run:tool_use"; data: RunToolUseData })
-	| (RunEventBase & { type: "phase.started"; data: PhaseStartedData })
-	| (RunEventBase & { type: "phase.completed"; data: PhaseCompletedData })
-	| (RunEventBase & { type: "phase.failed"; data: PhaseFailedData })
+	| (RunEventBase & PhaseEvent)
 	| (RunEventBase & { type: "run:completed"; data: RunCompletedData })
 	| (RunEventBase & { type: "run:failed"; data: RunFailedData });
 

--- a/server/event-bus.ts
+++ b/server/event-bus.ts
@@ -1,5 +1,8 @@
 import { EventEmitter } from "node:events";
 import type {
+	PhaseCompletedData,
+	PhaseFailedData,
+	PhaseStartedData,
 	RunCompletedData,
 	RunFailedData,
 	RunOutputData,
@@ -17,6 +20,9 @@ export type RunEvent =
 	| (RunEventBase & { type: "run:started"; data: RunStartedData })
 	| (RunEventBase & { type: "run:output"; data: RunOutputData })
 	| (RunEventBase & { type: "run:tool_use"; data: RunToolUseData })
+	| (RunEventBase & { type: "phase.started"; data: PhaseStartedData })
+	| (RunEventBase & { type: "phase.completed"; data: PhaseCompletedData })
+	| (RunEventBase & { type: "phase.failed"; data: PhaseFailedData })
 	| (RunEventBase & { type: "run:completed"; data: RunCompletedData })
 	| (RunEventBase & { type: "run:failed"; data: RunFailedData });
 

--- a/server/orchestrator/__tests__/orchestrator.dispatch-failure.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.dispatch-failure.integration.test.ts
@@ -45,6 +45,7 @@ describe("Orchestrator dispatch failure and polling", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 
@@ -147,6 +148,7 @@ describe("Orchestrator dispatch failure and polling", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});

--- a/server/orchestrator/__tests__/orchestrator.dispatch-hooks.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.dispatch-hooks.integration.test.ts
@@ -144,6 +144,7 @@ describe("Orchestrator dispatch hooks and completion", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 
@@ -192,6 +193,7 @@ describe("Orchestrator dispatch hooks and completion", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 
@@ -250,6 +252,7 @@ describe("Orchestrator dispatch hooks and completion", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});

--- a/server/orchestrator/__tests__/orchestrator.dispatch-multi-repo.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.dispatch-multi-repo.integration.test.ts
@@ -106,6 +106,7 @@ describe("Orchestrator dispatch multi-repo", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});
@@ -184,6 +185,7 @@ describe("Orchestrator dispatch multi-repo", () => {
 					sessionId: null,
 					attempt: 1,
 					parentRunId: null,
+					phaseIndex: 0,
 				},
 				{
 					id: expect.any(String),
@@ -198,6 +200,7 @@ describe("Orchestrator dispatch multi-repo", () => {
 					sessionId: null,
 					attempt: 1,
 					parentRunId: null,
+					phaseIndex: 0,
 				},
 			]),
 		);
@@ -238,6 +241,7 @@ describe("Orchestrator dispatch multi-repo", () => {
 				sessionId: "test-sess-abc",
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});
@@ -286,6 +290,7 @@ describe("Orchestrator dispatch multi-repo", () => {
 				sessionId: "sess-mixed",
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});

--- a/server/orchestrator/__tests__/orchestrator.dispatch.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.dispatch.integration.test.ts
@@ -89,6 +89,7 @@ describe("Orchestrator dispatch", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});
@@ -160,6 +161,7 @@ describe("Orchestrator dispatch", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});
@@ -203,6 +205,7 @@ describe("Orchestrator dispatch", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 			{
 				id: expect.any(String),
@@ -217,6 +220,7 @@ describe("Orchestrator dispatch", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});
@@ -260,6 +264,7 @@ describe("Orchestrator dispatch", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 

--- a/server/orchestrator/__tests__/orchestrator.multi-phase.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.multi-phase.integration.test.ts
@@ -1,0 +1,268 @@
+import { readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { query } from "@anthropic-ai/claude-agent-sdk";
+import { describe, expect, it } from "vitest";
+import { runs } from "../../db/schema.ts";
+import { createGitHubIssue, REPO } from "../../testing/support/fixtures.ts";
+import { githubHandlers, server } from "../../testing/support/msw.ts";
+import { getEvents, seedRun } from "../../testing/support/test-db.ts";
+import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
+import type { RepoWorkflow } from "../../workflow/workflow.ts";
+
+type QueryParams = Parameters<typeof query>[0];
+
+const failedRunDefaults = {
+	agentName: "issue-1",
+	status: "failed" as const,
+	issueKey: `${REPO}#1`,
+	issueTitle: "Fix the login bug",
+	completedAt: new Date().toISOString(),
+	error: "agent exploded",
+	attempt: 1,
+};
+
+function phasedWorkflow(overrides: Partial<RepoWorkflow> = {}): RepoWorkflow {
+	return {
+		branch: "agent/issue-{{ issue.number }}",
+		base_branch: "main",
+		phases: [
+			{
+				name: "plan",
+				prompt: "Plan {{ issue.number }} !`printf one`",
+				resume_previous: false,
+			},
+			{
+				name: "implement",
+				prompt: "Implement {{ issue.title }} !`printf two`",
+				resume_previous: true,
+			},
+		],
+		...overrides,
+	};
+}
+
+function createPhaseSpyAgent() {
+	const calls: QueryParams[] = [];
+	async function* phaseSpyAgent(params: QueryParams) {
+		calls.push(params);
+		yield {
+			type: "assistant" as const,
+			session_id: `sess-${calls.length}`,
+			// biome-ignore lint/suspicious/noExplicitAny: decouple test fixture from SDK's BetaMessage shape
+			message: { content: [] } as any,
+			parent_tool_use_id: null,
+			uuid: "00000000-0000-0000-0000-000000000003" as const,
+		};
+	}
+
+	return { phaseSpyAgent, calls };
+}
+
+describe("Orchestrator multi-phase workflows", () => {
+	it("runs phases sequentially with freshly rendered and shell-expanded prompts", async () => {
+		server.use(
+			...githubHandlers({
+				issues: [createGitHubIssue(1, ["agent"])],
+			}),
+		);
+
+		const { phaseSpyAgent, calls } = createPhaseSpyAgent();
+
+		await using ctx = await createTestOrchestrator({
+			workflows: new Map([[REPO, phasedWorkflow()]]),
+			runAgent: phaseSpyAgent,
+		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
+
+		await orchestrator.tick();
+		await runner.queue.waitForIdle();
+		await orchestrator.settled();
+
+		expect(calls.map((call) => call.prompt)).toEqual([
+			"Plan 1 one",
+			"Implement Issue 1 two",
+		]);
+		expect(calls[0]?.options).not.toHaveProperty("resume");
+		expect(calls[1]?.options).toMatchObject({ resume: "sess-1" });
+
+		const [run] = db.select().from(runs).all();
+		expect(run).toMatchObject({
+			status: "completed",
+			sessionId: "sess-2",
+			phaseIndex: 1,
+		});
+
+		const events = getEvents(db, run?.id ?? "");
+		expect(events.map((event) => event.type)).toEqual([
+			"run:started",
+			"phase.started",
+			"phase.completed",
+			"phase.started",
+			"phase.completed",
+			"run:completed",
+		]);
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "phase.started",
+				data: { name: "plan", index: 0, total: 2 },
+			}),
+		);
+	});
+
+	it("runs hooks once around the whole dispatch", async () => {
+		server.use(
+			...githubHandlers({
+				issues: [createGitHubIssue(1, ["agent"])],
+			}),
+		);
+
+		const sentinel = join(tmpdir(), `phase-hooks-${Date.now()}`);
+
+		await using ctx = await createTestOrchestrator({
+			workflows: new Map([
+				[
+					REPO,
+					phasedWorkflow({
+						hooks: {
+							before_run: `printf before >> ${sentinel}`,
+							after_run: `printf after >> ${sentinel}`,
+						},
+					}),
+				],
+			]),
+		});
+		const { orchestrator, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
+
+		await orchestrator.tick();
+		await runner.queue.waitForIdle();
+		await orchestrator.settled();
+
+		await expect(readFile(sentinel, "utf8")).resolves.toBe("beforeafter");
+		await rm(sentinel, { force: true });
+	});
+
+	it("records the failed phase index and emits a phase failure marker", async () => {
+		server.use(
+			...githubHandlers({
+				issues: [createGitHubIssue(1, ["agent"])],
+			}),
+		);
+
+		let calls = 0;
+
+		await using ctx = await createTestOrchestrator({
+			workflows: new Map([[REPO, phasedWorkflow()]]),
+			runAgent: async function* failSecondPhaseAgent() {
+				calls++;
+				if (calls === 2) throw new Error("phase exploded");
+				yield {
+					type: "assistant" as const,
+					session_id: "sess-plan",
+					// biome-ignore lint/suspicious/noExplicitAny: decouple test fixture from SDK's BetaMessage shape
+					message: { content: [] } as any,
+					parent_tool_use_id: null,
+					uuid: "00000000-0000-0000-0000-000000000004" as const,
+				};
+			},
+		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
+
+		await orchestrator.tick();
+		await runner.queue.waitForIdle();
+		await orchestrator.settled();
+
+		const [run] = db.select().from(runs).all();
+		expect(run).toMatchObject({
+			status: "failed",
+			error: "phase exploded",
+			sessionId: "sess-plan",
+			phaseIndex: 1,
+		});
+		expect(getEvents(db, run?.id ?? "")).toContainEqual(
+			expect.objectContaining({
+				type: "phase.failed",
+				data: { name: "implement", index: 1, error: "phase exploded" },
+			}),
+		);
+	});
+
+	it("retries from the failed phase and resumes its stored session", async () => {
+		server.use(
+			...githubHandlers({
+				issues: [createGitHubIssue(1, ["agent:running"])],
+			}),
+		);
+
+		const { phaseSpyAgent, calls } = createPhaseSpyAgent();
+
+		await using ctx = await createTestOrchestrator({
+			workflows: new Map([[REPO, phasedWorkflow()]]),
+			runAgent: phaseSpyAgent,
+		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
+		seedRun(db, {
+			...failedRunDefaults,
+			id: "failed-phase",
+			sessionId: "sess-failed-phase",
+			phaseIndex: 1,
+		});
+
+		await expect(orchestrator.retryRun("failed-phase")).resolves.toEqual({
+			runId: expect.any(String),
+		});
+		await runner.queue.waitForIdle();
+		await orchestrator.settled();
+
+		expect(calls.map((call) => call.prompt)).toEqual(["Implement Issue 1 two"]);
+		expect(calls[0]?.options).toMatchObject({ resume: "sess-failed-phase" });
+
+		const retryRun = db
+			.select()
+			.from(runs)
+			.all()
+			.find((run) => run.id !== "failed-phase");
+		expect(retryRun).toMatchObject({
+			status: "completed",
+			attempt: 2,
+			parentRunId: "failed-phase",
+			phaseIndex: 1,
+		});
+	});
+
+	it("retries the failed phase fresh when it has no stored session", async () => {
+		server.use(
+			...githubHandlers({
+				issues: [createGitHubIssue(1, ["agent:running"])],
+			}),
+		);
+
+		const { phaseSpyAgent, calls } = createPhaseSpyAgent();
+
+		await using ctx = await createTestOrchestrator({
+			workflows: new Map([[REPO, phasedWorkflow()]]),
+			runAgent: phaseSpyAgent,
+		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
+		seedRun(db, {
+			...failedRunDefaults,
+			id: "failed-no-session",
+			sessionId: null,
+			phaseIndex: 1,
+		});
+
+		await expect(orchestrator.retryRun("failed-no-session")).resolves.toEqual({
+			runId: expect.any(String),
+		});
+		await runner.queue.waitForIdle();
+		await orchestrator.settled();
+
+		expect(calls.map((call) => call.prompt)).toEqual(["Implement Issue 1 two"]);
+		expect(calls[0]?.options).not.toHaveProperty("resume");
+	});
+});

--- a/server/orchestrator/__tests__/orchestrator.multi-phase.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.multi-phase.integration.test.ts
@@ -1,16 +1,17 @@
 import { readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { query } from "@anthropic-ai/claude-agent-sdk";
 import { describe, expect, it } from "vitest";
 import { runs } from "../../db/schema.ts";
-import { createGitHubIssue, REPO } from "../../testing/support/fixtures.ts";
+import {
+	createGitHubIssue,
+	createPromptSpyAgent,
+	REPO,
+} from "../../testing/support/fixtures.ts";
 import { githubHandlers, server } from "../../testing/support/msw.ts";
 import { getEvents, seedRun } from "../../testing/support/test-db.ts";
 import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
 import type { RepoWorkflow } from "../../workflow/workflow.ts";
-
-type QueryParams = Parameters<typeof query>[0];
 
 const failedRunDefaults = {
 	agentName: "issue-1",
@@ -42,23 +43,6 @@ function phasedWorkflow(overrides: Partial<RepoWorkflow> = {}): RepoWorkflow {
 	};
 }
 
-function createPhaseSpyAgent() {
-	const calls: QueryParams[] = [];
-	async function* phaseSpyAgent(params: QueryParams) {
-		calls.push(params);
-		yield {
-			type: "assistant" as const,
-			session_id: `sess-${calls.length}`,
-			// biome-ignore lint/suspicious/noExplicitAny: decouple test fixture from SDK's BetaMessage shape
-			message: { content: [] } as any,
-			parent_tool_use_id: null,
-			uuid: "00000000-0000-0000-0000-000000000003" as const,
-		};
-	}
-
-	return { phaseSpyAgent, calls };
-}
-
 describe("Orchestrator multi-phase workflows", () => {
 	it("runs phases sequentially with freshly rendered and shell-expanded prompts", async () => {
 		server.use(
@@ -67,11 +51,11 @@ describe("Orchestrator multi-phase workflows", () => {
 			}),
 		);
 
-		const { phaseSpyAgent, calls } = createPhaseSpyAgent();
+		const { spyAgent, getCapturedCalls } = createPromptSpyAgent();
 
 		await using ctx = await createTestOrchestrator({
 			workflows: new Map([[REPO, phasedWorkflow()]]),
-			runAgent: phaseSpyAgent,
+			runAgent: spyAgent,
 		});
 		const { orchestrator, db, runner, workspace } = ctx;
 		await workspace.preCreateWorkspace(`${REPO}#1`);
@@ -80,33 +64,42 @@ describe("Orchestrator multi-phase workflows", () => {
 		await runner.queue.waitForIdle();
 		await orchestrator.settled();
 
+		const calls = getCapturedCalls();
 		expect(calls.map((call) => call.prompt)).toEqual([
 			"Plan 1 one",
 			"Implement Issue 1 two",
 		]);
 		expect(calls[0]?.options).not.toHaveProperty("resume");
-		expect(calls[1]?.options).toMatchObject({ resume: "sess-1" });
+		expect(calls[1]?.options).toMatchObject({ resume: "spy-session" });
 
 		const [run] = db.select().from(runs).all();
 		expect(run).toMatchObject({
 			status: "completed",
-			sessionId: "sess-2",
+			sessionId: "spy-session",
 			phaseIndex: 1,
 		});
 
 		const events = getEvents(db, run?.id ?? "");
-		expect(events.map((event) => event.type)).toEqual([
-			"run:started",
+		expect(
+			events
+				.filter((event) => event.type.startsWith("phase."))
+				.map((event) => event.type),
+		).toEqual([
 			"phase.started",
 			"phase.completed",
 			"phase.started",
 			"phase.completed",
-			"run:completed",
 		]);
 		expect(events).toContainEqual(
 			expect.objectContaining({
 				type: "phase.started",
 				data: { name: "plan", index: 0, total: 2 },
+			}),
+		);
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "phase.started",
+				data: { name: "implement", index: 1, total: 2 },
 			}),
 		);
 	});
@@ -197,11 +190,11 @@ describe("Orchestrator multi-phase workflows", () => {
 			}),
 		);
 
-		const { phaseSpyAgent, calls } = createPhaseSpyAgent();
+		const { spyAgent, getCapturedCalls } = createPromptSpyAgent();
 
 		await using ctx = await createTestOrchestrator({
 			workflows: new Map([[REPO, phasedWorkflow()]]),
-			runAgent: phaseSpyAgent,
+			runAgent: spyAgent,
 		});
 		const { orchestrator, db, runner, workspace } = ctx;
 		await workspace.preCreateWorkspace(`${REPO}#1`);
@@ -218,6 +211,7 @@ describe("Orchestrator multi-phase workflows", () => {
 		await runner.queue.waitForIdle();
 		await orchestrator.settled();
 
+		const calls = getCapturedCalls();
 		expect(calls.map((call) => call.prompt)).toEqual(["Implement Issue 1 two"]);
 		expect(calls[0]?.options).toMatchObject({ resume: "sess-failed-phase" });
 
@@ -241,11 +235,11 @@ describe("Orchestrator multi-phase workflows", () => {
 			}),
 		);
 
-		const { phaseSpyAgent, calls } = createPhaseSpyAgent();
+		const { spyAgent, getCapturedCalls } = createPromptSpyAgent();
 
 		await using ctx = await createTestOrchestrator({
 			workflows: new Map([[REPO, phasedWorkflow()]]),
-			runAgent: phaseSpyAgent,
+			runAgent: spyAgent,
 		});
 		const { orchestrator, db, runner, workspace } = ctx;
 		await workspace.preCreateWorkspace(`${REPO}#1`);
@@ -262,6 +256,7 @@ describe("Orchestrator multi-phase workflows", () => {
 		await runner.queue.waitForIdle();
 		await orchestrator.settled();
 
+		const calls = getCapturedCalls();
 		expect(calls.map((call) => call.prompt)).toEqual(["Implement Issue 1 two"]);
 		expect(calls[0]?.options).not.toHaveProperty("resume");
 	});

--- a/server/orchestrator/__tests__/orchestrator.reconcile.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.reconcile.integration.test.ts
@@ -52,6 +52,7 @@ describe("Orchestrator reconciliation", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 
@@ -78,6 +79,7 @@ describe("Orchestrator reconciliation", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});
@@ -126,6 +128,7 @@ describe("Orchestrator reconciliation", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});
@@ -215,6 +218,7 @@ describe("Orchestrator reconciliation", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 
@@ -329,6 +333,7 @@ describe("Orchestrator reconciliation", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 

--- a/server/orchestrator/__tests__/orchestrator.retry.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.retry.integration.test.ts
@@ -52,9 +52,10 @@ describe("Orchestrator retryRun", () => {
 			startedAt: expect.any(String),
 			completedAt: expect.any(String),
 			durationMs: expect.any(Number),
-			sessionId: null,
+			sessionId: "sess-abc",
 			attempt: 2,
 			parentRunId: "failed-1",
+			phaseIndex: 0,
 		});
 	});
 
@@ -135,9 +136,10 @@ describe("Orchestrator retryRun", () => {
 			startedAt: expect.any(String),
 			completedAt: expect.any(String),
 			durationMs: expect.any(Number),
-			sessionId: null,
+			sessionId: "sess-abc",
 			attempt: 2,
 			parentRunId: "no-title",
+			phaseIndex: 0,
 		});
 	});
 
@@ -157,15 +159,29 @@ describe("Orchestrator retryRun", () => {
 		expect(result).toEqual({ error: "Run is not failed" });
 	});
 
-	it("rejects retry when run has no sessionId", async () => {
-		server.use(...githubHandlers());
+	it("retries fresh when run has no sessionId", async () => {
+		server.use(
+			...githubHandlers({
+				issues: [createGitHubIssue(1, ["agent:running"])],
+			}),
+		);
 
-		await using ctx = await createTestOrchestrator();
-		const { orchestrator, db } = ctx;
+		const { spyAgent, getCaptured } = createPromptSpyAgent();
+
+		await using ctx = await createTestOrchestrator({
+			runAgent: spyAgent,
+		});
+		const { orchestrator, db, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace(`${REPO}#1`);
 		seedRun(db, { ...failedRunDefaults, id: "no-sess", sessionId: null });
 
 		const result = await orchestrator.retryRun("no-sess");
-		expect(result).toEqual({ error: "No session to resume" });
+		expect(result).toEqual({ runId: expect.any(String) });
+
+		await runner.queue.waitForIdle();
+		await orchestrator.settled();
+
+		expect(getCaptured().options).not.toHaveProperty("resume");
 	});
 
 	it("rejects retry when max retries exceeded", async () => {

--- a/server/orchestrator/__tests__/orchestrator.shell-expansion.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.shell-expansion.integration.test.ts
@@ -90,6 +90,7 @@ describe("Orchestrator shell expansion", () => {
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
+				phaseIndex: 0,
 			},
 		]);
 	});

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -8,13 +8,9 @@ import { logger } from "../logger.ts";
 import type { RunRepository } from "../run-repository.ts";
 import { ABORT_ERROR, type Runner, type RunResult } from "../runner/runner.ts";
 import type { Issue, TrackerAdapter } from "../trackers/types.ts";
-import {
-	expandMarkedShellBlocks,
-	markTrustedShellBlocks,
-} from "../workflow/prompt-preprocessor.ts";
 import type { RepoWorkflow } from "../workflow/workflow.ts";
 import { renderPrompt } from "../workflow/workflow.ts";
-import { logAgentMessage } from "./agent-logging.ts";
+import { type RunAgent, runWorkflowPhases } from "./phase-runner.ts";
 import { ensureWorkspace, removeWorkspace } from "./workspace.ts";
 
 const exec = promisify(execFile);
@@ -22,12 +18,6 @@ const exec = promisify(execFile);
 async function runShell(script: string, cwd: string): Promise<void> {
 	await exec("sh", ["-c", script], { cwd });
 }
-
-type RunAgent = (
-	params: Parameters<typeof query>[0],
-) => AsyncIterable<
-	ReturnType<typeof query> extends AsyncGenerator<infer T> ? T : never
->;
 
 type OrchestratorConfig = {
 	runRepo: RunRepository;
@@ -78,7 +68,8 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		workflow: RepoWorkflow;
 		attempt: number;
 		parentRunId?: string;
-		resumeSessionId?: string;
+		startPhaseIndex?: number;
+		failedPhaseResumeSessionId?: string;
 	}): Promise<string> {
 		const { issue, repo, workflow, attempt } = params;
 
@@ -97,14 +88,6 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 			});
 			await runShell(script, ws.path);
 		}
-
-		const renderedPrompt = renderPrompt(
-			markTrustedShellBlocks(workflow.prompt),
-			{
-				issue,
-				attempt,
-			},
-		);
 
 		const { runId, done } = runner.enqueue({
 			name: `issue-${issue.number}`,
@@ -134,35 +117,22 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 
 							await Promise.race([
 								(async () => {
-									const options = {
+									await runWorkflowPhases({
+										ctx,
+										runAgent,
+										workflow,
+										issue,
+										attempt,
 										cwd: ws.path,
 										model: defaults.model,
-										allowedTools: [
-											"Read",
-											"Write",
-											"Edit",
-											"Bash",
-											"Glob",
-											"Grep",
-										],
-										permissionMode: "dontAsk" as const,
-										...(params.resumeSessionId && {
-											resume: params.resumeSessionId,
+										...(params.startPhaseIndex != null && {
+											startPhaseIndex: params.startPhaseIndex,
 										}),
-									};
-
-									const prompt = await expandMarkedShellBlocks(renderedPrompt, {
-										cwd: ws.path,
+										...(params.failedPhaseResumeSessionId && {
+											failedPhaseResumeSessionId:
+												params.failedPhaseResumeSessionId,
+										}),
 									});
-
-									for await (const msg of runAgent({
-										prompt,
-										options,
-									})) {
-										if (msg.type !== "assistant") continue;
-										logAgentMessage(msg, ws.path, ctx.emitToolUse);
-										ctx.setSessionId(msg.session_id);
-									}
 
 									if (workflow.hooks?.after_run) {
 										const script = renderPrompt(workflow.hooks.after_run, {
@@ -413,7 +383,6 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		const failedRun = runRepo.getRunById(failedRunId);
 		if (!failedRun) return { error: "Run not found" };
 		if (failedRun.status !== "failed") return { error: "Run is not failed" };
-		if (!failedRun.sessionId) return { error: "No session to resume" };
 		if (!failedRun.issueKey) return { error: "No issue key" };
 
 		const attempt = failedRun.attempt + 1;
@@ -439,7 +408,10 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 			workflow,
 			attempt,
 			parentRunId: failedRunId,
-			resumeSessionId: failedRun.sessionId,
+			startPhaseIndex: failedRun.phaseIndex,
+			...(failedRun.sessionId && {
+				failedPhaseResumeSessionId: failedRun.sessionId,
+			}),
 		});
 
 		logger.info(

--- a/server/orchestrator/phase-runner.ts
+++ b/server/orchestrator/phase-runner.ts
@@ -1,5 +1,6 @@
 import type { query } from "@anthropic-ai/claude-agent-sdk";
 import * as canonicalLog from "../canonical-log.ts";
+import type { PhaseEvent } from "../event-bus.ts";
 import type { RunContext } from "../runner/runner.ts";
 import type { Issue } from "../trackers/types.ts";
 import {
@@ -45,12 +46,12 @@ export async function runWorkflowPhases({
 	for (const [index, phase] of phases.entries()) {
 		if (index < startPhaseIndex) continue;
 
-		const phaseResumeSessionId =
-			index === startPhaseIndex && failedPhaseResumeSessionId
-				? failedPhaseResumeSessionId
-				: phase.resume_previous
-					? previousSessionId
-					: undefined;
+		let phaseResumeSessionId: string | undefined;
+		if (index === startPhaseIndex && failedPhaseResumeSessionId) {
+			phaseResumeSessionId = failedPhaseResumeSessionId;
+		} else if (phase.resume_previous) {
+			phaseResumeSessionId = previousSessionId;
+		}
 
 		const completedSessionId = await runWorkflowPhase({
 			ctx,
@@ -95,15 +96,14 @@ async function runWorkflowPhase({
 	resumeSessionId,
 }: RunWorkflowPhaseParams): Promise<string | undefined> {
 	const startedAt = Date.now();
+	let currentSessionId = resumeSessionId;
 	ctx.setPhaseIndex(phaseIndex);
-	ctx.setSessionId(resumeSessionId ?? null);
 	emitPhaseMarker(ctx, {
 		type: "phase.started",
 		data: { name: phase.name, index: phaseIndex, total: totalPhases },
 	});
 
 	try {
-		let currentSessionId = resumeSessionId;
 		const renderedPrompt = renderPrompt(markTrustedShellBlocks(phase.prompt), {
 			issue,
 			attempt,
@@ -123,9 +123,9 @@ async function runWorkflowPhase({
 			if (msg.type !== "assistant") continue;
 			logAgentMessage(msg, cwd, ctx.emitToolUse);
 			currentSessionId = msg.session_id;
-			ctx.setSessionId(msg.session_id);
 		}
 
+		ctx.setSessionId(currentSessionId ?? null);
 		emitPhaseMarker(ctx, {
 			type: "phase.completed",
 			data: {
@@ -136,6 +136,7 @@ async function runWorkflowPhase({
 		});
 		return currentSessionId;
 	} catch (err) {
+		ctx.setSessionId(currentSessionId ?? null);
 		emitPhaseMarker(ctx, {
 			type: "phase.failed",
 			data: {
@@ -148,10 +149,7 @@ async function runWorkflowPhase({
 	}
 }
 
-function emitPhaseMarker(
-	ctx: RunContext,
-	event: Parameters<RunContext["emitPhaseEvent"]>[0],
-): void {
+function emitPhaseMarker(ctx: RunContext, event: PhaseEvent): void {
 	ctx.emitPhaseEvent(event);
 	canonicalLog.append("phase_events", event);
 }

--- a/server/orchestrator/phase-runner.ts
+++ b/server/orchestrator/phase-runner.ts
@@ -1,0 +1,157 @@
+import type { query } from "@anthropic-ai/claude-agent-sdk";
+import * as canonicalLog from "../canonical-log.ts";
+import type { RunContext } from "../runner/runner.ts";
+import type { Issue } from "../trackers/types.ts";
+import {
+	expandMarkedShellBlocks,
+	markTrustedShellBlocks,
+} from "../workflow/prompt-preprocessor.ts";
+import type { RepoWorkflow, WorkflowPhase } from "../workflow/workflow.ts";
+import { getWorkflowPhases, renderPrompt } from "../workflow/workflow.ts";
+import { logAgentMessage } from "./agent-logging.ts";
+
+export type RunAgent = (
+	params: Parameters<typeof query>[0],
+) => AsyncIterable<
+	ReturnType<typeof query> extends AsyncGenerator<infer T> ? T : never
+>;
+
+type RunWorkflowPhasesParams = {
+	ctx: RunContext;
+	runAgent: RunAgent;
+	workflow: RepoWorkflow;
+	issue: Issue;
+	attempt: number;
+	cwd: string;
+	model: string;
+	startPhaseIndex?: number;
+	failedPhaseResumeSessionId?: string;
+};
+
+export async function runWorkflowPhases({
+	ctx,
+	runAgent,
+	workflow,
+	issue,
+	attempt,
+	cwd,
+	model,
+	startPhaseIndex = 0,
+	failedPhaseResumeSessionId,
+}: RunWorkflowPhasesParams): Promise<void> {
+	const phases = getWorkflowPhases(workflow);
+	let previousSessionId: string | undefined;
+
+	for (const [index, phase] of phases.entries()) {
+		if (index < startPhaseIndex) continue;
+
+		const phaseResumeSessionId =
+			index === startPhaseIndex && failedPhaseResumeSessionId
+				? failedPhaseResumeSessionId
+				: phase.resume_previous
+					? previousSessionId
+					: undefined;
+
+		const completedSessionId = await runWorkflowPhase({
+			ctx,
+			runAgent,
+			phase,
+			phaseIndex: index,
+			totalPhases: phases.length,
+			issue,
+			attempt,
+			cwd,
+			model,
+			...(phaseResumeSessionId && { resumeSessionId: phaseResumeSessionId }),
+		});
+
+		previousSessionId = completedSessionId;
+	}
+}
+
+type RunWorkflowPhaseParams = {
+	ctx: RunContext;
+	runAgent: RunAgent;
+	phase: WorkflowPhase;
+	phaseIndex: number;
+	totalPhases: number;
+	issue: Issue;
+	attempt: number;
+	cwd: string;
+	model: string;
+	resumeSessionId?: string;
+};
+
+async function runWorkflowPhase({
+	ctx,
+	runAgent,
+	phase,
+	phaseIndex,
+	totalPhases,
+	issue,
+	attempt,
+	cwd,
+	model,
+	resumeSessionId,
+}: RunWorkflowPhaseParams): Promise<string | undefined> {
+	const startedAt = Date.now();
+	ctx.setPhaseIndex(phaseIndex);
+	ctx.setSessionId(resumeSessionId ?? null);
+	emitPhaseMarker(ctx, {
+		type: "phase.started",
+		data: { name: phase.name, index: phaseIndex, total: totalPhases },
+	});
+
+	try {
+		let currentSessionId = resumeSessionId;
+		const renderedPrompt = renderPrompt(markTrustedShellBlocks(phase.prompt), {
+			issue,
+			attempt,
+		});
+		const prompt = await expandMarkedShellBlocks(renderedPrompt, { cwd });
+
+		for await (const msg of runAgent({
+			prompt,
+			options: {
+				cwd,
+				model,
+				allowedTools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
+				permissionMode: "dontAsk" as const,
+				...(resumeSessionId && { resume: resumeSessionId }),
+			},
+		})) {
+			if (msg.type !== "assistant") continue;
+			logAgentMessage(msg, cwd, ctx.emitToolUse);
+			currentSessionId = msg.session_id;
+			ctx.setSessionId(msg.session_id);
+		}
+
+		emitPhaseMarker(ctx, {
+			type: "phase.completed",
+			data: {
+				name: phase.name,
+				index: phaseIndex,
+				durationMs: Date.now() - startedAt,
+			},
+		});
+		return currentSessionId;
+	} catch (err) {
+		emitPhaseMarker(ctx, {
+			type: "phase.failed",
+			data: {
+				name: phase.name,
+				index: phaseIndex,
+				error: canonicalLog.errorMessage(err),
+			},
+		});
+		throw err;
+	}
+}
+
+function emitPhaseMarker(
+	ctx: RunContext,
+	event: Parameters<RunContext["emitPhaseEvent"]>[0],
+): void {
+	ctx.emitPhaseEvent(event);
+	canonicalLog.append("phase_events", event);
+}

--- a/server/run-repository.ts
+++ b/server/run-repository.ts
@@ -23,7 +23,8 @@ export type RunRepository = {
 		attempt: number;
 		parentRunId: string | null;
 	}): void;
-	setSessionId(runId: string, sessionId: string): void;
+	setSessionId(runId: string, sessionId: string | null): void;
+	setPhaseIndex(runId: string, phaseIndex: number): void;
 	completeRun(
 		runId: string,
 		params: { completedAt: string; durationMs: number },
@@ -58,6 +59,10 @@ export function createRunRepository(db: Db): RunRepository {
 
 		setSessionId(runId, sessionId) {
 			db.update(runs).set({ sessionId }).where(eq(runs.id, runId)).run();
+		},
+
+		setPhaseIndex(runId, phaseIndex) {
+			db.update(runs).set({ phaseIndex }).where(eq(runs.id, runId)).run();
 		},
 
 		completeRun(runId, params) {

--- a/server/runner/__tests__/runner.integration.test.ts
+++ b/server/runner/__tests__/runner.integration.test.ts
@@ -62,6 +62,7 @@ describe("Runner integration", () => {
 			sessionId: null,
 			attempt: 1,
 			parentRunId: null,
+			phaseIndex: 0,
 		});
 
 		resolveHandler({ status: "completed", durationMs: 0 });
@@ -108,6 +109,7 @@ describe("Runner integration", () => {
 			sessionId: null,
 			attempt: 1,
 			parentRunId: null,
+			phaseIndex: 0,
 		});
 
 		resolveBlocker({ status: "completed", durationMs: 0 });
@@ -144,6 +146,7 @@ describe("Runner integration", () => {
 			sessionId: null,
 			attempt: 1,
 			parentRunId: null,
+			phaseIndex: 0,
 		});
 	});
 
@@ -311,6 +314,7 @@ describe("Runner integration", () => {
 			sessionId: null,
 			attempt: 1,
 			parentRunId: null,
+			phaseIndex: 0,
 		});
 	});
 
@@ -348,10 +352,11 @@ describe("Runner integration", () => {
 			sessionId: null,
 			attempt: 2,
 			parentRunId: "prev-id",
+			phaseIndex: 0,
 		});
 	});
 
-	it("only persists the first sessionId when handler calls setSessionId multiple times", async () => {
+	it("persists the latest sessionId when handler calls setSessionId multiple times", async () => {
 		const runner = createRunner({ repo, maxConcurrency: 1 });
 
 		const { runId } = runner.enqueue({
@@ -379,9 +384,32 @@ describe("Runner integration", () => {
 			startedAt: expect.any(String),
 			completedAt: expect.any(String),
 			durationMs: expect.any(Number),
-			sessionId: "first-session",
+			sessionId: "third-session",
 			attempt: 1,
 			parentRunId: null,
+			phaseIndex: 0,
+		});
+	});
+
+	it("persists phase index progress from the run context", async () => {
+		const runner = createRunner({ repo, maxConcurrency: 1 });
+
+		const { runId } = runner.enqueue({
+			name: "phase-job",
+			issueKey: "owner/repo#9",
+			issueTitle: "Phase issue",
+			handler: async (ctx) => {
+				ctx.setPhaseIndex(2);
+				return { status: "completed", durationMs: 0 };
+			},
+		});
+
+		await runner.queue.waitForIdle();
+
+		const run = getRun(db, runId);
+		expect(run).toMatchObject({
+			id: runId,
+			phaseIndex: 2,
 		});
 	});
 
@@ -435,6 +463,7 @@ describe("Runner integration", () => {
 			sessionId: "sess-123",
 			attempt: 1,
 			parentRunId: null,
+			phaseIndex: 0,
 		});
 	});
 });

--- a/server/runner/runner.ts
+++ b/server/runner/runner.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { eventBus, type RunEvent } from "../event-bus.ts";
+import { eventBus, type PhaseEvent, type RunEvent } from "../event-bus.ts";
 import type { RunRepository } from "../run-repository.ts";
 import { createJobQueue, type JobQueue } from "./queue.ts";
 
@@ -8,21 +8,7 @@ export const ABORT_ERROR = "Run killed by user";
 export type RunContext = {
 	runId: string;
 	emitToolUse: (tool: string, target: string) => void;
-	emitPhaseEvent: (
-		event:
-			| {
-					type: "phase.started";
-					data: { name: string; index: number; total: number };
-			  }
-			| {
-					type: "phase.completed";
-					data: { name: string; index: number; durationMs: number };
-			  }
-			| {
-					type: "phase.failed";
-					data: { name: string; index: number; error: string };
-			  },
-	) => void;
+	emitPhaseEvent: (event: PhaseEvent) => void;
 	setSessionId: (id: string | null) => void;
 	setPhaseIndex: (index: number) => void;
 	signal: AbortSignal;

--- a/server/runner/runner.ts
+++ b/server/runner/runner.ts
@@ -8,7 +8,23 @@ export const ABORT_ERROR = "Run killed by user";
 export type RunContext = {
 	runId: string;
 	emitToolUse: (tool: string, target: string) => void;
-	setSessionId: (id: string) => void;
+	emitPhaseEvent: (
+		event:
+			| {
+					type: "phase.started";
+					data: { name: string; index: number; total: number };
+			  }
+			| {
+					type: "phase.completed";
+					data: { name: string; index: number; durationMs: number };
+			  }
+			| {
+					type: "phase.failed";
+					data: { name: string; index: number; error: string };
+			  },
+	) => void;
+	setSessionId: (id: string | null) => void;
+	setPhaseIndex: (index: number) => void;
 	signal: AbortSignal;
 };
 
@@ -115,11 +131,12 @@ export function createRunner(config: RunnerConfig): Runner {
 		queue.enqueue(async () => {
 			const executionStart = Date.now();
 
-			let sessionCaptured = false;
-			const setSessionId = (id: string) => {
-				if (sessionCaptured) return;
-				sessionCaptured = true;
+			const setSessionId = (id: string | null) => {
 				repo.setSessionId(runId, id);
+			};
+
+			const setPhaseIndex = (index: number) => {
+				repo.setPhaseIndex(runId, index);
 			};
 
 			const emitToolUse = (tool: string, target: string) => {
@@ -127,6 +144,10 @@ export function createRunner(config: RunnerConfig): Runner {
 					type: "run:tool_use",
 					data: { tool, target },
 				});
+			};
+
+			const emitPhaseEvent: RunContext["emitPhaseEvent"] = (event) => {
+				emitEvent(runId, job.name, event);
 			};
 
 			const abortPromise = new Promise<RunResult>((resolve) => {
@@ -143,7 +164,9 @@ export function createRunner(config: RunnerConfig): Runner {
 				job.handler({
 					runId,
 					emitToolUse,
+					emitPhaseEvent,
 					setSessionId,
+					setPhaseIndex,
 					signal: controller.signal,
 				}),
 				abortPromise,

--- a/server/testing/support/fixtures.ts
+++ b/server/testing/support/fixtures.ts
@@ -52,8 +52,10 @@ type QueryParams = Parameters<typeof query>[0];
 
 export function createPromptSpyAgent() {
 	let captured: QueryParams | undefined;
+	const capturedCalls: QueryParams[] = [];
 	async function* spyAgent(params: QueryParams) {
 		captured = params;
+		capturedCalls.push(params);
 		yield {
 			type: "assistant" as const,
 			session_id: "spy-session",
@@ -68,7 +70,7 @@ export function createPromptSpyAgent() {
 		return captured;
 	}
 
-	return { spyAgent, getCaptured };
+	return { spyAgent, getCaptured, getCapturedCalls: () => capturedCalls };
 }
 
 export function createTestWorkflow(

--- a/server/workflow/__tests__/prompt-preprocessor.test.ts
+++ b/server/workflow/__tests__/prompt-preprocessor.test.ts
@@ -135,11 +135,33 @@ describe("shell block preprocessing", () => {
 		).rejects.toThrow(/failed to spawn/);
 	});
 
+	it("fails when the shell is terminated by signal", async () => {
+		await using workspace = await createTestWorkspaceRoot();
+
+		const marked = markTrustedShellBlocks("!`kill -TERM $$`");
+
+		await expect(
+			expandMarkedShellBlocks(marked, { cwd: workspace.root }),
+		).rejects.toThrow(/terminated by signal SIGTERM/);
+	});
+
 	it("fails when shell output exceeds the buffer cap", async () => {
 		await using workspace = await createTestWorkspaceRoot();
 
 		const marked = markTrustedShellBlocks(
 			"!`yes x | head -c 2000000; printf done`",
+		);
+
+		await expect(
+			expandMarkedShellBlocks(marked, { cwd: workspace.root }),
+		).rejects.toThrow(/exceeded max output/);
+	});
+
+	it("fails when shell stderr exceeds the buffer cap", async () => {
+		await using workspace = await createTestWorkspaceRoot();
+
+		const marked = markTrustedShellBlocks(
+			"!`dd if=/dev/zero bs=1048577 count=1 1>&2 2>/dev/null`",
 		);
 
 		await expect(

--- a/server/workflow/__tests__/workflow.test.ts
+++ b/server/workflow/__tests__/workflow.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { Issue } from "../../trackers/types.ts";
-import { parseRepoWorkflow, renderPrompt } from "../workflow.ts";
+import {
+	getWorkflowPhases,
+	parseRepoWorkflow,
+	renderPrompt,
+} from "../workflow.ts";
 
 const baseIssue: Issue = {
 	key: "owner/repo#1",
@@ -48,7 +52,7 @@ describe("renderPrompt", () => {
 });
 
 describe("parseRepoWorkflow", () => {
-	it("applies defaults when branch and base_branch are omitted", () => {
+	it("accepts a single-prompt workflow and applies defaults", () => {
 		const yaml = "prompt: Fix this issue\n";
 
 		const result = parseRepoWorkflow(yaml);
@@ -56,12 +60,59 @@ describe("parseRepoWorkflow", () => {
 		expect(result.branch).toBe("agent/issue-{{ issue.number }}");
 		expect(result.base_branch).toBe("main");
 		expect(result.prompt).toBe("Fix this issue");
+		expect(getWorkflowPhases(result)).toEqual([
+			{ name: "prompt", prompt: "Fix this issue", resume_previous: false },
+		]);
+	});
+
+	it("accepts a phased workflow", () => {
+		const yaml = `
+phases:
+  - name: plan
+    prompt: Write a plan
+  - name: implement
+    prompt: Implement the plan
+    resume_previous: true
+`;
+
+		const result = parseRepoWorkflow(yaml);
+
+		expect(result.prompt).toBeUndefined();
+		expect(getWorkflowPhases(result)).toEqual([
+			{ name: "plan", prompt: "Write a plan", resume_previous: false },
+			{
+				name: "implement",
+				prompt: "Implement the plan",
+				resume_previous: true,
+			},
+		]);
 	});
 
 	it("rejects missing prompt", () => {
 		const yaml = "branch: my-branch\n";
 
 		expect(() => parseRepoWorkflow(yaml)).toThrow();
+	});
+
+	it("rejects workflows with both prompt and phases", () => {
+		const yaml = `
+prompt: Fix this issue
+phases:
+  - name: plan
+    prompt: Write a plan
+`;
+
+		expect(() => parseRepoWorkflow(yaml)).toThrow(
+			/Workflow must define exactly one of prompt or phases/,
+		);
+	});
+
+	it("rejects workflows with neither prompt nor phases", () => {
+		const yaml = "branch: my-branch\n";
+
+		expect(() => parseRepoWorkflow(yaml)).toThrow(
+			/Workflow must define exactly one of prompt or phases/,
+		);
 	});
 
 	it("throws on invalid YAML", () => {

--- a/server/workflow/workflow.ts
+++ b/server/workflow/workflow.ts
@@ -3,20 +3,52 @@ import { z } from "zod";
 import type { Issue } from "../trackers/types.ts";
 import { stripShellBlockMarkers } from "./prompt-preprocessor.ts";
 
-const repoWorkflowSchema = z.object({
-	branch: z.string().default("agent/issue-{{ issue.number }}"),
-	base_branch: z.string().default("main"),
-	hooks: z
-		.object({
-			after_create: z.string().optional(),
-			before_run: z.string().optional(),
-			after_run: z.string().optional(),
-		})
-		.optional(),
+const workflowPhaseSchema = z.object({
+	name: z.string().min(1),
 	prompt: z.string(),
+	resume_previous: z.boolean().optional().default(false),
 });
 
+const repoWorkflowSchema = z
+	.object({
+		branch: z.string().default("agent/issue-{{ issue.number }}"),
+		base_branch: z.string().default("main"),
+		hooks: z
+			.object({
+				after_create: z.string().optional(),
+				before_run: z.string().optional(),
+				after_run: z.string().optional(),
+			})
+			.optional(),
+		prompt: z.string().optional(),
+		phases: z.array(workflowPhaseSchema).min(1).optional(),
+	})
+	.superRefine((workflow, ctx) => {
+		const hasPrompt = workflow.prompt != null;
+		const hasPhases = workflow.phases != null;
+		if (hasPrompt === hasPhases) {
+			ctx.addIssue({
+				code: "custom",
+				message: "Workflow must define exactly one of prompt or phases",
+				path: hasPrompt ? ["phases"] : ["prompt"],
+			});
+		}
+	});
+
+export type WorkflowPhase = z.infer<typeof workflowPhaseSchema>;
+
 export type RepoWorkflow = z.infer<typeof repoWorkflowSchema>;
+
+export function getWorkflowPhases(workflow: RepoWorkflow): WorkflowPhase[] {
+	if (workflow.phases) return workflow.phases;
+	return [
+		{
+			name: "prompt",
+			prompt: workflow.prompt as string,
+			resume_previous: false,
+		},
+	];
+}
 
 export function parseRepoWorkflow(yamlContent: string): RepoWorkflow {
 	const parsed = parse(yamlContent);


### PR DESCRIPTION
## Summary
- extend workflow parsing to support mutually exclusive single prompt or phased workflows
- add phase runner for sequential prompt rendering, shell expansion, session resume, and phase markers
- persist run phase progress with runs.phaseIndex and a Drizzle migration
- update retry to resume from the failed phase or run fresh when no failed-phase session exists
- update tests and Slice 5 ledger status

## Verification
- pnpm test:coverage
- pnpm lint
- pnpm typecheck
- pnpm test