### PR TITLE
feat: add Jira tracker adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,7 @@ GITHUB_TOKEN=
 #
 # Needs API access to read repository files and create merge requests.
 GITLAB_TOKEN=
+
+# Jira Cloud credentials (required when tracker.kind=jira)
+JIRA_EMAIL=
+JIRA_API_TOKEN=

--- a/docs/shell-expansion-and-integrations-implementation-plan.md
+++ b/docs/shell-expansion-and-integrations-implementation-plan.md
@@ -523,7 +523,25 @@ Use this handoff template when a slice is interrupted:
 
 ## Slice 7 — Jira Tracker Adapter
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Started:** 2026-04-30 on branch `plan/slice-07-jira`.
+
+**Completed changes:**
+
+- Added a Jira Cloud REST client using basic auth from `JIRA_EMAIL` and `JIRA_API_TOKEN`.
+- Added `server/trackers/jira.ts` with Jira-native issue keys, configurable logical-state status mapping, safe JQL construction, active issue polling, issue fetch, and transition resolution/posting.
+- Extended config parsing for `tracker.kind: jira`, required `base_url` and `project`, default/custom statuses, and exactly one configured code-host repo.
+- Wired startup env validation and server adapter selection for GitHub or Jira trackers.
+- Added focused config, env, Jira client, Jira tracker, and orchestrator integration tests, including the single-repo Jira mapping.
+- Documented Jira credentials in `.env.example`.
+
+**Verification:**
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:coverage`
 
 **Purpose:** Add Jira Cloud as a tracker on top of the platform-neutral tracker state model.
 

--- a/server/__tests__/config.test.ts
+++ b/server/__tests__/config.test.ts
@@ -79,6 +79,95 @@ code_host:
 		});
 	});
 
+	it("accepts jira tracker with default statuses", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: jira
+  base_url: https://jira.example.test
+  project: PROJ
+code_host:
+  kind: gitlab
+  base_url: https://gitlab.example.test
+  repos:
+    - group/project
+`);
+
+		const config = loadConfig(configFile.path);
+
+		expect(config.tracker).toEqual({
+			kind: "jira",
+			base_url: "https://jira.example.test",
+			project: "PROJ",
+			statuses: {
+				pending: "To Do",
+				running: "In Progress",
+				awaiting_review: "In Review",
+			},
+		});
+	});
+
+	it("accepts jira tracker with custom statuses", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: jira
+  base_url: https://jira.example.test
+  project: PROJ
+  statuses:
+    pending: Backlog
+    running: Doing
+    awaiting_review: Code Review
+code_host:
+  kind: github
+  repos:
+    - owner/repo
+`);
+
+		const config = loadConfig(configFile.path);
+
+		expect(config.tracker).toEqual({
+			kind: "jira",
+			base_url: "https://jira.example.test",
+			project: "PROJ",
+			statuses: {
+				pending: "Backlog",
+				running: "Doing",
+				awaiting_review: "Code Review",
+			},
+		});
+	});
+
+	it("rejects jira tracker with zero code host repos", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: jira
+  base_url: https://jira.example.test
+  project: PROJ
+code_host:
+  kind: github
+  repos: []
+`);
+
+		expect(() => loadConfig(configFile.path)).toThrow();
+	});
+
+	it("rejects jira tracker with multiple code host repos", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: jira
+  base_url: https://jira.example.test
+  project: PROJ
+code_host:
+  kind: github
+  repos:
+    - owner/repo-a
+    - owner/repo-b
+`);
+
+		expect(() => loadConfig(configFile.path)).toThrow(
+			"Jira tracker requires exactly one code_host.repos entry",
+		);
+	});
+
 	it("rejects config without code_host repos", () => {
 		using configFile = writeConfig(`
 tracker:

--- a/server/__tests__/env.test.ts
+++ b/server/__tests__/env.test.ts
@@ -15,6 +15,26 @@ function gitlabConfig(): Pick<Config, "tracker" | "code_host"> {
 	};
 }
 
