### PR TITLE
Add GitLab code host adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,14 @@ LOG_LEVEL=info
 # Classic token — needs scopes: repo, read:user
 #
 # Fine-grained token — needs these repository permissions:
-#   Contents:    Read    (fetch .agents/workflow.yaml, git clone)
+#   Contents:    Read    (fetch repository files and clone)
 #   Issues:      Read/Write (poll issues, swap labels)
 #   Pull requests: Read/Write (create PRs, check for existing PRs)
 #   Metadata:    Read    (granted automatically)
 # Also needs account permission: Read (to resolve authenticated username)
 GITHUB_TOKEN=
+
+# GitLab Personal/Project/Group Access Token (required when code_host.kind=gitlab)
+#
+# Needs API access to read repository files and create merge requests.
+GITLAB_TOKEN=

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ defaults:
   workspace_root: /tmp/local-agent-workspaces
 ```
 
+For GitLab-hosted code, use `kind: gitlab`; `base_url` is optional and defaults
+to `https://gitlab.com`:
+
+```yaml
+code_host:
+  kind: gitlab
+  base_url: https://gitlab.example.com
+  repos:
+    - your-group/your-project
+```
+
 Create `workflow.yaml` in the local-agents working directory to define hooks and
 the prompt used for every configured repo:
 

--- a/config.yaml
+++ b/config.yaml
@@ -3,9 +3,8 @@ tracker:
 
 code_host:
   kind: github
-
-repos:
-  - nhollas/target-dummy
+  repos:
+    - nhollas/target-dummy
 
 defaults:
   polling_interval_ms: 30000

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,6 +46,17 @@ defaults:
   workspace_root: /tmp/local-agent-workspaces
 ```
 
+GitLab code hosting uses the same `code_host.repos` list. `base_url` is optional
+and defaults to `https://gitlab.com`:
+
+```yaml
+code_host:
+  kind: gitlab
+  base_url: https://gitlab.example.com
+  repos:
+    - group/project
+```
+
 ### 2. Global workflow
 
 The local-agents working directory contains one `workflow.yaml` with hooks and
@@ -112,9 +123,9 @@ The orchestrator detects when issues are closed or resolved and kills the corres
 The system uses two adapter interfaces to stay decoupled from any specific platform:
 
 - **TrackerAdapter** — fetches active issues from a tracker and manages label state
-- **CodeHostAdapter** — fetches files from repos, generates clone URLs, and creates pull requests
+- **CodeHostAdapter** — fetches files from repos, generates clone URLs, and creates pull requests or merge requests
 
-Both are currently implemented for GitHub (via the `gh` CLI and API). Adding support for another platform means implementing these two interfaces.
+GitHub is implemented as both a tracker and code host. GitLab is implemented as a code host. Adding full support for another platform means implementing the relevant adapter interface.
 
 ## Design Principles
 

