### PR TITLE
docs: add coding standards and slim AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,3 @@
-# Local Agents
-
-Local autonomous agents powered by Claude Agent SDK — a polling orchestrator that dispatches Claude Code agents to work on GitHub issues and PRs.
-
 ## Commands
 
 ```bash
@@ -15,16 +11,16 @@ pnpm test                 # vitest across all projects
 
 ## Structure
 
-| Directory      | Purpose                                                          |
-| -------------- | ---------------------------------------------------------------- |
-| `server/`      | Orchestrator, queue, runner, code-host adapters, workflow engine |
-| `dashboard/`   | React + Vite dashboard UI with Tailwind                          |
-| `docs/`        | Architecture and pattern documentation                           |
+| Directory    | Purpose                                                          |
+| ------------ | ---------------------------------------------------------------- |
+| `server/`    | Orchestrator, queue, runner, code-host adapters, workflow engine |
+| `dashboard/` | React + Vite dashboard UI with Tailwind                          |
+| `docs/`      | Architecture, patterns, and coding standards                     |
 
 ## Before writing code
 
 - Read existing code in the area you're changing. Follow the patterns already there.
-- Read existing tests before writing new ones. The test helpers ARE the conventions.
+- Read `docs/coding-standards.md`.
 
 ## Before considering work complete
 

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -1,0 +1,39 @@
+# Coding Standards
+
+Canonical rules for code in this repo. `CLAUDE.md` summarises; this doc is the source of truth.
+
+## Sections
+
+- [TypeScript](#typescript)
+
+---
+
+## TypeScript
+
+Goal: make invalid states unrepresentable; let the compiler verify assumptions.
+
+### Always
+
+- **No escape hatches.** No `any`, no unchecked `as`, no `@ts-ignore`. Use `unknown` and narrow.
+- **Infer, don't duplicate.** Derive types from one source (`typeof`, `ReturnType`, `z.infer`). Annotate boundaries; infer interiors.
+- **Exhaustive unions.** Every `switch` on a discriminant ends with `const _: never = x` in `default`.
+
+### At boundaries (network, input, env, DB)
+
+- **Parse, don't validate.** Untrusted input goes through a schema parser that returns the refined type. No `as User` on raw JSON.
+- **Brand meaningful primitives.** `UserId`, `Email`, `Meters` — distinct from `string`/`number`. Construction goes through the parser.
+
+### Domain modeling
+
+- **Illegal states unrepresentable.** Use discriminated unions, not optional-field bags. If a comment says "only set when…", it's a union.
+- **Errors as values.** Expected failures → `Result<T, E>` or tagged union in the return type. Throw only for unrecoverable invariant violations.
+
+### Use sparingly
+
+- **Generics:** only with a constraint and a relationship to preserve. No generic soup.
+- **Conditional/mapped types:** library-level only. In app code, prefer a clearer domain model.
+- **Type-level machinery (phantom types, etc.):** only when the guarantee is load-bearing.
+
+### Decision rule
+
+For any invariant: who enforces it? If the answer is "the developer, by remembering," move it into the type system.


### PR DESCRIPTION
## Summary
- Add `docs/coding-standards.md` as the canonical source for code rules, starting with a TypeScript section
- Trim `AGENTS.md` to point at the new doc instead of inlining conventions

## Test plan
- [ ] Confirm `docs/coding-standards.md` renders correctly on GitHub
- [ ] Confirm `AGENTS.md` link to `docs/coding-standards.md` is followable

🤖 Generated with [Claude Code](https://claude.com/claude-code)