### PR TITLE
Docs: refresh shell expansion and integrations guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ AI agents that run on your machine, triggered by issue trackers, powered by your
 
 A polling orchestrator watches multiple repos for labelled issues, merges them into an oldest-first queue, creates isolated workspaces, and runs Claude agents to do the work.
 
-See [docs/architecture.md](docs/architecture.md) for the full architecture and design decisions.
+See [docs/architecture.md](docs/architecture.md) for the current architecture.
+The shell expansion and integration design is tracked in
+[docs/design-shell-expansion-and-integrations.md](docs/design-shell-expansion-and-integrations.md)
+and the accompanying
+[decisions log](docs/design-shell-expansion-and-integrations-decisions.md).
 
 ## Setup
 
@@ -19,7 +23,10 @@ The Agent SDK uses your existing Claude Code login automatically. Make sure you'
 
 ### Configuration
 
-Edit `config.yaml` to list your target repos:
+Edit `config.yaml` to choose one tracker, one code host, and the target repos
+the orchestrator may clone and open change requests against.
+
+For GitHub issues with GitHub-hosted code:
 
 ```yaml
 tracker:
@@ -37,10 +44,21 @@ defaults:
   workspace_root: /tmp/local-agent-workspaces
 ```
 
-For GitLab-hosted code, use `kind: gitlab`; `base_url` is optional and defaults
-to `https://gitlab.com`:
+For Jira tracking, configure native Jira statuses. Jira issues do not identify a
+code repo, so Jira mode currently requires exactly one `code_host.repos` entry.
+This example uses GitLab-hosted code; `code_host.base_url` is optional and
+defaults to `https://gitlab.com`:
 
 ```yaml
+tracker:
+  kind: jira
+  base_url: https://yourco.atlassian.net
+  project: PROJ
+  statuses:
+    pending: "To Do"
+    running: "In Progress"
+    awaiting_review: "In Review"
+
 code_host:
   kind: gitlab
   base_url: https://gitlab.example.com
@@ -61,9 +79,30 @@ hooks:
     git push -u origin agent/issue-{{ issue.number }}
 
 prompt: |
-  You are working on: {{ issue.title }}
+  You are working on: {{ issue.key }} - {{ issue.title }}
   {{ issue.description }}
 ```
+
+The workflow can also define staged prompts with `phases` instead of `prompt`:
+
+```yaml
+phases:
+  - name: plan
+    prompt: |
+      Analyze {{ issue.key }} and write PLAN.md.
+
+  - name: implement
+    resume_previous: true
+    prompt: |
+      Implement PLAN.md.
+      !`test -f PLAN.md`
+```
+
+Shell blocks written directly in `workflow.yaml` with `` !`command` `` run in
+the cloned workspace before the agent prompt is sent. Their stdout replaces the
+block. Shell expansion is strict: non-zero exit, timeout, signal termination,
+spawn failure, or output overflow fails the run. Issue titles and descriptions
+are treated as untrusted content and cannot inject executable shell blocks.
 
 ## Running
 
@@ -76,16 +115,18 @@ This starts:
 - **Orchestrator** on `http://localhost:3000` — polls for issues, runs agents, serves API
 - **Dashboard** on `http://localhost:5173` — live monitoring via SSE
 
-### Adding a New Repo
+### Adding a New GitHub Repo
 
 1. Add the repo to the `code_host.repos` list in `config.yaml`
-2. Create the label (e.g., `agent`) on the repo:
+2. Create the required state labels on the repo:
    ```bash
    gh label create agent --repo your-org/your-repo
+   gh label create agent:running --repo your-org/your-repo
+   gh label create agent:awaiting-review --repo your-org/your-repo
    ```
-3. Restart the orchestrator — it loads `./workflow.yaml` on startup
+3. Restart the orchestrator - it loads `./workflow.yaml` on startup
 
-### Creating Work
+### Creating GitHub Work
 
 1. Open an issue with the configured label:
 
@@ -96,6 +137,17 @@ This starts:
 2. The orchestrator picks it up on the next tick (default: 30 seconds), clones the repo, runs the agent, and pushes a branch.
 
 3. Close the issue to stop the agent.
+
+For Jira, create or move an issue into the configured `pending` status. Jira
+issue keys use native Jira format, for example `PROJ-42`.
+
+## Migration Notes
+
+- Move old top-level `repos` entries under `code_host.repos`; top-level `repos`
+  is rejected by the config parser.
+- Move per-repo `.agents/workflow.yaml` content into the local
+  `./workflow.yaml`; target repos are no longer queried for workflow files.
+- Restart the orchestrator after changing `config.yaml` or `workflow.yaml`.
 
 ## Dashboard
 