--- a/docs/shell-expansion-and-integrations-implementation-plan.md
+++ b/docs/shell-expansion-and-integrations-implementation-plan.md
@@ -460,7 +460,26 @@ Use this handoff template when a slice is interrupted:
 
 ## Slice 6 — GitLab Code Host Adapter
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Started:** 2026-04-30 on branch `plan/slice-06-gitlab`.
+
+**Completed changes:**
+
+- Added a GitLab API client using `PRIVATE-TOKEN` authentication and encoded project/file paths.
+- Added `server/code-hosts/gitlab.ts` with clone URL generation, file fetching, and idempotent merge request creation.
+- Extended config parsing for `code_host.kind: gitlab` with optional `base_url` defaulting to `https://gitlab.com`.
+- Added startup env validation for `GITLAB_TOKEN` when GitLab is configured while preserving GitHub token validation.
+- Wired server startup to choose the GitHub or GitLab code-host adapter from config.
+- Updated config examples and docs for GitLab code hosting and corrected the checked-in `config.yaml` repo shape.
+- Added focused config, env, and GitLab adapter HTTP-level tests.
+
+**Verification:**
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:coverage`
 
 **Purpose:** Add GitLab as a code host while preserving the `CodeHostAdapter` contract.
 

--- a/server/__tests__/config.test.ts
+++ b/server/__tests__/config.test.ts
@@ -40,6 +40,45 @@ defaults:
 		expect(config.defaults.workspace_root).toBe("/tmp/workspaces");
 	});
 
+	it("accepts gitlab code host with default base URL", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: github
+code_host:
+  kind: gitlab
+  repos:
+    - group/project
+`);
+
+		const config = loadConfig(configFile.path);
+
+		expect(config.code_host).toEqual({
+			kind: "gitlab",
+			repos: ["group/project"],
+			base_url: "https://gitlab.com",
+		});
+	});
+
+	it("accepts gitlab code host with configured base URL", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: github
+code_host:
+  kind: gitlab
+  base_url: https://gitlab.example.test
+  repos:
+    - platform/team/project
+`);
+
+		const config = loadConfig(configFile.path);
+
+		expect(config.code_host).toEqual({
+			kind: "gitlab",
+			repos: ["platform/team/project"],
+			base_url: "https://gitlab.example.test",
+		});
+	});
+
 	it("rejects config without code_host repos", () => {
 		using configFile = writeConfig(`
 tracker:

--- a/server/__tests__/env.test.ts
+++ b/server/__tests__/env.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "../config.ts";
+import { loadEnv } from "../env.ts";
+
+const originalEnv = process.env;
+
+function gitlabConfig(): Pick<Config, "tracker" | "code_host"> {
+	return {
+		tracker: { kind: "github" },
+		code_host: {
+			kind: "gitlab",
+			repos: ["group/project"],
+			base_url: "https://gitlab.com",
+		},
+	};
+}
+
+describe("loadEnv", () => {
+	afterEach(() => {
+		process.env = originalEnv;
+		vi.restoreAllMocks();
+	});
+
+	it("requires GITLAB_TOKEN when GitLab code host is configured", () => {
+		process.env = { ...originalEnv, GITHUB_TOKEN: "github-token" };
+		delete process.env["GITLAB_TOKEN"];
+		const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new Error("exit");
+		}) as typeof process.exit);
+		vi.spyOn(console, "error").mockImplementation(() => {});
+
+		expect(() => loadEnv(gitlabConfig())).toThrow("exit");
+		expect(exit).toHaveBeenCalledWith(1);
+	});
+
+	it("returns GITLAB_TOKEN when GitLab code host is configured", () => {
+		process.env = {
+			...originalEnv,
+			GITHUB_TOKEN: "github-token",
+			GITLAB_TOKEN: "gitlab-token",
+		};
+
+		const env = loadEnv(gitlabConfig());
+
+		expect(env.GITLAB_TOKEN).toBe("gitlab-token");
+	});
+});

--- a/server/__tests__/gitlab-client.integration.test.ts
+++ b/server/__tests__/gitlab-client.integration.test.ts
@@ -1,0 +1,54 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+import { createGitLabClient } from "../gitlab-client.ts";
+import { GITLAB_API, GITLAB_BASE_URL } from "../testing/support/fixtures.ts";
+import { server } from "../testing/support/msw.ts";
+
+const REPO = "group/project";
+
+describe("GitLab client retry", () => {
+	it("retries on 500 and succeeds on the next attempt", async () => {
+		let attempts = 0;
+		server.use(
+			http.get(`${GITLAB_API}/projects/:project/merge_requests`, () => {
+				attempts++;
+				if (attempts === 1) {
+					return new HttpResponse(null, { status: 500 });
+				}
+				return HttpResponse.json([]);
+			}),
+		);
+
+		const client = createGitLabClient("test-token", {
+			baseUrl: GITLAB_BASE_URL,
+			baseDelayMs: 1,
+		});
+		const mergeRequests = await client.listMergeRequests(REPO, {
+			source_branch: "agent/issue-1",
+			target_branch: "main",
+			state: "opened",
+		});
+
+		expect(mergeRequests).toEqual([]);
+		expect(attempts).toBe(2);
+	});
+
+	it("throws after exhausting all retry attempts", async () => {
+		server.use(
+			http.get(
+				`${GITLAB_API}/projects/:project/repository/files/:file`,
+				() => new HttpResponse(null, { status: 500 }),
+			),
+		);
+
+		const client = createGitLabClient("test-token", {
+			baseUrl: GITLAB_BASE_URL,
+			maxAttempts: 2,
+			baseDelayMs: 1,
+		});
+
+		await expect(client.getFileContent(REPO, "README.md")).rejects.toThrow(
+			"GitLab API GET /projects/group%2Fproject/repository/files/README.md?ref=HEAD failed (500)",
+		);
+	});
+});

