### PR TITLE
feat: add workflow.yaml for orchestrator

### DIFF
--- a/workflow.yaml
+++ b/workflow.yaml
@@ -1,0 +1,108 @@
+branch: "agent/issue-{{ issue.number }}"
+base_branch: main
+
+hooks:
+  after_create: |
+    git checkout -b agent/issue-{{ issue.number }}
+    if [ -f pnpm-lock.yaml ]; then
+      pnpm install --frozen-lockfile
+    elif [ -f yarn.lock ]; then
+      yarn install --frozen-lockfile
+    elif [ -f package-lock.json ]; then
+      npm ci
+    fi
+  before_run: |
+    git fetch origin main
+    git rebase origin/main
+  after_run: |
+    git push -u origin agent/issue-{{ issue.number }}
+
+phases:
+  - name: implement
+    prompt: |
+      # Task
+
+      Work on issue {{ issue.key }}: {{ issue.title }}
+
+      <issue-description>
+      {{ issue.description }}
+      </issue-description>
+
+      Only work on this one issue. The orchestrator created branch
+      `agent/issue-{{ issue.number }}` and rebased it on `origin/main` for you.
+      Make commits before finishing — the branch is pushed and a pull request
+      is opened by the orchestrator after the review phase completes.
+
+      # Project Context
+
+      Read `AGENTS.md` first if it exists, then `README.md`. Then read any
+      project docs relevant to the change, especially anything under `docs/`.
+
+      Recent commits:
+
+      <recent-commits>
+      !`git log -n 10 --format="%H%n%ad%n%B---" --date=short`
+      </recent-commits>
+
+      Top-level layout:
+
+      <repo-tree>
+      !`ls -1`
+      </repo-tree>
+
+      # Execution
+
+      1. Explore the implementation and tests before editing.
+      2. Keep the change as small as possible.
+      3. Add or update tests when behaviour changes.
+      4. Update docs when shipped behaviour, installation, usage, or document
+         structure changes.
+      5. Run the project's typecheck, test, and lint commands. Discover them
+         from `package.json` scripts or project docs — do not assume.
+      6. Commit the result with a Conventional Commit message
+         (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, or `test:`).
+
+      If you are blocked or the issue is incomplete, leave a clear final
+      message explaining the state and stop without committing speculative
+      work. Do not transition the issue yourself — the orchestrator owns
+      tracker state.
+
+  - name: review
+    prompt: |
+      # Task
+
+      Review the code changes on branch `agent/issue-{{ issue.number }}` for
+      issue {{ issue.key }}: {{ issue.title }}.
+
+      <issue-description>
+      {{ issue.description }}
+      </issue-description>
+
+      Diff against the target branch:
+
+      <diff>
+      !`git diff origin/main...HEAD`
+      </diff>
+
+      Commits on this branch:
+
+      <commits>
+      !`git log origin/main..HEAD --oneline`
+      </commits>
+
+      # Review Focus
+
+      Review for correctness, maintainability, test coverage, and fit with
+      project conventions (`AGENTS.md`, `CODING_STANDARDS.md`, anything under
+      `docs/coding-standards*` or `docs/adrs/`).
+
+      Check that:
+
+      - behaviour matches the issue
+      - tests cover meaningful changed behaviour
+      - typecheck, test, and lint all pass
+      - docs are updated when shipped behaviour changed
+
+      If you find issues, fix them directly on this branch and commit the
+      refinements with a Conventional Commit message. If the branch is
+      already good, make no changes.


### PR DESCRIPTION
## Summary
- Adds the project's first `workflow.yaml`, defining how every configured repo's issues get worked on.
- Mirrors the per-issue work `.sandcastle` did in `meridian.cli` (implement + review phases), but lets the orchestrator own the parts it already handles — issue selection, workspace creation, and PR opening.
- Branches use `agent/issue-{{ issue.number }}`; install is detected from the lockfile (`pnpm`/`yarn`/`npm`); `before_run` rebases on `origin/main`; `after_run` pushes the branch.

## Notes
- The implement prompt instructs the agent to discover typecheck/test/lint commands from `package.json` rather than hardcoding `npm run …`, so the same workflow is portable across configured repos.
- No `<promise>COMPLETE</promise>` sentinel — phases end naturally when the agent's session finishes; the runner has no completion-signal handling (matches Q2 in `docs/design-shell-expansion-and-integrations-decisions.md`).
- Branch naming and PR-title structure are open follow-ups; keeping them out of this PR.

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (workflow-loader/workflow tests still pass)
- [ ] Manual: orchestrator boots and loads `workflow.yaml` without parser errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)