### PR TITLE
refactor: typesafe migration slice 6 — cleanup pass

### DIFF
--- a/docs/typesafe-migration-plan.md
+++ b/docs/typesafe-migration-plan.md
@@ -26,15 +26,14 @@ Every slice must:
 
 ## Sequencing
 
-Slices 1 → 5 are sequential. Each unblocks the next:
+Slices 1 → 4 are sequential. Each unblocks the next:
 
 - Slice 1 introduces the primitives (brands, `Result`, `assertNever`) that later slices use.
 - Slice 2 brands the values that ripple through every module; doing this before slice 3+ means later slices already see the right types at boundaries.
-- Slice 3 reshapes `Run` state, which slices 4 and 5 depend on for parsing and API responses.
+- Slice 3 reshapes `Run` state, which slice 4 depends on for parsing.
 - Slice 4 parses at the DB boundary; needs slice 3's union shape to parse into.
-- Slice 5 converts API throws to returns; cleaner once slice 3 has tightened the shape it returns.
 
-Slice 6 is cleanup and can run in parallel with anything once 1–5 are done.
+Slice 6 is cleanup and can run in parallel with anything once 1–4 are done.
 
 ## Slice 1 — Type Foundations
 
@@ -197,53 +196,63 @@ Slice 6 is cleanup and can run in parallel with anything once 1–5 are done.
 - `RunEvent` data is a single inferred type with no hand-maintained duplicates.
 - `pnpm lint`, `pnpm typecheck`, `pnpm test`.
 
-## Slice 5 — API Errors as Values
+## Slice 5 — API Errors as Values (dropped)
 
-**Status:** Not started
+**Status:** Dropped 2026-05-01.
 