--- a/server/code-hosts/__tests__/gitlab.integration.test.ts
+++ b/server/code-hosts/__tests__/gitlab.integration.test.ts
@@ -1,0 +1,175 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+import { createGitLabClient } from "../../gitlab-client.ts";
+import { GITLAB_API, GITLAB_BASE_URL } from "../../testing/support/fixtures.ts";
+import { server } from "../../testing/support/msw.ts";
+import { gitlabCodeHostAdapter } from "../gitlab.ts";
+
+const REPO = "group/subgroup/project";
+const adapter = gitlabCodeHostAdapter(
+	createGitLabClient("test-token", { baseUrl: GITLAB_BASE_URL }),
+	GITLAB_BASE_URL,
+);
+
+describe("cloneUrl", () => {
+	it("uses the configured base URL", () => {
+		expect(adapter.cloneUrl(REPO)).toBe(
+			"https://gitlab.example.test/group/subgroup/project.git",
+		);
+	});
+
+	it("defaults to gitlab.com when no base URL is configured", async () => {
+		const defaultAdapter = gitlabCodeHostAdapter(
+			createGitLabClient("test-token"),
+		);
+		let capturedPathname = "";
+
+		server.use(
+			http.get(
+				"https://gitlab.com/api/v4/projects/:project/repository/files/:file",
+				({ request }) => {
+					capturedPathname = new URL(request.url).pathname;
+					return HttpResponse.json({
+						content: Buffer.from("default base").toString("base64"),
+					});
+				},
+			),
+		);
+
+		await expect(defaultAdapter.fetchFile(REPO, "README.md")).resolves.toBe(
+			"default base",
+		);
+		expect(defaultAdapter.cloneUrl(REPO)).toBe(
+			"https://gitlab.com/group/subgroup/project.git",
+		);
+		expect(capturedPathname).toBe(
+			"/api/v4/projects/group%2Fsubgroup%2Fproject/repository/files/README.md",
+		);
+	});
+});
+
+describe("fetchFile", () => {
+	it("fetches file content through the encoded GitLab project and file API path", async () => {
+		let capturedPathname = "";
+		let capturedRef: string | null = null;
+		let capturedToken: string | null = null;
+
+		server.use(
+			http.get(
+				`${GITLAB_API}/projects/:project/repository/files/:file`,
+				({ request }) => {
+					const url = new URL(request.url);
+					capturedPathname = url.pathname;
+					capturedRef = url.searchParams.get("ref");
+					capturedToken = request.headers.get("PRIVATE-TOKEN");
+					return HttpResponse.json({
+						content: Buffer.from("hello from gitlab").toString("base64"),
+					});
+				},
+			),
+		);
+
+		const content = await adapter.fetchFile(
+			REPO,
+			"docs/guide.md",
+			"feature/gitlab",
+		);
+
+		expect(content).toBe("hello from gitlab");
+		expect(capturedPathname).toBe(
+			"/api/v4/projects/group%2Fsubgroup%2Fproject/repository/files/docs%2Fguide.md",
+		);
+		expect(capturedRef).toBe("feature/gitlab");
+		expect(capturedToken).toBe("test-token");
+	});
+
+	it("returns null when the GitLab file does not exist", async () => {
+		server.use(
+			http.get(
+				`${GITLAB_API}/projects/:project/repository/files/:file`,
+				() => new HttpResponse(null, { status: 404 }),
+			),
+		);
+
+		const content = await adapter.fetchFile(REPO, "missing.md");
+		expect(content).toBeNull();
+	});
+});
+
+describe("createChangeRequest", () => {
+	it("creates a new MR when none exists", async () => {
+		let capturedSearchParams: URLSearchParams | undefined;
+		let capturedBody: unknown;
+
+		server.use(
+			http.get(
+				`${GITLAB_API}/projects/:project/merge_requests`,
+				({ request }) => {
+					capturedSearchParams = new URL(request.url).searchParams;
+					return HttpResponse.json([]);
+				},
+			),
+			http.post(
+				`${GITLAB_API}/projects/:project/merge_requests`,
+				async ({ request }) => {
+					capturedBody = await request.json();
+					return HttpResponse.json({
+						iid: 5,
+						web_url: `${GITLAB_BASE_URL}/${REPO}/-/merge_requests/5`,
+					});
+				},
+			),
+		);
+
+		const result = await adapter.createChangeRequest(
+			REPO,
+			"agent/issue-1",
+			"main",
+			"Fix issue 1",
+			"Closes TEST-1",
+		);
+
+		expect(capturedSearchParams?.get("source_branch")).toBe("agent/issue-1");
+		expect(capturedSearchParams?.get("target_branch")).toBe("main");
+		expect(capturedSearchParams?.get("state")).toBe("opened");
+		expect(capturedBody).toEqual({
+			source_branch: "agent/issue-1",
+			target_branch: "main",
+			title: "Fix issue 1",
+			description: "Closes TEST-1",
+		});
+		expect(result).toEqual({
+			number: 5,
+			url: `${GITLAB_BASE_URL}/${REPO}/-/merge_requests/5`,
+		});
+	});
+
+	it("returns an existing MR for the source branch", async () => {
+		server.use(
+			http.get(`${GITLAB_API}/projects/:project/merge_requests`, () =>
+				HttpResponse.json([
+					{
+						iid: 3,
+						web_url: `${GITLAB_BASE_URL}/${REPO}/-/merge_requests/3`,
+					},
+				]),
+			),
+			http.post(`${GITLAB_API}/projects/:project/merge_requests`, () =>
+				HttpResponse.json(null, { status: 400 }),
+			),
+		);
+
+		const result = await adapter.createChangeRequest(
+			REPO,
+			"agent/issue-1",
+			"main",
+			"Fix issue 1",
+			"Closes TEST-1",
+		);
+
+		expect(result).toEqual({
+			number: 3,
+			url: `${GITLAB_BASE_URL}/${REPO}/-/merge_requests/3`,
+		});
+	});
+});