@@ -111,5 +163,7 @@ The dashboard shows all agent runs in real-time:
 
 - Node.js >= 22.6.0
 - pnpm
-- `gh` CLI (authenticated)
 - Claude Code (logged in with active subscription)
+- `GITHUB_TOKEN` when either the tracker or code host is GitHub
+- `GITLAB_TOKEN` when the code host is GitLab
+- `JIRA_EMAIL` and `JIRA_API_TOKEN` when the tracker is Jira

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,7 +3,7 @@
 A polling orchestrator watches multiple repos for labelled issues, merges them into an oldest-first queue, creates isolated workspaces, and runs Claude agents powered by your existing Claude Code subscription.
 
 ```
-Issue Tracker (GitHub Issues, GitLab, Jira)
+Issue Tracker (GitHub Issues or Jira)
         │
         ▼
 Polling Orchestrator (tick every N seconds)
@@ -12,22 +12,23 @@ Polling Orchestrator (tick every N seconds)
 Fetch All Repos → Merge → Sort oldest first
         │
         ▼
-Label swap → Create Workspace (git clone) → Run Agent
+State transition → Create Workspace (git clone) → Run Agent
         │
         ▼
 Claude Agent SDK (query)
         │
         ▼
-Push Result (commits, branches, pull requests)
+Push Result (commits, branches, PRs/MRs)
 ```
 
 The issue tracker is the orchestration layer. Polling means the orchestrator is resilient to downtime (it catches up on the next tick), works behind NATs and firewalls, and needs nothing exposed publicly.
 
 ## How It Works
 
-### 1. Central config
+### 1. Central Config
 
-A `config.yaml` defines which repos to poll and operational defaults:
+A `config.yaml` defines one tracker, one code host, the code-host repo list,
+and operational defaults:
 
 ```yaml
 tracker:
@@ -46,8 +47,9 @@ defaults:
   workspace_root: /tmp/local-agent-workspaces
 ```
 
-GitLab code hosting uses the same `code_host.repos` list. `base_url` is optional
-and defaults to `https://gitlab.com`:
+GitLab code hosting uses the same `code_host.repos` list. `base_url` is
+optional and defaults to `https://gitlab.com`; it is commonly paired with Jira
+tracking in the current implementation:
 
 ```yaml
 code_host:
@@ -57,7 +59,29 @@ code_host:
     - group/project
 ```
 
-### 2. Global workflow
+Jira tracking maps logical orchestrator states to Jira status names. Statuses
+default to `To Do`, `In Progress`, and `In Review`; override them when your
+Jira project uses different names. Because Jira issues do not identify a code
+repo, Jira mode requires exactly one configured code-host repo:
+
+```yaml
+tracker:
+  kind: jira
+  base_url: https://yourco.atlassian.net
+  project: PROJ
+  statuses:
+    pending: "Backlog"
+    running: "Doing"
+    awaiting_review: "Code Review"
+
+code_host:
+  kind: gitlab
+  base_url: https://gitlab.example.com
+  repos:
+    - group/project
+```
+
+### 2. Global Workflow
 
 The local-agents working directory contains one `workflow.yaml` with hooks and
 the prompt. The same workflow is used for every configured repo:
@@ -72,37 +96,69 @@ hooks:
     git push -u origin agent/issue-{{ issue.number }}
 
 prompt: |