-**Purpose:** Stop using `throw` for expected API failures. 404, validation, and state-conflict responses are routine outcomes, not invariant violations.
-
-**Scope:**
-
-- Audit `server/api/*` routes for `throw new ProblemDetailsError(...)` in expected paths.
-- Convert each to a returned response (`return c.json({...}, status)`).
-- Keep `ProblemDetailsError` and the global handler for genuine invariant violations / 500s only.
-- Where a route reads from the repository and may need to 404, the repository returns `Result<Run, NotFound>` (or similar); the route maps that to a response.
-
-**Natural code areas:**
-
-- `server/api/*`
-- `server/api/problem-details.ts`
-- `server/run-repository.ts` (signature changes for find-style reads)
-
-**Quality gates:**
-
-- No expected failure paths throw.
-- Existing route tests still pass with same response shapes.
-- `pnpm lint`, `pnpm typecheck`, `pnpm test`.
+**Why dropped:** The existing pattern (route throws `ProblemDetailsError`, single `onError` handler converts it to an RFC 9457 response) is already errors-as-values in everything but syntax. Conversion to `return problemResponse(c, ...)` is purely cosmetic — same status codes, same response shapes, same control flow. A trial implementation also forced an `as unknown as Context<AppEnv>` cast in the helper because `@hono/zod-validator`'s `Hook` binds `Env` looser than `AppEnv`, which is a regression the slice was supposed to avoid. The "errors as values" wins are already realised by slices 1–3 (branded types, `Run` discriminated union, `parseIssueKey` returning `Result`). `ProblemDetailsError` stays as the route → handler bridge.
 
 ## Slice 6 — Cleanup Pass
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Started:** 2026-05-01.
+
+**Completed changes:**
+
+- `server/workflow/workflow.ts`: Folded the `prompt | phases` shorthand into a single Zod schema with a `.transform()` that normalizes both YAML shapes into a `phases` array at the boundary. `RepoWorkflow` is now `z.infer<typeof repoWorkflowSchema>` — no hand-written duplicate. Dropped `getWorkflowPhases` (callers read `workflow.phases` directly), removed `prompt as string` and the `value as Record<string, unknown>` cast in `renderPrompt` (now uses an `isRecord` type predicate). `NonEmptyArray<WorkflowPhase>` was considered and dropped — no caller indexes phases (only `.length`/`.entries()`), so per the standards it is non-load-bearing type machinery.
+- `server/orchestrator/phase-runner.ts`: Reads `workflow.phases` directly. Added a guard that throws if `startPhaseIndex` is out of range for the configured phases — the invariant could otherwise silently fail when stored DB state predates a config change.
+- `server/workflow/prompt-preprocessor.ts`: Removed `match[1] as string` and `outputs[i++] as string`. Both call sites now check for `undefined` and throw an unreachable-invariant error documented with a `/* v8 ignore */` pragma.
+- `server/api/problem-details.ts`: `zodProblemHook` now derives validation errors from `result.error.issues` directly, dropping the `messages as string[]` cast and the `flattenError` round-trip.
+- `server/orchestrator/orchestrator.ts`: Tightened tick-state types — `runningByIssue: Map<IssueKey, RunId[]>` and `stillRunning: Map<RepoSlug, Set<IssueKey>>` (was `string` keyed). Removed the `i.key as string` widening cast.
+- `server/run-repository.ts`: `getRunningSnapshot` now narrows via a `filter` with a typed predicate rather than asserting through `as`.
+- `server/trackers/jira.ts`: `extractText` uses `in`-based narrowing instead of casting through `Record<string, unknown>`.
+- `server/runner/runner.ts`: Documented the lone remaining `as RunEvent` cast — a TS limitation when recombining a discriminated union through a spread. `EventPayload` is the distributive `Pick<RunEvent, "type" | "data">`, so the runtime invariant is intact.
+- Added `server/orchestrator/__tests__/phase-runner.test.ts` covering the new `startPhaseIndex` invariant in both directions (negative and past-last-phase).
+- Updated test fixtures (`createTestWorkflow`) and the few tests that constructed `RepoWorkflow` literals with the old `prompt` shorthand to use the normalized `phases` form.
+
+**Verification:**
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:coverage` — 100% across all `server/` and `dashboard/` files.
+
+**Surviving `as` casts under `server/` (all documented post-narrowing assertions):**
+
+- `server/types/brands.ts` — Brand constructors at trusted boundaries (slice 1/2 design).
+- `server/run-repository.ts` `rowToRun` — exhaustive switch ends in `assertNever` (slice 3 design).
+- `server/runner/runner.ts` `as RunEvent` — see above.
 
 **Purpose:** Sweep the remaining items the earlier slices did not naturally fix.
 
-**Scope:**
+**Scope (executed):**
 
-- Remove unchecked `as` casts in `server/workflow/workflow.ts` (`prompt as string`, etc.) and `server/workflow/prompt-preprocessor.ts` (`match as RegExpExecArray`). Use control-flow narrowing or small assertion helpers.
-- Encode workflow phase invariants: `phases` as `NonEmptyArray<Phase>`, `startPhaseIndex` valid against the array.
-- Audit `server/api/problem-details.ts` for the `messages as string[]` cast.
-- Final scan with `rg -n '\bany\b|\bas \b|@ts-ignore|@ts-expect-error'` under `server/` (excluding `as const`); document any survivors with a justification or fix them.
+- Remove unchecked `as` casts in `server/workflow/workflow.ts` and `server/workflow/prompt-preprocessor.ts`.
+- Encode workflow phase invariants: `phases` always defined post-parse via Zod transform; `startPhaseIndex` validated at runtime against the array.
+- Drop the `messages as string[]` cast in `server/api/problem-details.ts`.
+- Final scan with `rg -n '\bany\b|\bas \b|@ts-ignore|@ts-expect-error'` under `server/` (excluding `as const`); document survivors.
 
 **Natural code areas:**
 
 - `server/workflow/*`
 - `server/api/problem-details.ts`
-- Anywhere flagged by the final sweep.
+- `server/orchestrator/*`, `server/run-repository.ts`, `server/trackers/jira.ts`
+- `server/runner/runner.ts`
 
 **Quality gates:**
 
-- No `any`, no `@ts-ignore`/`@ts-expect-error`, no unchecked `as` outside `as const` and post-narrowing assertions.
+- No `any`, no `@ts-ignore`/`@ts-expect-error`, no unchecked `as` outside `as const` and the documented post-narrowing assertions listed above.
 - `pnpm lint`, `pnpm typecheck`, `pnpm test`.
 
 ## Release-Level Acceptance

--- a/server/api/problem-details.ts
+++ b/server/api/problem-details.ts
@@ -1,6 +1,5 @@
 import type { Hook } from "@hono/zod-validator";
 import type { Context, Env, ErrorHandler, ValidationTargets } from "hono";
-import { z } from "zod";
 import type { $ZodType } from "zod/v4/core";
 import * as canonicalLog from "../canonical-log.ts";
 import type { AppEnv } from "./types.ts";
@@ -75,11 +74,10 @@ export const zodProblemHook: Hook<
 > = (result) => {
 	if (result.success) return;
 
-	const flat = z.flattenError(result.error);
-	const errors: ValidationError[] = Object.entries(flat.fieldErrors).flatMap(
-		([field, messages]) =>
-			(messages as string[]).map((message) => ({ field, message })),
-	);
+	const errors: ValidationError[] = result.error.issues.map((issue) => ({
+		field: issue.path.map(String).join("."),
+		message: issue.message,
+	}));
 
 	throw new ProblemDetailsError(422, "Validation failed", { errors });
 };

--- a/server/orchestrator/__tests__/orchestrator.retry-prompt.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.retry-prompt.integration.test.ts
@@ -34,8 +34,14 @@ describe("Orchestrator retry prompt fidelity", () => {
 		const workflow: RepoWorkflow = {
 			branch: "agent/issue-{{ issue.number }}",
 			base_branch: "main",
-			prompt:
-				"Fix issue #{{ issue.number }}: {{ issue.title }}\n\nDescription: {{ issue.description }}",
+			phases: [
+				{
+					name: "prompt",
+					prompt:
+						"Fix issue #{{ issue.number }}: {{ issue.title }}\n\nDescription: {{ issue.description }}",
+					resume_previous: false,
+				},
+			],
 		};
 
 		await using ctx = await createTestOrchestrator({
@@ -68,8 +74,14 @@ describe("Orchestrator retry prompt fidelity", () => {
 		const workflow: RepoWorkflow = {
 			branch: "agent/issue-{{ issue.number }}",
 			base_branch: "main",
-			prompt:
-				"Fix issue #{{ issue.number }} [{{ issue.labels }}]: {{ issue.title }}",
+			phases: [
+				{
+					name: "prompt",
+					prompt:
+						"Fix issue #{{ issue.number }} [{{ issue.labels }}]: {{ issue.title }}",
+					resume_previous: false,
+				},
+			],
 		};
 
 		await using ctx = await createTestOrchestrator({

--- a/server/orchestrator/__tests__/orchestrator.shell-expansion.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.shell-expansion.integration.test.ts
@@ -24,7 +24,13 @@ describe("Orchestrator shell expansion", () => {
 				[
 					REPO,
 					createTestWorkflow({
-						prompt: "Fix issue {{ issue.number }}\n!`printf from-shell`",
+						phases: [
+							{
+								name: "prompt",
+								prompt: "Fix issue {{ issue.number }}\n!`printf from-shell`",
+								resume_previous: false,
+							},
+						],
 					}),
 				],
 			]),
@@ -55,7 +61,13 @@ describe("Orchestrator shell expansion", () => {
 				[
 					REPO,
 					createTestWorkflow({
-						prompt: "!`printf expansion-failed >&2; exit 7`",
+						phases: [
+							{
+								name: "prompt",
+								prompt: "!`printf expansion-failed >&2; exit 7`",
+								resume_previous: false,
+							},
+						],
 					}),
 				],
 			]),

--- a/server/orchestrator/__tests__/phase-runner.test.ts
+++ b/server/orchestrator/__tests__/phase-runner.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { Issue } from "../../trackers/types.ts";
+import { issueKey, issueNumber, runId } from "../../types/brands.ts";
+import type { RepoWorkflow } from "../../workflow/workflow.ts";
+import type { RunAgent } from "../phase-runner.ts";
+import { runWorkflowPhases } from "../phase-runner.ts";
+
+const issue: Issue = {
+	key: issueKey("owner/repo#1"),
+	number: issueNumber(1),
+	title: "Anything",
+	description: "",
+	labels: [],
+	url: "https://example.com/1",
+	createdAt: "2026-01-01T00:00:00Z",
+};
+
+const workflow: RepoWorkflow = {
+	branch: "agent/x",
+	base_branch: "main",
+	phases: [
+		{ name: "plan", prompt: "plan", resume_previous: false },
+		{ name: "implement", prompt: "implement", resume_previous: false },
+	],
+};
+
+const noopAgent: RunAgent = async function* noopAgent() {
+	yield* [];
+};
+
+const ctx = {
+	runId: runId("test-run"),
+	emitToolUse: () => {},
+	emitPhaseEvent: () => {},
+	setSessionId: () => {},
+	setPhaseIndex: () => {},
+	signal: new AbortController().signal,
+};
+
+describe("runWorkflowPhases", () => {
+	it("throws when startPhaseIndex is past the last phase", async () => {
+		await expect(
+			runWorkflowPhases({
+				ctx,
+				runAgent: noopAgent,
+				workflow,
+				issue,
+				attempt: 1,
+				cwd: "/tmp",
+				model: "test-model",
+				startPhaseIndex: 5,
+			}),
+		).rejects.toThrow(/startPhaseIndex 5 is out of range for 2 phases/);
+	});
+
+	it("throws when startPhaseIndex is negative", async () => {
+		await expect(
+			runWorkflowPhases({
+				ctx,
+				runAgent: noopAgent,
+				workflow,
+				issue,
+				attempt: 1,
+				cwd: "/tmp",
+				model: "test-model",
+				startPhaseIndex: -1,
+			}),
+		).rejects.toThrow(/startPhaseIndex -1 is out of range for 2 phases/);
+	});
+});

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -8,7 +8,12 @@ import { logger } from "../logger.ts";
 import type { RunRepository } from "../run-repository.ts";
 import { ABORT_ERROR, type Runner, type RunResult } from "../runner/runner.ts";
 import type { Issue, TrackerAdapter } from "../trackers/types.ts";
-import { branchName, type RepoSlug, type RunId } from "../types/brands.ts";
+import {
+	branchName,
+	type IssueKey,
+	type RepoSlug,
+	type RunId,
+} from "../types/brands.ts";
 import { unwrap } from "../types/result.ts";
 import type { RepoWorkflow } from "../workflow/workflow.ts";
 import { renderPrompt } from "../workflow/workflow.ts";
@@ -42,10 +47,10 @@ type Orchestrator = {
 
 type TaggedIssue = { issue: Issue; repo: RepoSlug; workflow: RepoWorkflow };
 type TickState = {
-	runningByIssue: Map<string, RunId[]>;
+	runningByIssue: Map<IssueKey, RunId[]>;
 	runningCount: number;
 	pending: TaggedIssue[];
-	stillRunning: Map<RepoSlug, Set<string>>;
+	stillRunning: Map<RepoSlug, Set<IssueKey>>;
 };
 
 export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
@@ -249,7 +254,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		const entries = [...workflows.entries()];
 
 		const dbSnapshot = runRepo.getRunningSnapshot();
-		const runningByIssue = new Map<string, RunId[]>();
+		const runningByIssue = new Map<IssueKey, RunId[]>();
 		for (const r of dbSnapshot) {
 			const ids = runningByIssue.get(r.issueKey) ?? [];
 			ids.push(r.id);
@@ -268,7 +273,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 			Promise.allSettled(
 				entries.map(async ([repo]) => {
 					const issues = await tracker.fetchActiveIssues(repo, "running");
-					return { repo, keys: new Set(issues.map((i) => i.key as string)) };
+					return { repo, keys: new Set(issues.map((i) => i.key)) };
 				}),
 			),
 		]);
@@ -286,7 +291,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		}
 		pending.sort((a, b) => a.issue.createdAt.localeCompare(b.issue.createdAt));
 
-		const stillRunning = new Map<RepoSlug, Set<string>>();
+		const stillRunning = new Map<RepoSlug, Set<IssueKey>>();
 		for (const result of runningResults) {
 			if (result.status === "fulfilled") {
 				stillRunning.set(result.value.repo, result.value.keys);

--- a/server/orchestrator/phase-runner.ts
+++ b/server/orchestrator/phase-runner.ts
@@ -8,7 +8,7 @@ import {
 	markTrustedShellBlocks,
 } from "../workflow/prompt-preprocessor.ts";
 import type { RepoWorkflow, WorkflowPhase } from "../workflow/workflow.ts";
-import { getWorkflowPhases, renderPrompt } from "../workflow/workflow.ts";
+import { renderPrompt } from "../workflow/workflow.ts";
 import { logAgentMessage } from "./agent-logging.ts";
 
 export type RunAgent = (
@@ -40,7 +40,12 @@ export async function runWorkflowPhases({
 	startPhaseIndex = 0,
 	failedPhaseResumeSessionId,
 }: RunWorkflowPhasesParams): Promise<void> {
-	const phases = getWorkflowPhases(workflow);
+	const { phases } = workflow;
+	if (startPhaseIndex < 0 || startPhaseIndex >= phases.length) {
+		throw new Error(
+			`Invariant: startPhaseIndex ${startPhaseIndex} is out of range for ${phases.length} phases`,
+		);
+	}
 	let previousSessionId: string | undefined;
 
 	for (const [index, phase] of phases.entries()) {

--- a/server/run-repository.ts
+++ b/server/run-repository.ts
@@ -172,7 +172,11 @@ export function createRunRepository(db: Db): RunRepository {
 				.select({ id: runs.id, issueKey: runs.issueKey })
 				.from(runs)
 				.where(and(eq(runs.status, "running"), isNotNull(runs.issueKey)))
-				.all() as { id: RunId; issueKey: IssueKey }[];
+				.all()
+				.filter(
+					(row): row is { id: RunId; issueKey: IssueKey } =>
+						row.issueKey != null,
+				);
 		},
 
 		getRunById(id) {

--- a/server/runner/runner.ts
+++ b/server/runner/runner.ts
@@ -64,6 +64,7 @@ export function createRunner(config: RunnerConfig): Runner {
 		event: EventPayload,
 		createdAt = new Date().toISOString(),
 	): void {
+		// Post-narrowing: TS doesn't recombine the discriminated union through a spread.
 		const fullEvent = {
 			...event,
 			runId: id,

--- a/server/testing/support/fixtures.ts
+++ b/server/testing/support/fixtures.ts
@@ -109,7 +109,13 @@ export function createTestWorkflow(
 	return {
 		branch: "agent/issue-{{ issue.number }}",
 		base_branch: "main",
-		prompt: "Fix issue {{ issue.number }}: {{ issue.title }}",
+		phases: [
+			{
+				name: "prompt",
+				prompt: "Fix issue {{ issue.number }}: {{ issue.title }}",
+				resume_previous: false,
+			},
+		],
 		...overrides,
 	};
 }

--- a/server/trackers/jira.ts
+++ b/server/trackers/jira.ts
@@ -29,10 +29,10 @@ function extractText(value: unknown): string {
 	if (typeof value === "string") return value;
 	if (Array.isArray(value))
 		return value.map(extractText).filter(Boolean).join("\n");
-	if (value && typeof value === "object") {
-		const record = value as Record<string, unknown>;
-		if (typeof record["text"] === "string") return record["text"];
-		if (Array.isArray(record["content"])) return extractText(record["content"]);
+	if (value !== null && typeof value === "object") {
+		if ("text" in value && typeof value.text === "string") return value.text;
+		if ("content" in value && Array.isArray(value.content))
+			return extractText(value.content);
 	}
 	return "";
 }

--- a/server/workflow/__tests__/prompt-preprocessor.test.ts
+++ b/server/workflow/__tests__/prompt-preprocessor.test.ts
@@ -34,10 +34,12 @@ describe("shell block preprocessing", () => {
 		});
 
 		const match = result.match(/^issue=1 pwd=(.+)\n$/);
-		expect(match).not.toBeNull();
-		await expect(
-			realpath((match as RegExpMatchArray)[1] as string),
-		).resolves.toBe(await realpath(workspace.root));
+		const matchedPath = match?.[1];
+		expect(matchedPath).toBeDefined();
+		if (matchedPath === undefined) return;
+		await expect(realpath(matchedPath)).resolves.toBe(
+			await realpath(workspace.root),
+		);
 	});
 
 	it("runs marked shell blocks in parallel", async () => {

--- a/server/workflow/__tests__/workflow-loader.test.ts
+++ b/server/workflow/__tests__/workflow-loader.test.ts
@@ -35,7 +35,9 @@ describe("loadWorkflow", () => {
 		const workflow = loadWorkflow(workflowFile.path);
 
 		expect(workflow).toEqual({
-			prompt: "Fix the issue",
+			phases: [
+				{ name: "prompt", prompt: "Fix the issue", resume_previous: false },
+			],
 			branch: "agent/issue-{{ issue.number }}",
 			base_branch: "main",
 		});

--- a/server/workflow/__tests__/workflow.test.ts
+++ b/server/workflow/__tests__/workflow.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Issue } from "../../trackers/types.ts";
 import { issueKey, issueNumber } from "../../types/brands.ts";
-import {
-	getWorkflowPhases,
-	parseRepoWorkflow,
-	renderPrompt,
-} from "../workflow.ts";
+import { parseRepoWorkflow, renderPrompt } from "../workflow.ts";
 
 const baseIssue: Issue = {
 	key: issueKey("owner/repo#1"),
@@ -64,8 +60,7 @@ prompt: Fix this issue
 
 		expect(result.branch).toBe("agent/issue-{{ issue.number }}");
 		expect(result.base_branch).toBe("main");
-		expect(result.prompt).toBe("Fix this issue");
-		expect(getWorkflowPhases(result)).toEqual([
+		expect(result.phases).toEqual([
 			{ name: "prompt", prompt: "Fix this issue", resume_previous: false },
 		]);
 	});
@@ -84,8 +79,7 @@ phases:
 
 		const result = parseRepoWorkflow(yaml);
 
-		expect(result.prompt).toBeUndefined();
-		expect(getWorkflowPhases(result)).toEqual([
+		expect(result.phases).toEqual([
 			{ name: "plan", prompt: "Write a plan", resume_previous: false },
 			{
 				name: "implement",

--- a/server/workflow/prompt-preprocessor.ts
+++ b/server/workflow/prompt-preprocessor.ts
@@ -28,9 +28,15 @@ export async function expandMarkedShellBlocks(
 	prompt: string,
 	options: ExpandShellBlocksOptions,
 ): Promise<string> {
-	const commands = [...prompt.matchAll(markedShellBlockPattern)].map(
-		(match) => match[1] as string,
-	);
+	const commands: string[] = [];
+	for (const match of prompt.matchAll(markedShellBlockPattern)) {
+		const command = match[1];
+		/* v8 ignore next 3 -- unreachable; pattern's first capture group always matches */
+		if (command === undefined) {
+			throw new Error("Invariant: shell block match missing capture group");
+		}
+		commands.push(command);
+	}
 	if (commands.length === 0) return prompt;
 
 	const outputs = await Promise.all(
@@ -38,7 +44,14 @@ export async function expandMarkedShellBlocks(
 	);
 
 	let i = 0;
-	return prompt.replace(markedShellBlockPattern, () => outputs[i++] as string);
+	return prompt.replace(markedShellBlockPattern, () => {
+		const output = outputs[i++];
+		/* v8 ignore next 3 -- unreachable; outputs.length matches number of replacements */
+		if (output === undefined) {
+			throw new Error("Invariant: shell block output missing");
+		}
+		return output;
+	});
 }
 
 async function runShellBlock(

--- a/server/workflow/workflow.ts
+++ b/server/workflow/workflow.ts
@@ -9,6 +9,8 @@ const workflowPhaseSchema = z.object({
 	resume_previous: z.boolean().optional().default(false),
 });
 
+export type WorkflowPhase = z.infer<typeof workflowPhaseSchema>;
+
 const repoWorkflowSchema = z
 	.object({
 		branch: z.string().min(1),
@@ -33,26 +35,27 @@ const repoWorkflowSchema = z
 				path: hasPrompt ? ["phases"] : ["prompt"],
 			});
 		}