--- a/server/code-hosts/gitlab.ts
+++ b/server/code-hosts/gitlab.ts
@@ -1,0 +1,59 @@
+import type { GitLabClient } from "../gitlab-client.ts";
+import { decorateCodeHost } from "./decorator.ts";
+import type { ChangeRequest, CodeHostAdapter } from "./types.ts";
+
+function trimTrailingSlash(value: string): string {
+	return value.replace(/\/+$/, "");
+}
+
+export function gitlabCodeHostAdapter(
+	client: GitLabClient,
+	baseUrl = "https://gitlab.com",
+): CodeHostAdapter {
+	const cloneBaseUrl = trimTrailingSlash(baseUrl);
+
+	return decorateCodeHost({
+		async fetchFile(
+			repo: string,
+			path: string,
+			ref?: string,
+		): Promise<string | null> {
+			try {
+				const content = await client.getFileContent(repo, path, ref);
+				return Buffer.from(content.content, "base64").toString("utf-8");
+			} catch {
+				return null;
+			}
+		},
+
+		cloneUrl(repo: string): string {
+			return `${cloneBaseUrl}/${repo}.git`;
+		},
+
+		async createChangeRequest(
+			repo: string,
+			head: string,
+			base: string,
+			title: string,
+			body: string,
+		): Promise<ChangeRequest> {
+			const [existing] = await client.listMergeRequests(repo, {
+				source_branch: head,
+				target_branch: base,
+				state: "opened",
+			});
+
+			if (existing) {
+				return { number: existing.iid, url: existing.web_url };
+			}
+
+			const mr = await client.createMergeRequest(repo, {
+				source_branch: head,
+				target_branch: base,
+				title,
+				description: body,
+			});
+			return { number: mr.iid, url: mr.web_url };
+		},
+	});
+}