-  You are working on: {{ issue.title }}
+  You are working on: {{ issue.key }} - {{ issue.title }}
   {{ issue.description }}
 ```
 
 Hooks must use plain git commands, not platform-specific CLI tools. The orchestrator handles cloning via `git clone` before the `after_create` hook runs.
 
-### 3. The orchestrator loop
+Workflows define exactly one of `prompt` or `phases`. Multi-phase workflows run
+ordered prompts in one dispatch. By default each phase starts a fresh Claude
+session; a phase can set `resume_previous: true` to resume the previous phase's
+session:
+
+```yaml
+phases:
+  - name: plan
+    prompt: |
+      Analyze {{ issue.key }} and write PLAN.md.
+
+  - name: implement
+    resume_previous: true
+    prompt: |
+      Implement PLAN.md.
+      !`test -f PLAN.md`
+```
+
+Shell blocks written in workflow prompts with `` !`command` `` run in the
+workspace after template rendering and before the Claude Agent SDK receives the
+prompt. Stdout replaces the block. Non-zero exit, timeout, signal termination,
+spawn failure, or output overflow fails the run. Issue fields cannot inject
+executable shell blocks because only blocks authored in the raw workflow
+template are marked for execution.
+
+### 3. The Orchestrator Loop
 
 Each tick:
 
 1. **Fetch** active issues from all configured repos (concurrent)
 2. **Merge** all issues into a single list, sorted oldest-first for cross-repo fairness
 3. **Reconcile** — if a previously running issue is no longer active, kill the run
-4. **Dispatch** — for each unclaimed issue (up to `max_concurrent`), swap its label to mark it as running, create a workspace, and start a Claude agent
+4. **Dispatch** — for each unclaimed issue (up to `max_concurrent`), transition it to `running`, create a workspace, and start a Claude agent
 
-### 4. Label-based state
+### 4. Logical Tracker State
 
-The orchestrator tracks issue state through label swaps on the issue tracker rather than maintaining its own database of claims:
+The orchestrator tracks work through logical states and lets each tracker
+adapter map those states to platform-specific labels or statuses:
 
-- `agent` — issue is pending, waiting to be picked up
-- `agent:running` — orchestrator has claimed this issue and an agent is working on it
-- `agent:awaiting-review` — agent has finished and the result is ready for review
+| Logical state | GitHub label | Default Jira status |
+|---|---|---|
+| `pending` | `agent` | `To Do` |
+| `running` | `agent:running` | `In Progress` |
+| `awaiting_review` | `agent:awaiting-review` | `In Review` |
 
-This keeps the issue tracker as the single source of truth for what's happening.
+This keeps the issue tracker as the single source of truth for what's happening
+without making the orchestrator know GitHub label strings or Jira status names.
 
-### 5. Workflow loading
+GitHub issue keys use `owner/repo#42`. Jira issue keys use native Jira format,
+for example `PROJ-42`.
+
+### 5. Workflow Loading
 
 The orchestrator loads `./workflow.yaml` once from the local-agents working
 directory at startup. Restart the orchestrator to pick up workflow changes.
 
-### 6. Workspaces and hooks
+### 6. Workspaces And Hooks
 
 Each issue gets an isolated workspace directory. The orchestrator runs `git clone` to set up the workspace, then executes lifecycle hooks:
 
@@ -110,9 +166,15 @@ Each issue gets an isolated workspace directory. The orchestrator runs `git clon
 - `before_run` — runs before each agent execution (e.g. fetch latest, rebase)
 - `after_run` — runs after agent completes (e.g. push the branch)
 
-### 7. The agent
+### 7. The Agent
 
-Uses `query()` from the Claude Agent SDK with full tool access. The prompt is rendered from the workflow template with issue context injected via `{{ variable.path }}` interpolation.
+Uses `query()` from the Claude Agent SDK with full tool access. Each prompt or
+phase prompt is rendered from the workflow template with issue context injected
+via `{{ variable.path }}` interpolation, then shell-expanded if it contains
+trusted shell blocks.
+
+Retries skip previously completed phases and resume from the failed phase when
+the previous in-flight session ID is available.
 
 ### 8. Reconciliation
 
@@ -125,7 +187,18 @@ The system uses two adapter interfaces to stay decoupled from any specific platf
 - **TrackerAdapter** — fetches active issues from a tracker and manages label state
 - **CodeHostAdapter** — fetches files from repos, generates clone URLs, and creates pull requests or merge requests
 
-GitHub is implemented as both a tracker and code host. GitLab is implemented as a code host. Adding full support for another platform means implementing the relevant adapter interface.
+GitHub is implemented as both a tracker and code host. Jira is implemented as a
+tracker. GitLab is implemented as a code host. Adding full support for another
+platform means implementing the relevant adapter interface.
+
+## Migration Notes
+
+- `repos` now lives under `code_host.repos`; top-level `repos` is not accepted.
+- The workflow now lives at local `./workflow.yaml`; target repo
+  `.agents/workflow.yaml` files are not fetched.
+- Workflow changes are picked up on orchestrator restart, not by polling or hot
+  reload.
+- Jira mode supports one code-host repo per orchestrator instance.
 
 ## Design Principles
 

--- a/docs/design-shell-expansion-and-integrations-decisions.md
+++ b/docs/design-shell-expansion-and-integrations-decisions.md
@@ -405,7 +405,7 @@ phases:
   - name: review
     prompt: |
       Review the diff against the plan.
-      !`git diff {{ workflow.base_branch }}...HEAD`
+      !`git diff main...HEAD`
 ```
 
 ### Environment variables