+	})
+	.transform(({ prompt, phases, ...rest }) => {
+		if (phases) return { ...rest, phases };
+		/* v8 ignore next 3 -- unreachable; superRefine guarantees prompt is set when phases is not */
+		if (prompt == null) {
+			throw new Error("Invariant: workflow has neither prompt nor phases");
+		}
+		return {
+			...rest,
+			phases: [{ name: "prompt", prompt, resume_previous: false }],
+		};
 	});
-
-export type WorkflowPhase = z.infer<typeof workflowPhaseSchema>;
 
 export type RepoWorkflow = z.infer<typeof repoWorkflowSchema>;
 
-export function getWorkflowPhases(workflow: RepoWorkflow): WorkflowPhase[] {
-	if (workflow.phases) return workflow.phases;
-	return [
-		{
-			name: "prompt",
-			prompt: workflow.prompt as string,
-			resume_previous: false,
-		},
-	];
+export function parseRepoWorkflow(yamlContent: string): RepoWorkflow {
+	return repoWorkflowSchema.parse(parse(yamlContent));
 }
 
-export function parseRepoWorkflow(yamlContent: string): RepoWorkflow {
-	const parsed = parse(yamlContent);
-	return repoWorkflowSchema.parse(parsed);
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object";
 }
 
 /**
@@ -66,8 +69,8 @@ export function renderPrompt(
 		const parts = path.split(".");
 		let value: unknown = vars;
 		for (const part of parts) {
-			if (value == null || typeof value !== "object") return "";
-			value = (value as Record<string, unknown>)[part];
+			if (!isRecord(value)) return "";
+			value = value[part];
 		}
 		if (value == null) return "";
 		if (Array.isArray(value))


### PR DESCRIPTION
## Summary

Final slice of the typesafe migration. Sweeps the remaining unchecked `as` casts, hand-maintained type duplicates, and weakly-typed maps left after slices 1–3.

- **`workflow.ts`**: collapse `prompt | phases` shorthand into a single Zod schema with `.transform()`; `RepoWorkflow = z.infer<...>` (no hand-written duplicate). `getWorkflowPhases` removed — callers read `workflow.phases` directly. `NonEmptyArray<WorkflowPhase>` was considered and dropped: no caller indexes phases (only `.length`/`.entries()`), so per the standards it's non-load-bearing type machinery.
- **`prompt-preprocessor.ts`**: replace `match[1] as string` and `outputs[i++] as string` with documented invariant throws.
- **`problem-details.ts`**: derive validation errors from `result.error.issues` directly; drop the `flattenError` round-trip and `messages as string[]` cast.
- **`orchestrator.ts`**: tighten tick-state to `Map<IssueKey, RunId[]>` and `Map<RepoSlug, Set<IssueKey>>`; drop the `i.key as string` widening.
- **`run-repository.ts`**: `getRunningSnapshot` narrows via a typed `filter` predicate instead of `as`.
- **`phase-runner.ts`**: validate `startPhaseIndex` against the configured phases at runtime — guards against drift between persisted DB state and a changed config. Covered by `phase-runner.test.ts`.
- **`jira.ts`**: `extractText` uses `in`-based narrowing.
- **`runner.ts`**: document the lone surviving `as RunEvent` cast (TS can't recombine the discriminated union through a spread).

Surviving documented `as` casts: brand constructors at trusted boundaries, `rowToRun`'s exhaustive switch tail, and `runner.ts` event spread.

Slice 5 (errors-as-values in API) was dropped — see `docs/typesafe-migration-plan.md` for rationale.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 252/252 passing
- [x] `pnpm test:coverage` — 100% across `server/` and `dashboard/`
- [x] `pnpm knip` — no unused exports/files/deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)