### PR TITLE
refactor: typesafe migration slice 3 — discriminate Run state

### DIFF
--- a/docs/typesafe-migration-plan.md
+++ b/docs/typesafe-migration-plan.md
@@ -126,7 +126,27 @@ Slice 6 is cleanup and can run in parallel with anything once 1–5 are done.
 
 ## Slice 3 — Discriminate `Run` State
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Started:** 2026-04-30.
+
+**Completed changes:**
+
+- Replaced `Run = typeof runs.$inferSelect` in `server/run-repository.ts` with a discriminated union: `RunningRun | CompletedRun | FailedRun`. Each variant carries only the fields that are valid in that state (e.g. `running` has no `completedAt`/`durationMs`/`error`; `completed` requires `completedAt` and `durationMs`; `failed` requires `completedAt` and `error`, with `durationMs: number | null` because stale-run reconciliation fails without one).
+- Added `rowToRun` projection at the repository edge. `getRunById` and `getRuns` now parse rows into the union; mixed-state rows throw an invariant error rather than being returned. The exhaustive switch on `row.status` ends in `assertNever`.
+- `getRunningSnapshot` keeps its narrow `{ id, issueKey }` projection — it already filters on `status = "running" AND issueKey IS NOT NULL`, so it bypasses the union mapping intentionally.
+- DB schema is unchanged. Drizzle columns stay nullable; the row/union mismatch lives entirely inside the repository.
+- `server/api/api.ts` adds a `runToWire` projection back to the existing wide JSON shape so the API contract is unchanged. Both `/runs` and `/runs/:id` go union → wire. Exhaustive switch ends in `assertNever`.
+- Orchestrator `retryRun` already used early-return on `failedRun.status !== "failed"`; the union just makes that narrowing real — `failedRun` is a `FailedRun` after the guard, no other code changes needed.
+- `seedRun` test helper now auto-fills variant-required fields (`completedAt`/`durationMs` for completed; `completedAt`/`durationMs`/`error` for failed) so tests can seed by status without restating the invariants.
+- New `server/__tests__/run-repository.test.ts` covers the projection: invariant throws for malformed completed/failed rows and the failed-run round-trip. New API test asserts the failed-run wire shape.
+
+**Verification:**
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:coverage` — 100% across all `server/` and `dashboard/` files.
 
 **Purpose:** Make impossible run states unrepresentable. Replace the optional-field bag (`status` plus optional `error`, `completedAt`, etc.) with a tagged union at the repository boundary.
 

--- a/server/__tests__/run-repository.test.ts
+++ b/server/__tests__/run-repository.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { runs } from "../db/schema.ts";
+import { createRunRepository } from "../run-repository.ts";
+import { createTestDb } from "../testing/support/test-db.ts";
+import { issueKey, runId } from "../types/brands.ts";
+
+describe("run repository row projection", () => {
+	it("throws when a completed row is missing completedAt", () => {
+		const db = createTestDb();
+		const repo = createRunRepository(db);
+		db.insert(runs)
+			.values({
+				id: runId("bad-completed"),
+				agentName: "agent",
+				status: "completed",
+				startedAt: "2025-01-01T00:00:00Z",
+				durationMs: 100,
+			})
+			.run();
+
+		expect(() => repo.getRunById(runId("bad-completed"))).toThrow(
+			/Invariant: completed run/,
+		);
+	});
+
+	it("throws when a failed row is missing error", () => {
+		const db = createTestDb();
+		const repo = createRunRepository(db);
+		db.insert(runs)
+			.values({
+				id: runId("bad-failed"),
+				agentName: "agent",
+				status: "failed",
+				startedAt: "2025-01-01T00:00:00Z",
+				completedAt: "2025-01-01T00:00:01Z",
+			})
+			.run();
+
+		expect(() => repo.getRunById(runId("bad-failed"))).toThrow(
+			/Invariant: failed run/,
+		);
+	});
+
+	it("returns failed runs with error and completion fields preserved", () => {
+		const db = createTestDb();
+		const repo = createRunRepository(db);
+		db.insert(runs)
+			.values({
+				id: runId("failed-1"),
+				agentName: "agent",
+				status: "failed",
+				issueKey: issueKey("owner/repo#1"),
+				issueTitle: "boom",
+				startedAt: "2025-01-01T00:00:00Z",
+				completedAt: "2025-01-01T00:00:02Z",
+				durationMs: 2000,
+				error: "exploded",
+			})
+			.run();
+
+		const run = repo.getRunById(runId("failed-1"));
+		expect(run).toEqual({
+			id: "failed-1",
+			agentName: "agent",
+			status: "failed",
+			issueKey: "owner/repo#1",
+			issueTitle: "boom",
+			startedAt: "2025-01-01T00:00:00Z",
+			completedAt: "2025-01-01T00:00:02Z",
+			durationMs: 2000,
+			error: "exploded",
+			sessionId: null,
+			attempt: 1,
+			parentRunId: null,
+			phaseIndex: 0,
+		});
+	});
+});

--- a/server/api/__tests__/runs.test.ts
+++ b/server/api/__tests__/runs.test.ts
@@ -32,8 +32,8 @@ describe("GET /runs", () => {
 				issueKey: null,
 				issueTitle: null,
 				startedAt: "2025-01-03T00:00:00Z",
-				completedAt: null,
-				durationMs: null,
+				completedAt: expect.any(String),
+				durationMs: 0,
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
@@ -47,8 +47,8 @@ describe("GET /runs", () => {
 				issueKey: null,
 				issueTitle: null,
 				startedAt: "2025-01-02T00:00:00Z",
-				completedAt: null,
-				durationMs: null,
+				completedAt: expect.any(String),
+				durationMs: 0,
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
@@ -62,8 +62,8 @@ describe("GET /runs", () => {
 				issueKey: null,
 				issueTitle: null,
 				startedAt: "2025-01-01T00:00:00Z",
-				completedAt: null,
-				durationMs: null,
+				completedAt: expect.any(String),
+				durationMs: 0,
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
@@ -98,8 +98,8 @@ describe("GET /runs", () => {
 				issueKey: null,
 				issueTitle: null,
 				startedAt: "2025-01-01T00:00:00Z",
-				completedAt: null,
-				durationMs: null,
+				completedAt: expect.any(String),
+				durationMs: 0,
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
@@ -149,6 +149,40 @@ describe("GET /runs", () => {
 		]);
 	});
 
+	it("returns failed runs with their error and completion fields", async () => {
+		const { app, db } = createTestApi();
+		seedRun(db, {
+			id: "fail-1",
+			status: "failed",
+			startedAt: "2025-01-03T00:00:00Z",
+			completedAt: "2025-01-03T00:00:02Z",
+			durationMs: 1500,
+			error: "agent timed out",
+		});
+
+		const res = await app.request("/runs?status=failed");
+		const body = await res.json();
+
+		expect(res.status).toBe(200);
+		expect(body).toEqual([
+			{
+				id: "fail-1",
+				agentName: "test-agent",
+				status: "failed",
+				error: "agent timed out",
+				issueKey: null,
+				issueTitle: null,
+				startedAt: "2025-01-03T00:00:00Z",
+				completedAt: "2025-01-03T00:00:02Z",
+				durationMs: 1500,
+				sessionId: null,
+				attempt: 1,
+				parentRunId: null,
+				phaseIndex: 0,
+			},
+		]);
+	});
+
 	it("respects limit parameter", async () => {
 		const { app, db } = createTestApi();
 		seedRun(db, { id: "r1", startedAt: "2025-01-01T00:00:00Z" });
@@ -168,8 +202,8 @@ describe("GET /runs", () => {
 				issueKey: null,
 				issueTitle: null,
 				startedAt: "2025-01-03T00:00:00Z",
-				completedAt: null,
-				durationMs: null,
+				completedAt: expect.any(String),
+				durationMs: 0,
 				sessionId: null,
 				attempt: 1,
 				parentRunId: null,
@@ -215,8 +249,8 @@ describe("GET /runs/:id", () => {
 			issueKey: null,
 			issueTitle: null,
 			startedAt: "2025-01-01T00:00:00Z",
-			completedAt: null,
-			durationMs: null,
+			completedAt: expect.any(String),
+			durationMs: 0,
 			sessionId: null,
 			attempt: 1,
 			parentRunId: null,

--- a/server/api/api.ts
+++ b/server/api/api.ts
@@ -2,10 +2,12 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { z } from "zod";
+import type { runs } from "../db/schema.ts";
 import { eventBus, type RunEvent } from "../event-bus.ts";
-import type { RunRepository } from "../run-repository.ts";
+import type { Run, RunRepository } from "../run-repository.ts";
 import type { Runner } from "../runner/runner.ts";
 import { runId as brandRunId, type RunId } from "../types/brands.ts";
+import { assertNever } from "../types/exhaustive.ts";
 import { canonicalLogMiddleware } from "./canonical-log-middleware.ts";
 import {
 	ProblemDetailsError,
@@ -34,6 +36,22 @@ type HealthCheckResult = {
 };
 
 export type HealthCheck = () => HealthCheckResult;
+
+type RunWire = typeof runs.$inferSelect;
+
+function runToWire(run: Run): RunWire {
+	switch (run.status) {
+		case "running":
+			return { ...run, error: null, completedAt: null, durationMs: null };
+		case "completed":
+			return { ...run, error: null };
+		case "failed":
+			return run;
+		/* v8 ignore next 2 -- unreachable; Run union is exhaustively handled above */
+		default:
+			return assertNever(run);
+	}
+}
 
 export function createApi({
 	runner,
@@ -82,7 +100,7 @@ export function createApi({
 		zValidator("query", runsQuerySchema, zodProblemHook),
 		(c) => {
 			const { agent, status, limit } = c.req.valid("query");
-			return c.json(repo.getRuns({ agent, status, limit }));
+			return c.json(repo.getRuns({ agent, status, limit }).map(runToWire));
 		},
 	);
 
@@ -96,7 +114,7 @@ export function createApi({
 			if (!run) throw new ProblemDetailsError(404, "Not found");
 
 			const events = repo.getRunEvents(id);
-			return c.json({ ...run, events });
+			return c.json({ ...runToWire(run), events });
 		},
 	);
 

--- a/server/run-repository.ts
+++ b/server/run-repository.ts
@@ -10,9 +10,85 @@ import {
 	runs,
 } from "./db/schema.ts";
 import type { IssueKey, RunId } from "./types/brands.ts";
+import { assertNever } from "./types/exhaustive.ts";
 
-export type Run = typeof runs.$inferSelect;
+type RunRow = typeof runs.$inferSelect;
+
+type RunBase = {
+	id: RunId;
+	agentName: string;
+	issueKey: IssueKey | null;
+	issueTitle: string | null;
+	startedAt: string;
+	attempt: number;
+	parentRunId: RunId | null;
+	phaseIndex: number;
+	sessionId: string | null;
+};
+
+export type RunningRun = RunBase & { status: "running" };
+export type CompletedRun = RunBase & {
+	status: "completed";
+	completedAt: string;
+	durationMs: number;
+};
+export type FailedRun = RunBase & {
+	status: "failed";
+	completedAt: string;
+	durationMs: number | null;
+	error: string;
+};
+
+export type Run = RunningRun | CompletedRun | FailedRun;
+
 export type RunEvent = typeof runEvents.$inferSelect;
+
+function rowToRun(row: RunRow): Run {
+	const base: RunBase = {
+		id: row.id,
+		agentName: row.agentName,
+		issueKey: row.issueKey,
+		issueTitle: row.issueTitle,
+		startedAt: row.startedAt,
+		attempt: row.attempt,
+		parentRunId: row.parentRunId,
+		phaseIndex: row.phaseIndex,
+		sessionId: row.sessionId,
+	};
+
+	switch (row.status) {
+		case "running":
+			return { ...base, status: "running" };
+		case "completed":
+			if (row.completedAt == null || row.durationMs == null) {
+				throw new Error(
+					`Invariant: completed run ${row.id} missing completedAt or durationMs`,
+				);
+			}
+			return {
+				...base,
+				status: "completed",
+				completedAt: row.completedAt,
+				durationMs: row.durationMs,
+			};
+		case "failed":
+			if (row.completedAt == null || row.error == null) {
+				throw new Error(
+					`Invariant: failed run ${row.id} missing completedAt or error`,
+				);
+			}
+			return {
+				...base,
+				status: "failed",
+				completedAt: row.completedAt,
+				durationMs: row.durationMs,
+				error: row.error,
+			};
+		/* v8 ignore next 2 -- unreachable; RunStatus is exhaustively handled above */
+		default:
+			return assertNever(row.status);
+	}
+}
 
 export type RunRepository = {
 	insertRun(run: {
@@ -100,7 +176,8 @@ export function createRunRepository(db: Db): RunRepository {
 		},
 
 		getRunById(id) {
-			return db.select().from(runs).where(eq(runs.id, id)).get();
+			const row = db.select().from(runs).where(eq(runs.id, id)).get();
+			return row ? rowToRun(row) : undefined;
 		},
 
 		getRuns(filters) {
@@ -114,9 +191,11 @@ export function createRunRepository(db: Db): RunRepository {
 				.orderBy(desc(runs.startedAt))
 				.limit(filters.limit);
 
-			return conditions.length > 0
-				? query.where(and(...conditions)).all()
-				: query.all();
+			const rows =
+				conditions.length > 0
+					? query.where(and(...conditions)).all()
+					: query.all();
+			return rows.map(rowToRun);
 		},
 
 		getRunEvents(runId) {

--- a/server/testing/support/test-db.ts
+++ b/server/testing/support/test-db.ts
@@ -4,12 +4,7 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Db } from "../../db/db.ts";
 import { migrate } from "../../db/migrate.ts";
 import { runEvents, runs } from "../../db/schema.ts";
-import {
-	type IssueKey,
-	issueKey,
-	type RunId,
-	runId,
-} from "../../types/brands.ts";
+import { issueKey, runId } from "../../types/brands.ts";
 
 export function createTestDb(): Db {
 	const sqlite = new Database(":memory:");
@@ -28,19 +23,29 @@ type LooseRunInsert = Omit<
 	parentRunId?: string | null;
 };
 
+const variantDefaultsByStatus = {
+	running: {},
+	completed: { durationMs: 0 },
+	failed: { durationMs: 0, error: "test error" },
+} as const;
+
 export function seedRun(db: Db, overrides: LooseRunInsert) {
 	const { id, issueKey: keyStr, parentRunId, ...rest } = overrides;
+	const status = rest.status ?? "completed";
+	const now = new Date().toISOString();
+	const completedAt = status === "running" ? null : now;
+
 	db.insert(runs)
 		.values({
 			agentName: "test-agent",
-			status: "completed",
-			startedAt: new Date().toISOString(),
+			startedAt: now,
+			completedAt,
+			...variantDefaultsByStatus[status],
 			...rest,
+			status,
 			id: runId(id),
-			...(keyStr != null && { issueKey: issueKey(keyStr) as IssueKey | null }),
-			...(parentRunId != null && {
-				parentRunId: runId(parentRunId) as RunId | null,
-			}),
+			...(keyStr != null && { issueKey: issueKey(keyStr) }),
+			...(parentRunId != null && { parentRunId: runId(parentRunId) }),
 		})
 		.run();
 }


### PR DESCRIPTION
## Summary

- Replace `Run = typeof runs.$inferSelect` with a discriminated union (`RunningRun | CompletedRun | FailedRun`) at the repository boundary, so impossible run states (e.g. completed with no `completedAt`) are no longer representable in the domain layer.
- Project DB rows → union on read via `rowToRun`; project union → existing wide JSON shape on the API edge via `runToWire`, so the wire contract is unchanged.
- DB schema unchanged. Drizzle columns stay nullable; the row/union mismatch lives entirely inside the repository.

## Notes

- `getRunningSnapshot` deliberately keeps its narrow `{ id, issueKey }` projection — it filters on `status = "running" AND issueKey IS NOT NULL` and is on the orchestrator tick hot path.
- Orchestrator `retryRun` already early-returned on `status !== "failed"`; the union just makes that narrowing real.
- `seedRun` test helper now auto-fills variant-required fields so tests can seed by status without restating invariants.
- `RunWire` is `typeof runs.$inferSelect` — no separate type definition (the Drizzle row shape already matches the wire contract).

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 250 passing
- [x] `pnpm test:coverage` — 100% across `server/` and `dashboard/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)