--- a/docs/design-shell-expansion-and-integrations.md
+++ b/docs/design-shell-expansion-and-integrations.md
@@ -39,7 +39,7 @@ The settled design adds:
 
 `config.yaml` owns service configuration and the code-host repo list.
 
-The config key is singular: `code_host`, not `code_hosts`. The application configures one code host provider at a time, and `code_host.repos` is the allow-list of repositories the orchestrator may clone, work in, and open PRs/MRs against. The existing top-level `repos` field should move under `code_host` as part of this change.
+The config key is singular: `code_host`, not `code_hosts`. The application configures one code host provider at a time, and `code_host.repos` is the allow-list of repositories the orchestrator may clone, work in, and open PRs/MRs against. The old top-level `repos` field is no longer accepted.
 
 ```yaml
 tracker:
@@ -113,13 +113,13 @@ phases:
   - name: review
     prompt: |
       Review the diff against the plan.
-      !`git diff {{ workflow.base_branch }}...HEAD`
+      !`git diff main...HEAD`
 ```
 
-Workflow loading becomes a one-shot local file load at startup:
+Workflow loading is a one-shot local file load at startup:
 
-- `server/workflow/workflow-loader.ts` should expose `loadWorkflow(path): RepoWorkflow`.
-- Polling refresh and last-known-good workflow cache logic should be removed.
+- `server/workflow/workflow-loader.ts` exposes `loadWorkflow(path): RepoWorkflow`.
+- Polling refresh and last-known-good workflow cache logic have been removed.
 - `codeHost.fetchFile()` is no longer used to load workflows from target repos.
 - Restarting the orchestrator is required to pick up workflow file changes.
 
@@ -378,7 +378,9 @@ Jira issue keys are native Jira keys, for example `PROJ-42`.
 | `transitionState(repo, number, from, to)` | Resolve the transition whose target status matches `to`, then POST it. |
 | `parseIssueKey(key)` | Parse native Jira keys such as `PROJ-42`. |
 
-For Jira, `repo` means the global `tracker.project` value.
+For Jira, the adapter derives the Jira issue key from the configured
+`tracker.project` and issue number. `parseIssueKey()` returns the single
+configured code-host repo because Jira issues do not identify a repo directly.
 
 Because Jira issues do not identify the code repo they belong to, Jira support is limited to one configured code-host repo per orchestrator instance.
 

--- a/docs/shell-expansion-and-integrations-implementation-plan.md
+++ b/docs/shell-expansion-and-integrations-implementation-plan.md
@@ -592,7 +592,24 @@ Use this handoff template when a slice is interrupted:
 
 ## Slice 8 — Documentation And Architecture Refresh
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Started:** 2026-04-30 on branch `plan/slice-08-docs-refresh`.
+
+**Completed changes:**
+
+- Refreshed README setup and configuration guidance for GitHub, Jira, GitLab code hosting, global `workflow.yaml`, multi-phase workflows, trusted shell expansion, and migration from old repo/workflow locations.
+- Updated architecture docs to describe current tracker/code-host responsibilities, global workflow loading, logical tracker states, multi-phase execution, shell expansion, retry behavior, and migration notes.
+- Kept the design and decisions docs linked from the README and corrected stale implementation-facing examples.
+
+**Verification:**
+
+- `pnpm test:coverage` before docs changes: 100% statements, 100% branches, 100% functions, and 100% lines.
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:coverage`
+- `bash -lc "! rg -n 'workflow\\.base_branch|Issue Tracker \\\\(GitHub Issues, GitLab|per-repo workflow caching|per-target-repo workflow loading|logical state completed|completion_signal|max_iterations|PROJ#42' README.md docs/architecture.md docs/design-shell-expansion-and-integrations.md -S"`
 
 **Purpose:** Bring user-facing docs in line with the implemented system.
 


### PR DESCRIPTION
## Summary
- Refresh README setup guidance for GitHub, Jira, GitLab code hosting, global workflow loading, multi-phase workflows, and trusted shell expansion
- Update architecture docs for logical tracker states, tracker/code-host responsibilities, retry behavior, shell expansion, and migration notes
- Correct stale implementation-facing examples and Jira adapter wording in the design docs

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:coverage (100% statements, branches, functions, and lines)