+function jiraConfig(): Pick<Config, "tracker" | "code_host"> {
+	return {
+		tracker: {
+			kind: "jira",
+			base_url: "https://jira.example.test",
+			project: "PROJ",
+			statuses: {
+				pending: "To Do",
+				running: "In Progress",
+				awaiting_review: "In Review",
+			},
+		},
+		code_host: {
+			kind: "gitlab",
+			repos: ["group/project"],
+			base_url: "https://gitlab.com",
+		},
+	};
+}
+
 describe("loadEnv", () => {
 	afterEach(() => {
 		process.env = originalEnv;
@@ -43,5 +63,35 @@ describe("loadEnv", () => {
 		const env = loadEnv(gitlabConfig());
 
 		expect(env.GITLAB_TOKEN).toBe("gitlab-token");
+	});
+
+	it("requires Jira credentials when Jira tracker is configured", () => {
+		process.env = {
+			...originalEnv,
+			GITLAB_TOKEN: "gitlab-token",
+		};
+		delete process.env["JIRA_EMAIL"];
+		delete process.env["JIRA_API_TOKEN"];
+		const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new Error("exit");
+		}) as typeof process.exit);
+		vi.spyOn(console, "error").mockImplementation(() => {});
+
+		expect(() => loadEnv(jiraConfig())).toThrow("exit");
+		expect(exit).toHaveBeenCalledWith(1);
+	});
+
+	it("returns Jira credentials when Jira tracker is configured", () => {
+		process.env = {
+			...originalEnv,
+			GITLAB_TOKEN: "gitlab-token",
+			JIRA_EMAIL: "agent@example.test",
+			JIRA_API_TOKEN: "jira-token",
+		};
+
+		const env = loadEnv(jiraConfig());
+
+		expect(env.JIRA_EMAIL).toBe("agent@example.test");
+		expect(env.JIRA_API_TOKEN).toBe("jira-token");
 	});
 });

--- a/server/__tests__/jira-client.integration.test.ts
+++ b/server/__tests__/jira-client.integration.test.ts
@@ -1,0 +1,37 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+import { createJiraClient } from "../jira-client.ts";
+import {
+	createJiraIssue,
+	JIRA_API,
+	JIRA_BASE_URL,
+} from "../testing/support/fixtures.ts";
+import { server } from "../testing/support/msw.ts";
+
+describe("Jira client", () => {
+	it("defaults search maxResults to 100", async () => {
+		let capturedMaxResults = "";
+
+		server.use(
+			http.get(`${JIRA_API}/search`, ({ request }) => {
+				capturedMaxResults =
+					new URL(request.url).searchParams.get("maxResults") ?? "";
+				return HttpResponse.json({
+					issues: [createJiraIssue("PROJ-1", "To Do")],
+				});
+			}),
+		);
+
+		const client = createJiraClient({
+			baseUrl: JIRA_BASE_URL,
+			email: "agent@example.test",
+			apiToken: "jira-token",
+			maxAttempts: 1,
+		});
+
+		const issues = await client.searchIssues({ jql: 'project = "PROJ"' });
+
+		expect(capturedMaxResults).toBe("100");
+		expect(issues.map((issue) => issue.key)).toEqual(["PROJ-1"]);
+	});
+});