--- a/server/config.ts
+++ b/server/config.ts
@@ -5,10 +5,16 @@ export type Config = {
 	tracker: {
 		kind: "github";
 	};
-	code_host: {
-		kind: "github";
-		repos: string[];
-	};
+	code_host:
+		| {
+				kind: "github";
+				repos: string[];
+		  }
+		| {
+				kind: "gitlab";
+				repos: string[];
+				base_url: string;
+		  };
 	defaults: {
 		polling_interval_ms: number;
 		max_concurrent: number;
@@ -23,10 +29,21 @@ const configSchema = z
 		tracker: z.object({
 			kind: z.literal("github"),
 		}),
-		code_host: z.object({
-			kind: z.literal("github"),
-			repos: z.array(z.string()).min(1),
-		}),
+		code_host: z.discriminatedUnion("kind", [
+			z
+				.object({
+					kind: z.literal("github"),
+					repos: z.array(z.string()).min(1),
+				})
+				.strict(),
+			z
+				.object({
+					kind: z.literal("gitlab"),
+					repos: z.array(z.string()).min(1),
+					base_url: z.string().url().default("https://gitlab.com"),
+				})
+				.strict(),
+		]),
 		defaults: z
 			.object({
 				polling_interval_ms: z.number().default(30000),

--- a/server/env.ts
+++ b/server/env.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 import { z } from "zod";
+import type { Config } from "./config.ts";
 
 function parseEnv<T extends z.ZodTypeAny>(schema: T): z.infer<T> {
 	const result = schema.safeParse(process.env);
@@ -19,9 +20,32 @@ const envSchema = z.object({
 	CONFIG_PATH: z.string().default("./config.yaml"),
 	PORT: z.coerce.number().default(3000),
 	LOG_LEVEL: z.string().default("info"),
-	GITHUB_TOKEN: z.string().min(1, "GITHUB_TOKEN is required"),
+	GITHUB_TOKEN: z.string().optional(),
+	GITLAB_TOKEN: z.string().optional(),
 });
 
-export function loadEnv() {
-	return parseEnv(envSchema);
+function requireToken(env: z.infer<typeof envSchema>, name: keyof typeof env) {
+	if (typeof env[name] !== "string" || env[name].length === 0) {
+		console.error(
+			`Invalid environment variables:\n  ${name}: ${name} is required`,
+		);
+		process.exit(1);
+	}
+}
+
+export function loadEnv(config?: Pick<Config, "tracker" | "code_host">) {
+	const env = parseEnv(envSchema);
+
+	if (
+		config?.tracker.kind === "github" ||
+		config?.code_host.kind === "github"
+	) {
+		requireToken(env, "GITHUB_TOKEN");
+	}
+
+	if (config?.code_host.kind === "gitlab") {
+		requireToken(env, "GITLAB_TOKEN");
+	}
+
+	return env;
 }

--- a/server/github-client.ts
+++ b/server/github-client.ts
@@ -1,17 +1,7 @@
 import { z } from "zod";
+import { createJsonRequester, type HttpClientOptions } from "./http-client.ts";
 
 const BASE_URL = "https://api.github.com";
-const DEFAULT_TIMEOUT_MS = 30_000;
-const DEFAULT_MAX_ATTEMPTS = 3;
-const DEFAULT_BASE_DELAY_MS = 1_000;
-
-function isRetryableStatus(status: number): boolean {
-	return status === 429 || status >= 500;
-}
-
-function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 const githubUserSchema = z.object({ login: z.string() });
 
@@ -70,104 +60,20 @@ export type GitHubClient = {
 	): Promise<void>;
 };
 
-type GitHubClientOptions = {
-	maxAttempts?: number;
-	baseDelayMs?: number;
-	requestTimeoutMs?: number;
-};
-
 export function createGitHubClient(
 	token: string,
-	options?: GitHubClientOptions,
+	options?: HttpClientOptions,
 ): GitHubClient {
-	const maxAttempts = Math.max(1, options?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
-	const baseDelayMs = options?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
-	const requestTimeoutMs = options?.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
-
-	function retryDelay(response: Response, attempt: number): number {
-		if (response.status === 429) {
-			const retryAfter = response.headers.get("Retry-After");
-			if (retryAfter) return Number.parseInt(retryAfter, 10) * 1000;
-		}
-		return baseDelayMs * 2 ** (attempt - 1);
-	}
-
-	async function request<T extends z.ZodType>(
-		path: string,
-		options: { method?: string; body?: Record<string, unknown>; schema: T },
-	): Promise<z.infer<T>>;
-	async function request(
-		path: string,
-		options?: { method?: string; body?: Record<string, unknown> },
-	): Promise<void>;
-	async function request(
-		path: string,
-		options: {
-			method?: string;
-			body?: Record<string, unknown>;
-			schema?: z.ZodType;
-		} = {},
-	) {
-		const { method = "GET", body, schema } = options;
-		const url = `${BASE_URL}${path}`;
-
-		const headers: Record<string, string> = {
+	const request = createJsonRequester({
+		baseUrl: BASE_URL,
+		serviceName: "GitHub",
+		headers: {
 			Authorization: `Bearer ${token}`,
 			Accept: "application/vnd.github+json",
 			"X-GitHub-Api-Version": "2022-11-28",
-		};
-
-		if (body) {
-			headers["Content-Type"] = "application/json";
-		}
-
-		const init: RequestInit = { method, headers };
-		if (body) {
-			init.body = JSON.stringify(body);
-		}
-
-		let lastError: unknown;
-
-		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-			let response: Response;
-			try {
-				response = await fetch(url, {
-					...init,
-					signal: AbortSignal.timeout(requestTimeoutMs),
-				});
-			} catch (err) {
-				lastError = err;
-				if (attempt < maxAttempts) {
-					await sleep(baseDelayMs * 2 ** (attempt - 1));
-					continue;
-				}
-				/* v8 ignore next -- defensive: fetch always rejects with an Error */
-				const message = err instanceof Error ? err.message : String(err);
-				throw new Error(
-					`GitHub API ${method} ${path} failed after ${maxAttempts} attempts: ${message}`,
-				);
-			}
-
-			if (response.ok) {
-				if (!schema) return;
-				const text = await response.text();
-				return schema.parse(JSON.parse(text));
-			}
-
-			if (isRetryableStatus(response.status) && attempt < maxAttempts) {
-				await sleep(retryDelay(response, attempt));
-				continue;
-			}
-
-			const text = await response.text();
-			throw new Error(
-				`GitHub API ${method} ${path} failed (${response.status}): ${text}`,
-			);
-		}
-
-		/* v8 ignore next -- defensive: loop always returns or throws */
-		throw lastError;
-	}
+		},
+		...options,
+	});
 
 	return {
 		getAuthenticatedUser() {

--- a/server/gitlab-client.ts
+++ b/server/gitlab-client.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+import { createJsonRequester, type HttpClientOptions } from "./http-client.ts";
+
+const DEFAULT_BASE_URL = "https://gitlab.com";
+
+const gitlabFileSchema = z.object({
+	content: z.string(),
+});
+
+const gitlabMergeRequestSchema = z.object({
+	iid: z.number(),
+	web_url: z.string(),
+});
+
+export type GitLabClient = {
+	getFileContent(
+		projectPath: string,
+		filePath: string,
+		ref?: string,
+	): Promise<{ content: string }>;
+	listMergeRequests(
+		projectPath: string,
+		params: { source_branch: string; target_branch: string; state: string },
+	): Promise<{ iid: number; web_url: string }[]>;
+	createMergeRequest(
+		projectPath: string,
+		params: {
+			source_branch: string;
+			target_branch: string;
+			title: string;
+			description: string;
+		},
+	): Promise<{ iid: number; web_url: string }>;
+};
+
+type GitLabClientOptions = HttpClientOptions & {
+	baseUrl?: string;
+};
+
+function trimTrailingSlash(value: string): string {
+	return value.replace(/\/+$/, "");
+}
+
+function encodeProjectPath(projectPath: string): string {
+	return encodeURIComponent(projectPath);
+}
+
+function encodeFilePath(filePath: string): string {
+	return encodeURIComponent(filePath);
+}
+
+export function createGitLabClient(
+	token: string,
+	options: GitLabClientOptions = {},
+): GitLabClient {
+	const baseUrl = trimTrailingSlash(options.baseUrl ?? DEFAULT_BASE_URL);
+	const request = createJsonRequester({
+		...options,
+		baseUrl: `${baseUrl}/api/v4`,
+		serviceName: "GitLab",
+		headers: {
+			"PRIVATE-TOKEN": token,
+		},
+	});
+
+	return {
+		getFileContent(projectPath: string, filePath: string, ref = "HEAD") {
+			const query = new URLSearchParams({ ref });
+			return request(
+				`/projects/${encodeProjectPath(projectPath)}/repository/files/${encodeFilePath(filePath)}?${query}`,
+				{ schema: gitlabFileSchema },
+			);
+		},
+
+		listMergeRequests(
+			projectPath: string,
+			params: { source_branch: string; target_branch: string; state: string },
+		) {
+			const query = new URLSearchParams(params);
+			return request(
+				`/projects/${encodeProjectPath(projectPath)}/merge_requests?${query}`,
+				{ schema: z.array(gitlabMergeRequestSchema) },
+			);
+		},
+
+		createMergeRequest(
+			projectPath: string,
+			params: {
+				source_branch: string;
+				target_branch: string;
+				title: string;
+				description: string;
+			},
+		) {
+			return request(
+				`/projects/${encodeProjectPath(projectPath)}/merge_requests`,
+				{
+					method: "POST",
+					body: params,
+					schema: gitlabMergeRequestSchema,
+				},
+			);
+		},
+	};
+}

--- a/server/http-client.ts
+++ b/server/http-client.ts
@@ -1,0 +1,124 @@
+import type { z } from "zod";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 1_000;
+
+export type HttpClientOptions = {
+	maxAttempts?: number;
+	baseDelayMs?: number;
+	requestTimeoutMs?: number;
+};
+
+type JsonRequesterOptions = HttpClientOptions & {
+	baseUrl: string;
+	serviceName: string;
+	headers: Record<string, string>;
+};
+
+type RequestOptions<T extends z.ZodType> = {
+	method?: string;
+	body?: Record<string, unknown>;
+	schema: T;
+};
+
+type VoidRequestOptions = {
+	method?: string;
+	body?: Record<string, unknown>;
+};
+
+function isRetryableStatus(status: number): boolean {
+	return status === 429 || status >= 500;
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function retryDelay(
+	response: Response,
+	attempt: number,
+	baseDelayMs: number,
+): number {
+	if (response.status === 429) {
+		const retryAfter = response.headers.get("Retry-After");
+		if (retryAfter) return Number.parseInt(retryAfter, 10) * 1000;
+	}
+	return baseDelayMs * 2 ** (attempt - 1);
+}
+
+export function createJsonRequester(options: JsonRequesterOptions) {
+	const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+	const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+	const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+	async function request<T extends z.ZodType>(
+		path: string,
+		requestOptions: RequestOptions<T>,
+	): Promise<z.infer<T>>;
+	async function request(
+		path: string,
+		requestOptions?: VoidRequestOptions,
+	): Promise<void>;
+	async function request(
+		path: string,
+		requestOptions: VoidRequestOptions & { schema?: z.ZodType } = {},
+	) {
+		const { method = "GET", body, schema } = requestOptions;
+		const url = `${options.baseUrl}${path}`;
+		const headers: Record<string, string> = { ...options.headers };
+
+		if (body) {
+			headers["Content-Type"] = "application/json";
+		}
+
+		const init: RequestInit = { method, headers };
+		if (body) {
+			init.body = JSON.stringify(body);
+		}
+
+		let lastError: unknown;
+
+		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			let response: Response;
+			try {
+				response = await fetch(url, {
+					...init,
+					signal: AbortSignal.timeout(requestTimeoutMs),
+				});
+			} catch (err) {
+				lastError = err;
+				if (attempt < maxAttempts) {
+					await sleep(baseDelayMs * 2 ** (attempt - 1));
+					continue;
+				}
+				/* v8 ignore next -- defensive: fetch always rejects with an Error */
+				const message = err instanceof Error ? err.message : String(err);
+				throw new Error(
+					`${options.serviceName} API ${method} ${path} failed after ${maxAttempts} attempts: ${message}`,
+				);
+			}
+
+			if (response.ok) {
+				if (!schema) return;
+				const text = await response.text();
+				return schema.parse(JSON.parse(text));
+			}
+
+			if (isRetryableStatus(response.status) && attempt < maxAttempts) {
+				await sleep(retryDelay(response, attempt, baseDelayMs));
+				continue;
+			}
+
+			const text = await response.text();
+			throw new Error(
+				`${options.serviceName} API ${method} ${path} failed (${response.status}): ${text}`,
+			);
+		}
+
+		/* v8 ignore next -- defensive: loop always returns or throws */
+		throw lastError;
+	}
+
+	return request;
+}

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,11 +1,14 @@
 import { serve } from "@hono/node-server";
 import { createApi, type HealthCheck } from "./api/api.ts";
 import { githubCodeHostAdapter } from "./code-hosts/github.ts";
+import { gitlabCodeHostAdapter } from "./code-hosts/gitlab.ts";
+import type { CodeHostAdapter } from "./code-hosts/types.ts";
 import { loadConfig } from "./config.ts";
 import { closeDb, getDb } from "./db/db.ts";
 import { migrate } from "./db/migrate.ts";
 import { loadEnv } from "./env.ts";
 import { createGitHubClient } from "./github-client.ts";
+import { createGitLabClient } from "./gitlab-client.ts";
 import { logger } from "./logger.ts";
 import { createOrchestrator } from "./orchestrator/orchestrator.ts";
 import { createRunRepository } from "./run-repository.ts";
@@ -13,17 +16,26 @@ import { createRunner } from "./runner/runner.ts";
 import { githubTrackerAdapter } from "./trackers/github.ts";
 import { createWorkflowMap, loadWorkflow } from "./workflow/workflow-loader.ts";
 
-const env = loadEnv();
-const config = loadConfig(env.CONFIG_PATH);
+const baseEnv = loadEnv();
+const config = loadConfig(baseEnv.CONFIG_PATH);
+const env = loadEnv(config);
 
 // Initialize database
 const db = getDb();
 migrate(db);
 
 // Create components
-const github = createGitHubClient(env.GITHUB_TOKEN);
+const github = createGitHubClient(env.GITHUB_TOKEN ?? "");
 const tracker = githubTrackerAdapter(github);
-const codeHost = githubCodeHostAdapter(github);
+let codeHost: CodeHostAdapter;
+if (config.code_host.kind === "github") {
+	codeHost = githubCodeHostAdapter(github);
+} else {
+	const gitlab = createGitLabClient(env.GITLAB_TOKEN ?? "", {
+		baseUrl: config.code_host.base_url,
+	});
+	codeHost = gitlabCodeHostAdapter(gitlab, config.code_host.base_url);
+}
 const repo = createRunRepository(db);
 
 const runner = createRunner({
@@ -78,6 +90,7 @@ const httpServer = serve({ fetch: app.fetch, port: env.PORT }, (info) => {
 	logger.info(
 		{
 			port: info.port,
+			codeHost: config.code_host.kind,
 			repos: config.code_host.repos,
 			activeRepos: [...workflows.keys()],
 			interval: config.defaults.polling_interval_ms,

--- a/server/testing/support/fixtures.ts
+++ b/server/testing/support/fixtures.ts
@@ -2,6 +2,8 @@ import type { query } from "@anthropic-ai/claude-agent-sdk";
 import type { RepoWorkflow } from "../../workflow/workflow.ts";
 
 export const GITHUB_API = "https://api.github.com";
+export const GITLAB_BASE_URL = "https://gitlab.example.test";
+export const GITLAB_API = `${GITLAB_BASE_URL}/api/v4`;
 export const REPO = "test-owner/test-repo";
 
 export function createGitHubIssue(


### PR DESCRIPTION
## Summary
- add GitLab code host support with config parsing, env validation, clone URLs, file fetching, and idempotent merge request creation
- add a GitLab API client and shared HTTP requester so GitHub and GitLab clients use the same retry, timeout, and error handling behavior
- update examples and architecture docs for GitLab code hosting

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:coverage