--- a/server/__tests__/jira-client.integration.test.ts
+++ b/server/__tests__/jira-client.integration.test.ts
@@ -10,12 +10,11 @@ import { server } from "../testing/support/msw.ts";
 
 describe("Jira client", () => {
 	it("defaults search maxResults to 100", async () => {
-		let capturedMaxResults = "";
+		let capturedBody: unknown;
 
 		server.use(
-			http.get(`${JIRA_API}/search`, ({ request }) => {
-				capturedMaxResults =
-					new URL(request.url).searchParams.get("maxResults") ?? "";
+			http.post(`${JIRA_API}/search/jql`, async ({ request }) => {
+				capturedBody = await request.json();
 				return HttpResponse.json({
 					issues: [createJiraIssue("PROJ-1", "To Do")],
 				});
@@ -31,7 +30,11 @@ describe("Jira client", () => {
 
 		const issues = await client.searchIssues({ jql: 'project = "PROJ"' });
 
-		expect(capturedMaxResults).toBe("100");
+		expect(capturedBody).toMatchObject({
+			jql: 'project = "PROJ"',
+			maxResults: 100,
+			fields: ["summary", "description", "status", "created"],
+		});
 		expect(issues.map((issue) => issue.key)).toEqual(["PROJ-1"]);
 	});
 });

--- a/server/config.ts
+++ b/server/config.ts
@@ -2,9 +2,20 @@ import { readFileSync } from "node:fs";
 import { parse } from "yaml";
 import { z } from "zod";
 export type Config = {
-	tracker: {
-		kind: "github";
-	};
+	tracker:
+		| {
+				kind: "github";
+		  }
+		| {
+				kind: "jira";
+				base_url: string;
+				project: string;
+				statuses: {
+					pending: string;
+					running: string;
+					awaiting_review: string;
+				};
+		  };
 	code_host:
 		| {
 				kind: "github";
@@ -26,9 +37,32 @@ export type Config = {
 
 const configSchema = z
 	.object({
-		tracker: z.object({
-			kind: z.literal("github"),
-		}),
+		tracker: z.discriminatedUnion("kind", [
+			z
+				.object({
+					kind: z.literal("github"),
+				})
+				.strict(),
+			z
+				.object({
+					kind: z.literal("jira"),
+					base_url: z.string().url(),
+					project: z.string().min(1),
+					statuses: z
+						.object({
+							pending: z.string().default("To Do"),
+							running: z.string().default("In Progress"),
+							awaiting_review: z.string().default("In Review"),
+						})
+						.strict()
+						.default({
+							pending: "To Do",
+							running: "In Progress",
+							awaiting_review: "In Review",
+						}),
+				})
+				.strict(),
+		]),
 		code_host: z.discriminatedUnion("kind", [
 			z
 				.object({
@@ -64,7 +98,16 @@ const configSchema = z
 					},
 			),
 	})
-	.strict();
+	.strict()
+	.superRefine((config, ctx) => {
+		if (config.tracker.kind === "jira" && config.code_host.repos.length !== 1) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["code_host", "repos"],
+				message: "Jira tracker requires exactly one code_host.repos entry",
+			});
+		}
+	});
 
 export function loadConfig(filePath: string): Config {
 	const raw = readFileSync(filePath, "utf-8");

--- a/server/env.ts
+++ b/server/env.ts
@@ -22,6 +22,8 @@ const envSchema = z.object({
 	LOG_LEVEL: z.string().default("info"),
 	GITHUB_TOKEN: z.string().optional(),
 	GITLAB_TOKEN: z.string().optional(),
+	JIRA_EMAIL: z.string().optional(),
+	JIRA_API_TOKEN: z.string().optional(),
 });
 
 function requireToken(env: z.infer<typeof envSchema>, name: keyof typeof env) {
@@ -45,6 +47,11 @@ export function loadEnv(config?: Pick<Config, "tracker" | "code_host">) {
 
 	if (config?.code_host.kind === "gitlab") {
 		requireToken(env, "GITLAB_TOKEN");
+	}
+
+	if (config?.tracker.kind === "jira") {
+		requireToken(env, "JIRA_EMAIL");
+		requireToken(env, "JIRA_API_TOKEN");
 	}
 
 	return env;

--- a/server/jira-client.ts
+++ b/server/jira-client.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import { createJsonRequester, type HttpClientOptions } from "./http-client.ts";
+
+const jiraIssueSchema = z.object({
+	key: z.string(),
+	fields: z.object({
+		summary: z.string(),
+		description: z.unknown().nullable().optional(),
+		created: z.string(),
+		status: z.object({
+			name: z.string(),
+		}),
+	}),
+});
+
+const jiraSearchSchema = z.object({
+	issues: z.array(jiraIssueSchema),
+});
+
+const jiraTransitionsSchema = z.object({
+	transitions: z.array(
+		z.object({
+			id: z.string(),
+			name: z.string(),
+			to: z.object({
+				name: z.string(),
+			}),
+		}),
+	),
+});
+
+export type JiraIssue = z.infer<typeof jiraIssueSchema>;
+
+export type JiraTransition = z.infer<
+	typeof jiraTransitionsSchema
+>["transitions"][number];
+
+export type JiraClient = {
+	getIssue(key: string): Promise<JiraIssue>;
+	searchIssues(params: {
+		jql: string;
+		maxResults?: number;
+	}): Promise<JiraIssue[]>;
+	listTransitions(key: string): Promise<JiraTransition[]>;
+	transitionIssue(key: string, transitionId: string): Promise<void>;
+};
+
+type JiraClientOptions = HttpClientOptions & {
+	baseUrl: string;
+	email: string;
+	apiToken: string;
+};
+
+function trimTrailingSlash(value: string): string {
+	return value.replace(/\/+$/, "");
+}
+
+function encodeIssueKey(key: string): string {
+	return encodeURIComponent(key);
+}
+
+function basicAuth(email: string, apiToken: string): string {
+	return Buffer.from(`${email}:${apiToken}`, "utf8").toString("base64");
+}
+
+export function createJiraClient(options: JiraClientOptions): JiraClient {
+	const baseUrl = trimTrailingSlash(options.baseUrl);
+	const request = createJsonRequester({
+		...options,
+		baseUrl: `${baseUrl}/rest/api/3`,
+		serviceName: "Jira",
+		headers: {
+			Authorization: `Basic ${basicAuth(options.email, options.apiToken)}`,
+			Accept: "application/json",
+		},
+	});
+
+	return {
+		getIssue(key: string) {
+			const query = new URLSearchParams({
+				fields: "summary,description,status,created",
+			});
+			return request(`/issue/${encodeIssueKey(key)}?${query}`, {
+				schema: jiraIssueSchema,
+			});
+		},
+
+		async searchIssues(params: { jql: string; maxResults?: number }) {
+			const query = new URLSearchParams({
+				jql: params.jql,
+				maxResults: String(params.maxResults ?? 100),
+				fields: "summary,description,status,created",
+			});
+			const result = await request(`/search?${query}`, {
+				schema: jiraSearchSchema,
+			});
+			return result.issues;
+		},
+
+		async listTransitions(key: string) {
+			const result = await request(
+				`/issue/${encodeIssueKey(key)}/transitions`,
+				{
+					schema: jiraTransitionsSchema,
+				},
+			);
+			return result.transitions;
+		},
+
+		transitionIssue(key: string, transitionId: string) {
+			return request(`/issue/${encodeIssueKey(key)}/transitions`, {
+				method: "POST",
+				body: {
+					transition: {
+						id: transitionId,
+					},
+				},
+			});
+		},
+	};
+}

--- a/server/jira-client.ts
+++ b/server/jira-client.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { createJsonRequester, type HttpClientOptions } from "./http-client.ts";
 
+const ISSUE_FIELDS = ["summary", "description", "status", "created"] as const;
+const DEFAULT_SEARCH_MAX_RESULTS = 100;
+
 const jiraIssueSchema = z.object({
 	key: z.string(),
 	fields: z.object({
@@ -78,7 +81,7 @@ export function createJiraClient(options: JiraClientOptions): JiraClient {
 	return {
 		getIssue(key: string) {
 			const query = new URLSearchParams({
-				fields: "summary,description,status,created",
+				fields: ISSUE_FIELDS.join(","),
 			});
 			return request(`/issue/${encodeIssueKey(key)}?${query}`, {
 				schema: jiraIssueSchema,
@@ -86,12 +89,13 @@ export function createJiraClient(options: JiraClientOptions): JiraClient {
 		},
 
 		async searchIssues(params: { jql: string; maxResults?: number }) {
-			const query = new URLSearchParams({
-				jql: params.jql,
-				maxResults: String(params.maxResults ?? 100),
-				fields: "summary,description,status,created",
-			});
-			const result = await request(`/search?${query}`, {
+			const result = await request("/search/jql", {
+				method: "POST",
+				body: {
+					jql: params.jql,
+					maxResults: params.maxResults ?? DEFAULT_SEARCH_MAX_RESULTS,
+					fields: [...ISSUE_FIELDS],
+				},
 				schema: jiraSearchSchema,
 			});
 			return result.issues;

--- a/server/orchestrator/__tests__/orchestrator.jira.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.jira.integration.test.ts
@@ -24,8 +24,9 @@ describe("Orchestrator Jira dispatch", () => {
 		const transitionTargets: string[] = [];
 
 		server.use(
-			http.get(`${JIRA_API}/search`, ({ request }) => {
-				const jql = new URL(request.url).searchParams.get("jql") ?? "";
+			http.post(`${JIRA_API}/search/jql`, async ({ request }) => {
+				const body = (await request.json()) as { jql?: string };
+				const jql = body.jql ?? "";
 				if (jql.includes('status = "To Do"')) {
 					return HttpResponse.json({
 						issues: [createJiraIssue("PROJ-42", "To Do")],

--- a/server/orchestrator/__tests__/orchestrator.jira.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.jira.integration.test.ts
@@ -1,0 +1,84 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+import { createJiraClient } from "../../jira-client.ts";
+import {
+	createJiraIssue,
+	createTestWorkflow,
+	JIRA_API,
+	JIRA_BASE_URL,
+	REPO,
+} from "../../testing/support/fixtures.ts";
+import { server } from "../../testing/support/msw.ts";
+import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
+import { jiraTrackerAdapter } from "../../trackers/jira.ts";
+
+const statuses = {
+	pending: "To Do",
+	running: "In Progress",
+	awaiting_review: "In Review",
+} as const;
+
+describe("Orchestrator Jira dispatch", () => {
+	it("maps Jira issues to the single configured code-host repo", async () => {
+		const changeRequests: { repo: string; body: string }[] = [];
+		const transitionTargets: string[] = [];
+
+		server.use(
+			http.get(`${JIRA_API}/search`, ({ request }) => {
+				const jql = new URL(request.url).searchParams.get("jql") ?? "";
+				if (jql.includes('status = "To Do"')) {
+					return HttpResponse.json({
+						issues: [createJiraIssue("PROJ-42", "To Do")],
+					});
+				}
+				return HttpResponse.json({ issues: [] });
+			}),
+			http.get(`${JIRA_API}/issue/:key/transitions`, () =>
+				HttpResponse.json({
+					transitions: [
+						{ id: "11", name: "Start", to: { name: "In Progress" } },
+						{ id: "21", name: "Review", to: { name: "In Review" } },
+					],
+				}),
+			),
+			http.post(`${JIRA_API}/issue/:key/transitions`, async ({ request }) => {
+				const body = (await request.json()) as {
+					transition: { id: string };
+				};
+				transitionTargets.push(body.transition.id);
+				return new HttpResponse(null, { status: 204 });
+			}),
+		);
+
+		const tracker = jiraTrackerAdapter(
+			createJiraClient({
+				baseUrl: JIRA_BASE_URL,
+				email: "agent@example.test",
+				apiToken: "jira-token",
+				maxAttempts: 1,
+			}),
+			{ project: "PROJ", repo: REPO, baseUrl: JIRA_BASE_URL, statuses },
+		);
+
+		await using ctx = await createTestOrchestrator({
+			tracker: () => tracker,
+			codeHost: (defaults) => ({
+				...defaults,
+				createChangeRequest: async (repo, _head, _base, _title, body) => {
+					changeRequests.push({ repo, body });
+					return { number: 1, url: "https://example.test/change/1" };
+				},
+			}),
+			workflows: new Map([[REPO, createTestWorkflow()]]),
+		});
+		const { orchestrator, runner, workspace } = ctx;
+		await workspace.preCreateWorkspace("PROJ-42");
+
+		await orchestrator.tick();
+		await runner.queue.waitForIdle();
+		await orchestrator.settled();
+
+		expect(changeRequests).toEqual([{ repo: REPO, body: "Closes PROJ-42" }]);
+		expect(transitionTargets).toEqual(["11", "21"]);
+	});
+});

--- a/server/server.ts
+++ b/server/server.ts
@@ -9,11 +9,14 @@ import { migrate } from "./db/migrate.ts";
 import { loadEnv } from "./env.ts";
 import { createGitHubClient } from "./github-client.ts";
 import { createGitLabClient } from "./gitlab-client.ts";
+import { createJiraClient } from "./jira-client.ts";
 import { logger } from "./logger.ts";
 import { createOrchestrator } from "./orchestrator/orchestrator.ts";
 import { createRunRepository } from "./run-repository.ts";
 import { createRunner } from "./runner/runner.ts";
 import { githubTrackerAdapter } from "./trackers/github.ts";
+import { jiraTrackerAdapter } from "./trackers/jira.ts";
+import type { TrackerAdapter } from "./trackers/types.ts";
 import { createWorkflowMap, loadWorkflow } from "./workflow/workflow-loader.ts";
 
 const baseEnv = loadEnv();
@@ -26,7 +29,26 @@ migrate(db);
 
 // Create components
 const github = createGitHubClient(env.GITHUB_TOKEN ?? "");
-const tracker = githubTrackerAdapter(github);
+let tracker: TrackerAdapter;
+if (config.tracker.kind === "github") {
+	tracker = githubTrackerAdapter(github);
+} else {
+	const jiraRepo = config.code_host.repos[0];
+	if (!jiraRepo) {
+		throw new Error("Jira tracker requires exactly one code_host.repos entry");
+	}
+	const jira = createJiraClient({
+		baseUrl: config.tracker.base_url,
+		email: env.JIRA_EMAIL ?? "",
+		apiToken: env.JIRA_API_TOKEN ?? "",
+	});
+	tracker = jiraTrackerAdapter(jira, {
+		project: config.tracker.project,
+		repo: jiraRepo,
+		baseUrl: config.tracker.base_url,
+		statuses: config.tracker.statuses,
+	});
+}
 let codeHost: CodeHostAdapter;
 if (config.code_host.kind === "github") {
 	codeHost = githubCodeHostAdapter(github);

--- a/server/testing/support/fixtures.ts
+++ b/server/testing/support/fixtures.ts
@@ -4,6 +4,8 @@ import type { RepoWorkflow } from "../../workflow/workflow.ts";
 export const GITHUB_API = "https://api.github.com";
 export const GITLAB_BASE_URL = "https://gitlab.example.test";
 export const GITLAB_API = `${GITLAB_BASE_URL}/api/v4`;
+export const JIRA_BASE_URL = "https://jira.example.test";
+export const JIRA_API = `${JIRA_BASE_URL}/rest/api/3`;
 export const REPO = "test-owner/test-repo";
 
 export function createGitHubIssue(
@@ -18,6 +20,31 @@ export function createGitHubIssue(
 		labels: labels.map((name) => ({ name })),
 		html_url: `https://github.com/${REPO}/issues/${number}`,
 		created_at: createdAt,
+	};
+}
+
+export function createJiraIssue(
+	key: string,
+	status = "To Do",
+	created = "2025-01-01T00:00:00.000+0000",
+) {
+	return {
+		key,
+		fields: {
+			summary: `Issue ${key}`,
+			description: {
+				type: "doc",
+				version: 1,
+				content: [
+					{
+						type: "paragraph",
+						content: [{ type: "text", text: `Description for ${key}` }],
+					},
+				],
+			},
+			created,
+			status: { name: status },
+		},
 	};
 }
 

--- a/server/trackers/__tests__/jira.integration.test.ts
+++ b/server/trackers/__tests__/jira.integration.test.ts
@@ -120,15 +120,19 @@ describe("jiraTrackerAdapter", () => {
 	describe("fetchActiveIssues", () => {
 		it("builds safe JQL for the configured project and logical status", async () => {
 			let capturedJql = "";
+			let capturedMaxResults: unknown;
+			let capturedFields: unknown;
 
 			server.use(
-				http.get(`${JIRA_API}/search`, ({ request }) => {
-					const url = new URL(request.url);
-					capturedJql = url.searchParams.get("jql") ?? "";
-					expect(url.searchParams.get("maxResults")).toBe("100");
-					expect(url.searchParams.get("fields")).toBe(
-						"summary,description,status,created",
-					);
+				http.post(`${JIRA_API}/search/jql`, async ({ request }) => {
+					const body = (await request.json()) as {
+						jql?: string;
+						maxResults?: unknown;
+						fields?: unknown;
+					};
+					capturedJql = body.jql ?? "";
+					capturedMaxResults = body.maxResults;
+					capturedFields = body.fields;
 					return HttpResponse.json({
 						issues: [createJiraIssue("PROJ-1", "To Do")],
 					});
@@ -141,6 +145,13 @@ describe("jiraTrackerAdapter", () => {
 			expect(capturedJql).toBe(
 				'project = "PROJ" AND status = "To Do" ORDER BY created ASC',
 			);
+			expect(capturedMaxResults).toBe(100);
+			expect(capturedFields).toEqual([
+				"summary",
+				"description",
+				"status",
+				"created",
+			]);
 			expect(issues.map((issue) => issue.key)).toEqual(["PROJ-1"]);
 		});
 
@@ -148,8 +159,9 @@ describe("jiraTrackerAdapter", () => {
 			let capturedJql = "";
 
 			server.use(
-				http.get(`${JIRA_API}/search`, ({ request }) => {
-					capturedJql = new URL(request.url).searchParams.get("jql") ?? "";
+				http.post(`${JIRA_API}/search/jql`, async ({ request }) => {
+					const body = (await request.json()) as { jql?: string };
+					capturedJql = body.jql ?? "";
 					return HttpResponse.json({ issues: [] });
 				}),
 			);

--- a/server/trackers/__tests__/jira.integration.test.ts
+++ b/server/trackers/__tests__/jira.integration.test.ts
@@ -1,0 +1,252 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+import { createJiraClient } from "../../jira-client.ts";
+import {
+	createJiraIssue,
+	JIRA_API,
+	JIRA_BASE_URL,
+	REPO,
+} from "../../testing/support/fixtures.ts";
+import { server } from "../../testing/support/msw.ts";
+import { jiraTrackerAdapter } from "../jira.ts";
+
+const statuses = {
+	pending: "To Do",
+	running: "In Progress",
+	awaiting_review: "In Review",
+} as const;
+
+function createTracker() {
+	return jiraTrackerAdapter(
+		createJiraClient({
+			baseUrl: JIRA_BASE_URL,
+			email: "agent@example.test",
+			apiToken: "jira-token",
+			maxAttempts: 1,
+		}),
+		{
+			project: "PROJ",
+			repo: REPO,
+			baseUrl: JIRA_BASE_URL,
+			statuses,
+		},
+	);
+}
+
+describe("jiraTrackerAdapter", () => {
+	describe("fetchIssue", () => {
+		it("maps Jira issues to tracker issues", async () => {
+			server.use(
+				http.get(`${JIRA_API}/issue/:key`, ({ request, params }) => {
+					expect(params["key"]).toBe("PROJ-42");
+					expect(request.headers.get("Authorization")).toBe(
+						`Basic ${Buffer.from("agent@example.test:jira-token").toString("base64")}`,
+					);
+					return HttpResponse.json(createJiraIssue("PROJ-42", "To Do"));
+				}),
+			);
+
+			const tracker = createTracker();
+
+			await expect(tracker.fetchIssue(REPO, 42)).resolves.toEqual({
+				key: "PROJ-42",
+				number: 42,
+				title: "Issue PROJ-42",
+				description: "Description for PROJ-42",
+				labels: ["To Do"],
+				url: `${JIRA_BASE_URL}/browse/PROJ-42`,
+				createdAt: "2025-01-01T00:00:00.000+0000",
+			});
+		});
+
+		it("maps null descriptions to empty strings", async () => {
+			server.use(
+				http.get(`${JIRA_API}/issue/:key`, () =>
+					HttpResponse.json({
+						...createJiraIssue("PROJ-7", "To Do"),
+						fields: {
+							...createJiraIssue("PROJ-7", "To Do").fields,
+							description: null,
+						},
+					}),
+				),
+			);
+
+			const tracker = createTracker();
+			const issue = await tracker.fetchIssue(REPO, 7);
+
+			expect(issue.description).toBe("");
+		});
+
+		it("maps plain string descriptions", async () => {
+			server.use(
+				http.get(`${JIRA_API}/issue/:key`, () =>
+					HttpResponse.json({
+						...createJiraIssue("PROJ-8", "To Do"),
+						fields: {
+							...createJiraIssue("PROJ-8", "To Do").fields,
+							description: "Plain description",
+						},
+					}),
+				),
+			);
+
+			const tracker = createTracker();
+			const issue = await tracker.fetchIssue(REPO, 8);
+
+			expect(issue.description).toBe("Plain description");
+		});
+
+		it("maps unsupported object descriptions to empty strings", async () => {
+			server.use(
+				http.get(`${JIRA_API}/issue/:key`, () =>
+					HttpResponse.json({
+						...createJiraIssue("PROJ-9", "To Do"),
+						fields: {
+							...createJiraIssue("PROJ-9", "To Do").fields,
+							description: { type: "unknown" },
+						},
+					}),
+				),
+			);
+
+			const tracker = createTracker();
+			const issue = await tracker.fetchIssue(REPO, 9);
+
+			expect(issue.description).toBe("");
+		});
+	});
+
+	describe("fetchActiveIssues", () => {
+		it("builds safe JQL for the configured project and logical status", async () => {
+			let capturedJql = "";
+
+			server.use(
+				http.get(`${JIRA_API}/search`, ({ request }) => {
+					const url = new URL(request.url);
+					capturedJql = url.searchParams.get("jql") ?? "";
+					expect(url.searchParams.get("maxResults")).toBe("100");
+					expect(url.searchParams.get("fields")).toBe(
+						"summary,description,status,created",
+					);
+					return HttpResponse.json({
+						issues: [createJiraIssue("PROJ-1", "To Do")],
+					});
+				}),
+			);
+
+			const tracker = createTracker();
+			const issues = await tracker.fetchActiveIssues(REPO, "pending");
+
+			expect(capturedJql).toBe(
+				'project = "PROJ" AND status = "To Do" ORDER BY created ASC',
+			);
+			expect(issues.map((issue) => issue.key)).toEqual(["PROJ-1"]);
+		});
+
+		it("escapes quotes and backslashes in custom status names", async () => {
+			let capturedJql = "";
+
+			server.use(
+				http.get(`${JIRA_API}/search`, ({ request }) => {
+					capturedJql = new URL(request.url).searchParams.get("jql") ?? "";
+					return HttpResponse.json({ issues: [] });
+				}),
+			);
+
+			const tracker = jiraTrackerAdapter(
+				createJiraClient({
+					baseUrl: JIRA_BASE_URL,
+					email: "agent@example.test",
+					apiToken: "jira-token",
+					maxAttempts: 1,
+				}),
+				{
+					project: "PROJ",
+					repo: REPO,
+					baseUrl: JIRA_BASE_URL,
+					statuses: {
+						...statuses,
+						pending: 'Ready "Now" \\ Backlog',
+					},
+				},
+			);
+
+			await tracker.fetchActiveIssues(REPO, "pending");
+
+			expect(capturedJql).toBe(
+				'project = "PROJ" AND status = "Ready \\"Now\\" \\\\ Backlog" ORDER BY created ASC',
+			);
+		});
+	});
+
+	describe("transitionState", () => {
+		it("resolves and posts the transition whose target status matches the logical state", async () => {
+			let postedBody: unknown;
+
+			server.use(
+				http.get(`${JIRA_API}/issue/:key/transitions`, ({ params }) => {
+					expect(params["key"]).toBe("PROJ-42");
+					return HttpResponse.json({
+						transitions: [
+							{ id: "11", name: "Start", to: { name: "In Progress" } },
+							{ id: "21", name: "Review", to: { name: "In Review" } },
+						],
+					});
+				}),
+				http.post(`${JIRA_API}/issue/:key/transitions`, async ({ request }) => {
+					postedBody = await request.json();
+					return new HttpResponse(null, { status: 204 });
+				}),
+			);
+
+			const tracker = createTracker();
+			await tracker.transitionState(REPO, 42, "running", "awaiting_review");
+
+			expect(postedBody).toEqual({ transition: { id: "21" } });
+		});
+
+		it("fails when Jira does not expose a transition to the target status", async () => {
+			server.use(
+				http.get(`${JIRA_API}/issue/:key/transitions`, () =>
+					HttpResponse.json({
+						transitions: [
+							{ id: "11", name: "Start", to: { name: "In Progress" } },
+						],
+					}),
+				),
+				http.post(`${JIRA_API}/issue/:key/transitions`, () =>
+					HttpResponse.json(null, { status: 400 }),
+				),
+			);
+
+			const tracker = createTracker();
+
+			await expect(
+				tracker.transitionState(REPO, 42, "running", "awaiting_review"),
+			).rejects.toThrow("No Jira transition for PROJ-42 to status In Review");
+		});
+	});
+
+	describe("parseIssueKey", () => {
+		it("parses native Jira issue keys to the configured code-host repo", () => {
+			const tracker = createTracker();
+
+			expect(tracker.parseIssueKey("PROJ-42")).toEqual({
+				repo: REPO,
+				number: 42,
+			});
+		});
+
+		it("rejects malformed Jira issue keys", () => {
+			const tracker = createTracker();
+
+			expect(() => tracker.parseIssueKey("PROJ#42")).toThrow(
+				"Invalid Jira issue key",
+			);
+			expect(() => tracker.parseIssueKey("OTHER-42")).toThrow(
+				"Invalid Jira issue key",
+			);
+		});
+	});
+});

--- a/server/trackers/jira.ts
+++ b/server/trackers/jira.ts
@@ -1,0 +1,116 @@
+import type { JiraClient, JiraIssue } from "../jira-client.ts";
+import { decorateTracker } from "./decorator.ts";
+import type { Issue, TrackerAdapter, TrackerState } from "./types.ts";
+
+type JiraStatuses = Record<TrackerState, string>;
+
+type JiraTrackerOptions = {
+	project: string;
+	repo: string;
+	baseUrl: string;
+	statuses: JiraStatuses;
+};
+
+function issueKey(project: string, issueNumber: number): string {
+	return `${project}-${issueNumber}`;
+}
+
+function trimTrailingSlash(value: string): string {
+	return value.replace(/\/+$/, "");
+}
+
+function quoteJqlString(value: string): string {
+	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function extractText(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (Array.isArray(value))
+		return value.map(extractText).filter(Boolean).join("\n");
+	if (value && typeof value === "object") {
+		const record = value as Record<string, unknown>;
+		if (typeof record["text"] === "string") return record["text"];
+		if (Array.isArray(record["content"])) return extractText(record["content"]);
+	}
+	return "";
+}
+
+function parseJiraKey(project: string, key: string): number {
+	const match = /^([A-Z][A-Z0-9_]*)-(\d+)$/.exec(key);
+	const matchedProject = match?.[1];
+	const matchedNumber = match?.[2];
+	if (!matchedProject || !matchedNumber || matchedProject !== project) {
+		throw new Error(`Invalid Jira issue key: ${key}`);
+	}
+	return Number.parseInt(matchedNumber, 10);
+}
+
+function mapJiraIssue(
+	project: string,
+	baseUrl: string,
+	issue: JiraIssue,
+): Issue {
+	return {
+		key: issue.key,
+		number: parseJiraKey(project, issue.key),
+		title: issue.fields.summary,
+		description: extractText(issue.fields.description),
+		labels: [issue.fields.status.name],
+		url: `${trimTrailingSlash(baseUrl)}/browse/${issue.key}`,
+		createdAt: issue.fields.created,
+	};
+}
+
+export function jiraTrackerAdapter(
+	client: JiraClient,
+	options: JiraTrackerOptions,
+): TrackerAdapter {
+	return decorateTracker({
+		async fetchIssue(_repo: string, issueNumber: number): Promise<Issue> {
+			const issue = await client.getIssue(
+				issueKey(options.project, issueNumber),
+			);
+			return mapJiraIssue(options.project, options.baseUrl, issue);
+		},
+
+		async fetchActiveIssues(
+			_repo: string,
+			state: TrackerState,
+		): Promise<Issue[]> {
+			const filter = [
+				`project = ${quoteJqlString(options.project)}`,
+				`status = ${quoteJqlString(options.statuses[state])}`,
+			].join(" AND ");
+			const jql = `${filter} ORDER BY created ASC`;
+			const issues = await client.searchIssues({ jql, maxResults: 100 });
+			return issues.map((issue) =>
+				mapJiraIssue(options.project, options.baseUrl, issue),
+			);
+		},
+
+		async transitionState(
+			_repo: string,
+			issueNumber: number,
+			_from: TrackerState,
+			to: TrackerState,
+		): Promise<void> {
+			const key = issueKey(options.project, issueNumber);
+			const targetStatus = options.statuses[to];
+			const transitions = await client.listTransitions(key);
+			const transition = transitions.find((t) => t.to.name === targetStatus);
+			if (!transition) {
+				throw new Error(
+					`No Jira transition for ${key} to status ${targetStatus}`,
+				);
+			}
+			await client.transitionIssue(key, transition.id);
+		},
+
+		parseIssueKey(key: string): { repo: string; number: number } {
+			return {
+				repo: options.repo,
+				number: parseJiraKey(options.project, key),
+			};
+		},
+	});
+}


### PR DESCRIPTION
## Summary
- Add Jira Cloud client and tracker adapter with native issue keys, logical state status mapping, active issue polling, and transition posting.
- Extend config/env/server wiring for `tracker.kind: jira`, required Jira credentials, default/custom statuses, and exactly one configured code-host repo.
- Add focused config, env, client, tracker, and orchestrator integration coverage; update the implementation plan ledger and `.env.example`.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:coverage`