### PR TITLE
docs: workflow-restructure design, ADR, and example workflows

### DIFF
--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pnpm install --frozen-lockfile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@ pnpm test                 # vitest across all projects
 | `dashboard/` | React + Vite dashboard UI with Tailwind                          |
 | `docs/`      | Architecture, patterns, and coding standards                     |
 
+## Project status
+
+Pre-launch and unstable. There are no real users, no production data, and no compatibility guarantees. Don't propose migrations, backfills, dual-read shims, deprecation paths, or "additive" designs to preserve existing state — just make the breaking change. Drop old rows, rename freely, change schemas in place.
+
 ## Before writing code
 
 - Read existing code in the area you're changing. Follow the patterns already there.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,103 @@
+# Context
+
+Glossary of terms used by domain experts working on local-agents. Implementation details belong in `docs/`, not here.
+
+## Terms
+
+### Step
+
+A unit of work inside a workflow run. Steps run in order. A step is one of:
+
+- **Action step** — runs a prompt, may modify the workspace, produces no structured output.
+- **Output step** — an action step that additionally declares an `output_schema` (raw JSON Schema). The Claude Agent SDK enforces the schema via `outputFormat: { type: "json_schema", schema }`, re-prompting the agent internally on mismatch. On exhaustion the SDK emits a `result` message with `subtype: "error_max_structured_output_retries"` and the orchestrator aborts the run. On success the validated value arrives as `result.structured_output`, is stored under the step's name on `RunContext.outputs`, persisted to `run_step_outputs`, and addressable by later steps as `{{ steps.<name>.output.<field> }}`.
+
+A workflow can mix both kinds. There is no separate "review" or "implement" kind — a review step is just an action step whose prompt asks the agent to inspect the diff and apply fixes directly.
+
+Outputs are pure data. They flow into later step prompts and into `change_request` templates. They never trigger the orchestrator to do something it wouldn't otherwise do, never reorder lifecycle pins, and never gate the run.
+
+### Branch
+
+First-class workflow-level field. Either a static template that interpolates `{{ issue.* }}`, or a dedicated branch-naming agent that proposes a name from the issue. In both forms, branch creation runs at clone-time, before any step.
+
+```yaml
+branch: "agent/issue-{{ issue.number }}"        # static
+# OR
+branch:
+  prompt: |
+    Propose a branch name for {{ issue.key }}: {{ issue.title }}.
+  schema:
+    type: object
+    properties:
+      name: { type: string, pattern: "^(feat|fix|chore)/" }
+    required: [name]
+```
+
+The dynamic form is for workflows that want a model-derived slug (e.g. `feat/AINENG-2310-state-clear-command`) rather than a mechanical template. It costs one extra agent call at clone-time. The SDK enforces the schema and re-prompts internally; on exhaustion the orchestrator aborts the run before any step fires.
+
+Branch is the only field whose action timing is structurally constrained (must exist before steps that write commits) — it gets its own first-class mechanism to avoid coupling that timing to step output flow. See ADR-0001.
+
+### Change request
+
+The platform-neutral term for a GitHub PR or GitLab MR. Already used in `code-hosts/types.ts`.
+
+The workflow configures two required fields under `change_request`, each a template that can interpolate `{{ issue.* }}`, `{{ attempt }}`, `{{ branch }}`, and `{{ steps.<name>.output.<field> }}`:
+
+- `change_request.title`
+- `change_request.body`
+
+Both are required; missing fields fail at workflow parse. No silent defaults. `labels`, `draft`, reviewers, assignees, and milestones are out of scope for V1; CODEOWNERS handles reviewer assignment on the platform side.
+
+`change_request` renders at end of run, after the last step. Because all step outputs exist by then, referencing outputs in these templates is just substitution from a fully-populated map — no timing inference involved.
+
+### Setup
+
+Repo-owned, not workflow-owned. The orchestrator looks for `.agent/setup.sh` in the cloned target repo and runs it once after clone, before any step. If the file is absent, no setup runs.
+
+This keeps workflow files repo-agnostic: the same workflow drives runs across many repos with different package managers and bootstrap requirements. Repo authors define their own bootstrap once, in their repo, and every workflow targeting that repo benefits.
+
+**Contract.** `.agent/setup.sh`:
+
+- Runs as `bash .agent/setup.sh` with the cloned repo as `cwd`.
+- Runs after `branch:` is created, so `git status` already shows the agent's branch.
+- Non-zero exit aborts the run before any step fires. The agent never sees a half-bootstrapped workspace.
+- stdout and stderr are captured to the canonical log alongside step output.
+- Should be idempotent — retries that reuse the workspace skip setup, but a fresh clone re-runs it.
+- Receives no tracker tokens, code-host credentials, or model API keys. If the script needs network access (e.g. private package registries), the credentials live in the orchestrator's repo registry and are passed as scoped env vars — not as ambient secrets.
+
+**Out of scope for `.agent/`.** Tracker selection, code-host selection, base-branch override, and model selection are per-repo concerns but live in the orchestrator's repo registry, not in the cloned tree. The `.agent/` directory is only for things the agent's runtime in the cloned workspace needs to know.
+
+`AGENTS.md` and `CLAUDE.md` keep their existing repo-root locations — they're prompt context, not orchestrator config.
+
+### Commit ownership
+
+The agent commits inside its step via `git commit` Bash calls. The orchestrator does not author commits; it only pushes the branch and opens the change request at end of run.
+
+### Lifecycle pins
+
+The orchestrator's actions fire at fixed points, in order:
+
+1. Clone repo into workspace.
+2. Resolve `branch:` template. Create branch.
+3. Run `.agent/setup.sh` from the target repo if present.
+4. Run steps in declared order. Each step has full Bash access in the workspace.
+5. Push branch.
+6. Render `change_request.*` templates. Open the change request.
+7. Transition tracker to `awaiting_review`.
+
+Step 6 sees all step outputs in scope; earlier pins don't. Any reference to `{{ steps.X.output.Y }}` from `change_request` is resolved at lifecycle pin 6 against the in-memory output map.
+
+### Output persistence
+
+Validated step outputs are persisted to the `run_step_outputs(run_id, step_name, output_json, created_at)` table when an output step succeeds, and held in-memory on `RunContext.outputs` for the lifetime of the run. They are also appended to the canonical log as observability events.
+
+When a retry skips a previously-completed step, the lifecycle hydrates `RunContext.outputs` from `run_step_outputs` for the parent run before invoking the step runner, so downstream step prompts and the change-request renderer can resolve references to skipped steps. The agent does not get a second chance to re-decide — re-deciding would silently invalidate downstream artefacts.
+
+### Static reference validation
+
+At workflow parse time, every `{{ steps.X.output.Y }}` reference (in step prompts and in `change_request` templates) is checked against:
+
+- A step named `X` must exist in `steps[]`.
+- For step prompts: step `X` must appear *earlier* than the referencing step (no forward references).
+- The dotted path after `output.` must resolve through step `X`'s `output_schema` (the validator walks `properties` and `items` so nested paths like `output.summary.title` are checked).
+
+Bad references fail at workflow load, not 20 minutes into a run.

--- a/docs/adr/0001-phase-outputs-and-fixed-lifecycle.md
+++ b/docs/adr/0001-phase-outputs-and-fixed-lifecycle.md
@@ -1,0 +1,21 @@
+# Step outputs are data; orchestrator owns lifecycle at fixed timings; branch is a first-class field
+
+The orchestrator runs lifecycle actions (branch creation, push, change-request open, tracker transition) at fixed pins. Step outputs are pure typed data: they flow into later step prompts and into `change_request` templates, but never reorder when the orchestrator does anything. Because `branch:` is the only field whose action timing is structurally constrained (it has to exist before any step that writes commits), it is lifted out of the step-output mechanism entirely and becomes a first-class workflow field that can be either a static template or a dedicated branch-naming agent — both forms run at clone-time.
+
+Repo-specific bootstrap (`pnpm install`, codegen warm, etc.) is owned by the target repo, not the workflow. The orchestrator runs `.agent/setup.sh` from the cloned repo if present. This keeps workflow files repo-agnostic so the same workflow drives runs across many repos.
+
+## Considered alternatives
+
+- **Inferred timing from output references** (orchestrator schedules each action right after the step that produces its referenced field). Rejected: the only field where action timing is structurally constrained is `branch:`. Building a generic dependency-graph scheduler to handle one structural case is complexity for a single use case.
+- **Explicit lifecycle pins in YAML** (workflow author interleaves `lifecycle: create_branch` lines between steps). Rejected: that is a small DSL with rules ("create_branch must precede any step that writes files") and adds YAML surface for no UX gain over the first-class `branch:` field.
+- **End-of-run-only branching** (clone, run all steps on `base_branch`, branch + commit + push at the end). Rejected: steps would run with `git status` showing them on `main`, surprising mid-run, and incompatible with workflows that want intermediate commits to be visible on the agent's branch.
+- **Sandcastle-style "agent owns git and gh"** (orchestrator is glue; LLM runs `git checkout`, `git push`, `gh pr create`). Rejected: incompatible with the platform-abstraction goal (`TrackerAdapter`/`CodeHostAdapter` for GitHub/GitLab/Jira), gives up validation and audit, and removes the retry/rollback hooks the orchestrator needs.
+- **Workflow-level `setup:` block** (bootstrap script lives in `workflow.yaml`). Rejected: the same workflow is meant to run across many repos with different package managers and bootstrap requirements. Putting setup in the workflow either forces one workflow per repo or pushes a brittle "if pnpm-lock else if yarn.lock" ladder into the config. Cursor (`.cursor/environment.json`), GitHub Copilot coding agent (`copilot-setup-steps.yml`), and OpenHands (`AGENTS.md`) all put bootstrap in the target repo for the same reason.
+
+## Consequences
+
+- The workflow file's surface stays small: `branch`, `change_request.{title,body,labels,draft}`, `steps[]`. Three user-facing concepts.
+- Repo-specific bootstrap is the repo author's job, defined once in `.agent/setup.sh` and reused across every workflow that targets the repo.
+- The orchestrator-side change is small: branch creation is unconditional at clone-time using static template substitution.
+- Adding new orchestrator actions later (e.g. attaching review comments, posting issue updates) means picking a fixed lifecycle pin and a templated source — no new mechanism needed.
+- Future demand for "step X gates the run if its output is bad" would be a deliberate departure from this ADR and should be recorded as a successor.

--- a/docs/design-workflow-restructure.md
+++ b/docs/design-workflow-restructure.md
@@ -1,0 +1,301 @@
+# Design: Workflow Restructure (Steps, Outputs, Branch Agent, Repo Setup)
+
+This document is the implementation-facing design for the workflow API restructure: renaming phases to steps, adding typed step outputs, lifting branch creation into a first-class field with optional dynamic naming, replacing workflow-level `hooks:` with target-repo `.agent/setup.sh`, and adding a templated `change_request:` block.
+
+The originating decisions are captured in [CONTEXT.md](../CONTEXT.md) and [adr/0001-phase-outputs-and-fixed-lifecycle.md](./adr/0001-phase-outputs-and-fixed-lifecycle.md). If there is a conflict, the ADR explains the rationale, but this file should describe the design to implement.
+
+The companion examples are [examples/static-branch.yaml](../examples/static-branch.yaml) and [examples/dynamic-branch.yaml](../examples/dynamic-branch.yaml).
+
+The execution plan and slice ledger live in [workflow-restructure-implementation-plan.md](./workflow-restructure-implementation-plan.md). This file describes *what* to build; the plan tracks *how* to slice and verify the work.
+
+## Motivation
+
+The current orchestrator runs multi-phase workflows where phases share a `prompt:` and optional shell expansion, but phase output is purely the agent's session state — there is no typed value that the next phase or the change-request template can read. Bootstrapping is wedged into a workflow-level `hooks:` block that bakes one repo's package manager into every workflow file, fighting the goal of one workflow driving runs across many repos. Branch naming is a bare template even when the right name needs the issue body, not just its number. And the change request gets opened with a hard-coded title/body shape that workflow authors cannot influence.
+
+The settled design replaces those four things at once because they share the same root cause: the workflow shape conflates "what the agent does" with "how the orchestrator runs the lifecycle". This restructure separates them:
+
+- **Steps** replace phases, with optional `output_schema` so a step can produce typed data. The name avoids collision with the SDK concept of "agent turn".
+- **Branch** becomes first-class with two forms: a static template, or a dedicated agent at clone-time.
+- **Change request** becomes a required, templated block with `{{ steps.X.output.Y }}` interpolation.
+- **Setup** moves out of `workflow.yaml` and into the target repo at `.agent/setup.sh`, so one workflow drives runs across heterogeneous repos.
+- **Lifecycle pins** stay orchestrator-owned at fixed timings; step outputs flow as data only.
+
+## Key Decisions
+
+| Topic | Decision |
+|---|---|
+| Workflow location | Unchanged. One global `./workflow.yaml` in this application repo. |
+| Phase terminology | Rename `phases` → `steps`. Each step is one agent invocation. Avoids confusion with the SDK concept of an agent turn. |
+| Single-prompt form | Remove. All workflows are a `steps:` array. A single-step array is the smallest valid workflow. |
+| Step outputs | Optional `output_schema` per step. Validated values are addressable as `{{ steps.<name>.output.<field> }}` in later step prompts and in `change_request` templates. |
+| Output gating | Outputs never gate the run. Step-level *errors* abort the run; step-level *values* do not. |
+| Schema validation retries | The Claude Agent SDK enforces the schema and re-prompts internally. On exhaustion the SDK emits a `result` message with `subtype: "error_max_structured_output_retries"`; the orchestrator surfaces this as `step.failed` and aborts the run. Retry count is not configurable in the public SDK API. |
+| Branch field | First-class. Static template, or dedicated branch-naming agent with `prompt:` and `schema:`. Both forms run at clone-time, before setup. |
+| Change request | Required block with `title` and `body` only. Both are templates and both are required at parse time. Rendered at end of run. `labels` and `draft` are out of scope for V1. |
+| Setup location | Repo-owned at `.agent/setup.sh` in the cloned target repo. Workflow-level `hooks:` block is removed. |
+| Lifecycle pins | Fixed sequence: clone → branch → setup → steps → push → change request → tracker. |
+| Output persistence | New `run_step_outputs(run_id, step_name, output_json, created_at)` table. Written when a step's `outputFormat` returns a validated value. Loaded into `RunContext.outputs` on retry so previously-completed steps are skipped and their outputs reused. Also appended to the canonical log as observability events. |
+| Retry on resume | A retry skips previously-completed steps and reuses their stored outputs from `run_step_outputs`. The agent does not re-decide. |
+| Static reference validation | Every `{{ steps.X.output.Y }}` reference is validated at workflow parse — bad references fail at load, not 20 minutes into a run. |
+| Commit ownership | Unchanged. The agent commits inside its step. The orchestrator pushes and opens the change request. |
+
+## Configuration Model
+
+`config.yaml` is **unchanged** by this restructure. `tracker`, `code_host`, and `defaults` keep their current shapes.
+
+## Global Workflow
+
+The new `workflow.yaml` shape:
+
+```yaml
+branch: "agent/issue-{{ issue.number }}"        # static
+# OR
+branch:
+  prompt: |
+    Propose a branch name for {{ issue.key }}: {{ issue.title }}.
+  schema:
+    type: object
+    properties:
+      name: { type: string, pattern: "^(feat|fix|chore)/" }
+    required: [name]
+
+base_branch: main
+
+steps:
+  - name: implement
+    prompt: |
+      Work on {{ issue.key }}: {{ issue.title }}.
+      !`git log --oneline -5`
+
+  - name: summarise
+    prompt: |
+      Summarise the change for reviewers.
+      !`git diff main...HEAD`
+    output_schema:
+      type: object
+      properties:
+        title: { type: string }
+        body: { type: string }
+      required: [title, body]
+
+change_request:
+  title: "{{ steps.summarise.output.title }}"
+  body: |
+    Closes {{ issue.key }}: {{ issue.title }}.
+
+    {{ steps.summarise.output.body }}
+```
+
+The top-level `prompt:` form, the `phases:` key, and the `hooks:` block are removed. Workflows that previously used a single `prompt:` become a one-element `steps:` array. Workflows that used `hooks:` move bootstrap into the target repo's `.agent/setup.sh`.
+
+Workflow loading remains a one-shot local file load at startup via `server/workflow/workflow-loader.ts`. Restarting the orchestrator is required to pick up workflow file changes.
+
+## 1. Steps
+
+### What
+
+A step is one Claude Agent SDK `query()` invocation with a rendered prompt. Two kinds:
+
+- **Action step** — `name`, `prompt`, optional `resume_previous`. Modifies the workspace, may commit, produces no structured output.
+- **Output step** — an action step with an additional `output_schema` (raw JSON Schema). The SDK enforces the schema via `outputFormat: { type: "json_schema", schema }` and re-prompts internally on mismatch. The validated value is stored under the step's name on `RunContext.outputs` and persisted to `run_step_outputs`.
+
+A workflow can mix both kinds. There is no separate "review" or "implement" *kind* — review is just an action step whose prompt asks the agent to inspect the diff and apply fixes directly.
+
+### Templating
+
+Output values are addressable in later step prompts and in `change_request` templates as `{{ steps.<name>.output.<field> }}`. Field paths may be nested (`{{ steps.summarise.output.summary.title }}`). Scalars render as-is; nested objects and arrays render as `JSON.stringify(value)`. Output references are pure substitution — they do not reorder lifecycle pins, gate the run, or trigger orchestrator side effects.
+
+### Execution
+
+For each step:
+
+1. Render variables (`{{ issue.* }}`, `{{ attempt }}`, `{{ branch }}`, `{{ steps.X.output.Y }}`).
+2. Expand shell blocks (`!`...``).
+3. Run the agent with `query()`. If the step declares `output_schema`, pass it as `outputFormat`.
+4. Consume messages. Capture `session_id` from `assistant` messages. When the SDK emits a `result` message:
+   - `subtype === "success"` with `structured_output` → store under `RunContext.outputs[name]`, persist a row to `run_step_outputs`, append a canonical log event.
+   - `subtype === "error_max_structured_output_retries"` → emit `step.failed`, abort the run.
+5. Emit `step.started` / `step.completed` / `step.failed` markers (renamed from `phase.*`).
+
+By default each step starts a fresh session. `resume_previous: true` carries over from the existing implementation and is unchanged.
+
+### Retry
+
+Retries skip previously-completed steps and reuse their stored outputs. The agent does not re-decide. This matches the existing phase-skip behaviour, just under the new name.
+
+Persist `stepIndex` alongside the run's `sessionId` (renamed from `phaseIndex`). On retry, the lifecycle loads `run_step_outputs` for the parent run into `RunContext.outputs` before invoking the step runner so later steps and the change-request renderer can resolve references to skipped steps. For single-step workflows, `stepIndex` remains `0`.
+
+### Implementation
+
+| File | Role |
+|---|---|
+| `server/orchestrator/phase-runner.ts` → `step-runner.ts` | Rename. Add `output_schema` support: pass to SDK as `outputFormat`, branch on terminal `result` subtype, persist validated value on success, abort on `error_max_structured_output_retries`. |
+| `server/orchestrator/agent-invoker.ts` | Add optional `outputFormat` to `AgentInvokeOptions`; thread through to `query()`. |
+| `server/orchestrator/run-lifecycle.ts` | Update lifecycle markers (`phase.*` → `step.*`). Hold an in-memory `outputs` map on `RunContext`. On retry, hydrate the map from `run_step_outputs` before invoking the step runner. |
+| `server/workflow/workflow.ts` | Replace `phases` schema with `steps`. Remove top-level `prompt:` form. Add optional `output_schema` per step. Extend `renderPrompt` to substitute `{{ steps.X.output.Y }}` (including nested paths) against an outputs map. |
+| `server/workflow/workflow-loader.ts` | Static reference validation (see section 5). |
+| `server/db/schema.ts` | Rename `runs.phase_index` → `runs.step_index`. Add `run_step_outputs(run_id, step_name, output_json, created_at)` with PK on `(run_id, step_name)`. Rename event-type literals (`phase.*` → `step.*`); historic rows keep their old type strings — no backfill. |
+
+## 2. Branch
+
+### What
+
+Branch is a first-class workflow field with two forms.
+
+**Static template.** Same as today — a string with `{{ issue.* }}` interpolation, rendered at clone-time.
+
+```yaml
+branch: "agent/issue-{{ issue.number }}"
+```
+
+**Dynamic agent.** A dedicated agent at clone-time that proposes the branch name from the issue. The agent receives the issue and emits a value validated against the declared `schema`.
+
+```yaml
+branch:
+  prompt: |
+    Propose a branch name for {{ issue.key }}: {{ issue.title }}.
+  schema:
+    type: object
+    properties:
+      name: { type: string, pattern: "^(feat|fix|chore)/[A-Z]+-[0-9]+-[a-z0-9-]+$" }
+    required: [name]
+```
+
+The dynamic form costs one extra agent call at clone-time. The SDK enforces the schema and re-prompts internally; on exhaustion it emits `result` with `subtype: "error_max_structured_output_retries"` and the orchestrator aborts the run before any step fires.
+
+### Execution
+
+Branch creation runs at lifecycle pin 2: after clone, before setup, before any step.
+
+For the static form, render the template and `git checkout -b` the result.
+
+For the dynamic form:
+
+1. Render the prompt against the issue.
+2. Run a single `query()` with `outputFormat: { type: "json_schema", schema }`.
+3. Branch on the terminal `result` subtype. On `success`, take `structured_output.name`. On `error_max_structured_output_retries`, abort the run.
+4. `git checkout -b <validated-name>`.
+5. Store the resolved name on `RunContext.branch` so later step prompts and `change_request` templates can reference `{{ branch }}`.
+
+### Implementation
+
+| File | Role |
+|---|---|
+| `server/workflow/workflow.ts` | Accept either `string` or `{ prompt, schema }` for `branch`. |
+| `server/orchestrator/orchestrator.ts` | Branch resolution path (string vs object). For the agent form, invoke `agent-invoker.ts` once at clone-time with `outputFormat`. |
+| `server/orchestrator/workspace.ts` | `git checkout -b <name>` after resolution. |
+
+## 3. Change Request
+
+### What
+
+A required workflow-level block defining the PR/MR opened at end of run.
+
+```yaml
+change_request:
+  title: "{{ steps.summarise.output.title }}"
+  body: |
+    Closes {{ issue.key }}: {{ issue.title }}.
+    {{ steps.summarise.output.body }}
+```
+
+Both fields are required. Missing fields fail at workflow parse — no silent defaults. `labels`, `draft`, reviewers, assignees, and milestones are out of scope for V1; CODEOWNERS handles reviewer assignment on the platform side.
+
+### Execution
+
+`change_request` renders at lifecycle pin 6, after the last step and before the tracker transition. Because all step outputs exist by then (either freshly captured in this process or hydrated from `run_step_outputs` on retry), referencing `{{ steps.X.output.Y }}` is straightforward substitution from a fully-populated map — there is no timing inference.
+
+The `CodeHostAdapter.createChangeRequest()` signature is unchanged.
+
+### Implementation
+
+| File | Role |
+|---|---|
+| `server/workflow/workflow.ts` | Add required `change_request` schema (`title`, `body`). |
+| `server/orchestrator/change-request-renderer.ts` | New module. Renders `title` and `body` against the merged context (`issue`, `attempt`, `branch`, `steps.*.output.*`). |
+| `server/orchestrator/run-lifecycle.ts` | Call `change-request-renderer` at lifecycle pin 6 and pass the rendered values to `codeHost.createChangeRequest`. |
+
+## 4. Repo Setup
+
+### What
+
+Repo-specific bootstrap (`pnpm install`, codegen, etc.) lives in the target repo, not the workflow. The orchestrator runs `.agent/setup.sh` from the cloned repo if it exists. If absent, no setup runs.
+
+This keeps `workflow.yaml` repo-agnostic. The same workflow drives runs across many repos with different package managers and bootstrap requirements.
+
+### Contract
+
+`.agent/setup.sh`:
+
+- Executes as `bash .agent/setup.sh` with the cloned repo as `cwd`.
+- Runs at lifecycle pin 3, after the branch is created. `git status` shows the agent's branch.
+- Non-zero exit aborts the run before any step fires.
+- stdout and stderr are captured to the canonical log.
+- Should be idempotent. Retries that reuse the workspace skip setup; a fresh clone re-runs it.
+- Receives no tracker tokens, code-host credentials, or model API keys.
+
+### What is removed
+
+The workflow-level `hooks: { after_create, before_run, after_run }` block is removed. Migration:
+
+- `after_create` content moves to `.agent/setup.sh` in each target repo.
+- `before_run` and `after_run` content has no replacement. If a workflow author needs pre-step or post-step behaviour, they express it as a shell block (`` !`...` ``) in the relevant step's prompt.
+
+### Implementation
+
+| File | Role |
+|---|---|
+| `server/orchestrator/workspace.ts` | After branch creation, check for `.agent/setup.sh`. If present, execute with bash, fail-fast on non-zero exit. |
+| `server/orchestrator/run-lifecycle.ts` | Insert setup at lifecycle pin 3 between branch creation and the first step. Remove the legacy hooks invocations. |
+| `server/workflow/workflow.ts` | Remove `hooks` from the workflow schema. |
+
+## 5. Static Reference Validation
+
+### What
+
+At workflow parse time, every `{{ steps.X.output.Y }}` reference (in step prompts and in `change_request` templates) is validated:
+
+- A step named `X` must exist in `steps[]`.
+- For step prompts: step `X` must appear *earlier* than the referencing step (no forward references).
+- The dotted path after `output.` must resolve through step `X`'s `output_schema`. Validation walks the schema's `properties` tree (and `items` for arrays), so `{{ steps.summarise.output.summary.title }}` is checked against `properties.summary.properties.title`.
+
+Bad references fail at workflow load, not 20 minutes into a run.
+
+`change_request` references are not subject to the forward-reference rule because all steps have completed by the time `change_request` renders.
+
+### Execution
+
+Run after schema validation succeeds, before `loadWorkflow()` returns. Errors include the file path, the offending reference, and the reason (unknown step, forward reference, unknown field).
+
+### Implementation
+
+| File | Role |
+|---|---|
+| `server/workflow/workflow-loader.ts` | After schema parse, walk every prompt string and `change_request` template, extract `{{ steps.X.output.Y... }}` references, walk the referenced step's `output_schema` to confirm the dotted path resolves. |
+
+## Implementation Order
+
+Implement foundation refactors first, then features. This minimises churn — the rename and removals settle the surface before new functionality is added.
+
+1. **Foundation PR** — rename `phases` → `steps` across `server/`, `dashboard/`, `db/schema.ts`, and tests; rename `runs.phase_index` → `runs.step_index`; remove top-level `prompt:` form; remove `hooks:` block and add `.agent/setup.sh` invocation at lifecycle pin 3; add `run_step_outputs` table. No new behaviour, no backfill of historic event-type rows.
+2. **Change request block** — add required `change_request: { title, body }` schema, the `change-request-renderer.ts` module, and lifecycle pin 6 wiring. Templating supports `{{ issue.* }}`, `{{ attempt }}`, `{{ branch }}` only at this point — output substitution lands in step 4.
+3. **Output steps** — extend `AgentInvokeOptions` with `outputFormat`; teach `step-runner.ts` to consume the terminal `result` message, persist on success, abort on `error_max_structured_output_retries`; hydrate `RunContext.outputs` from `run_step_outputs` on retry.
+4. **Output substitution** — extend `renderPrompt` to handle `{{ steps.X.output.Y... }}` (including nested paths) against the outputs map. Wire it into both step prompts and the change-request renderer.
+5. **Dynamic branch agent** — branch field accepts string or `{ prompt, schema }`; agent form invokes the same SDK path as output steps.
+6. **Static reference validation** — walk prompts and change-request templates after schema parse; validate dotted paths against the relevant step's `output_schema`.
+
+## Deferred Items
+
+These are intentionally out of scope until a real consumer need appears:
+
+- alternative agent runtimes (codex, aider, etc.) — Claude Agent SDK only for V1
+- alternative sandboxes — current workspace model only
+- per-step wall-clock timeout override
+- output gating (a step declaring its output blocks the run if invalid)
+- per-repo workflow override
+- workflow file watch or reload without restart
+- a `completion_signal` sentinel (Sandcastle-style early exit)
+- branch-name conflict resolution when the agent proposes an already-existing branch
+- `change_request` updates on retry vs always opening fresh
+- `change_request.labels` and `change_request.draft` (hardcoded in the code-host adapter for V1)
+- per-invocation tool scoping for the branch agent (currently inherits the step agent's tool set)

--- a/docs/workflow-restructure-implementation-plan.md
+++ b/docs/workflow-restructure-implementation-plan.md
@@ -1,0 +1,499 @@
+# Living Implementation Plan: Workflow Restructure
+
+This is the execution plan for [design-workflow-restructure.md](./design-workflow-restructure.md) and the originating [adr/0001-phase-outputs-and-fixed-lifecycle.md](./adr/0001-phase-outputs-and-fixed-lifecycle.md). The design doc describes what to build; this plan tracks how to slice and verify the work.
+
+Keep this document current as implementation proceeds. When a slice starts, update its status. When scope changes, update the slice before changing code. When a slice completes, record the verification commands that passed and any deferred follow-up.
+
+## Status Key
+
+| Status | Meaning |
+|---|---|
+| Not started | No implementation work has begun. |
+| In progress | Code is being changed for this slice. |
+| Blocked | Work cannot continue without a decision or prerequisite. |
+| Ready for review | Code and tests are complete; final checks passed. |
+| Done | Reviewed and merged. |
+
+## Global Quality Gates
+
+Every implementation slice must preserve the existing repo standards:
+
+- Read the code and tests in the area before editing. Existing test helpers are the conventions.
+- Keep the slice small enough to review independently.
+- Update docs in the same slice when behaviour or config changes.
+- Add or update focused tests in the same layer as the behaviour being changed.
+- Keep GitHub-only behaviour working unless the slice explicitly changes it.
+- Do not leave compatibility gaps between workflow schema, server startup, orchestrator behaviour, dashboard assumptions, db schema, and docs.
+- Run `pnpm lint`, `pnpm typecheck`, and `pnpm test` before marking a slice ready for review.
+- Run `pnpm test:coverage` before the first slice starts and after feature slices that add behaviour. Coverage should stay level or improve.
+- Run narrower tests while iterating, but do not use narrow tests as the final gate.
+
+Recommended final verification block for every slice:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+```
+
+Coverage checkpoint:
+
+```bash
+pnpm test:coverage
+```
+
+## Operating Model
+
+This work should not be implemented as one long-running session. Use the plan as a sequence of independently reviewable slices.
+
+Recommended workflow:
+
+1. Create one branch per slice.
+2. Keep only one implementation slice in progress on a branch at a time.
+3. Commit each slice when its quality gates pass.
+4. Update this plan before and after implementation work in the same branch.
+5. Open or review each slice independently before starting dependent slices.
+
+Branch naming convention:
+
+```text
+plan/restructure-slice-00-baseline
+plan/restructure-slice-01-foundation
+plan/restructure-slice-02-change-request
+plan/restructure-slice-03-output-steps
+plan/restructure-slice-04-output-substitution
+plan/restructure-slice-05-dynamic-branch
+plan/restructure-slice-06-static-validation
+```
+
+Commit strategy:
+
+- Commit at the end of each slice after `pnpm lint`, `pnpm typecheck`, and `pnpm test` pass.
+- Prefer one clean commit per slice unless the slice is large enough to justify multiple reviewable commits.
+- Do not commit half-passing work unless intentionally creating a checkpoint branch for handoff.
+- If a context window is getting tight, stop at a clean boundary: update the slice progress notes, record failing/passing commands, and commit only if the work is coherent.
+
+Parallelism:
+
+- Slices 1, 2, 3, and 4 should be done sequentially because they reshape the workflow schema, the lifecycle, and the runner together. Slice 4 needs slice 3's outputs map to do anything observable.
+- Slice 5 (dynamic branch) depends on slice 3's `outputFormat` plumbing in `agent-invoker.ts` but is otherwise independent of slice 4.
+- Slice 6 (static validation) depends on slice 4 — the references it validates only exist in the schema once output substitution is wired.
+- Slices 5 and 6 can run in parallel after slice 4 lands.
+
+## Progress Discipline
+
+Every implementation thread should update this document. Treat it as the project ledger, not just a plan.
+
+When starting a slice:
+
+- Change `Status` from `Not started` to `In progress`.
+- Add a short `Started` note with date and branch.
+
+When pausing a slice:
+
+- Leave the status as `In progress` or `Blocked`.
+- Add a `Progress notes` subsection with what changed, what remains, and exact verification status.
+- Record any failing command output in summary form, not as a large pasted log.
+
+When completing a slice:
+
+- Change `Status` to `Ready for review`.
+- Add a `Completed changes` subsection.
+- Add a `Verification` subsection listing the exact commands that passed.
+- After merge, change `Status` to `Done`.
+
+Use this handoff template when a slice is interrupted:
+
+```markdown
+**Progress notes:**
+
+- Branch:
+- Files changed:
+- Completed:
+- Remaining:
+- Verification:
+- Known risks:
+```
+
+## Slice 0 — Baseline And Planning Hygiene
+
+**Status:** Not started
+
+**Purpose:** Establish the baseline before code changes and make sure design + glossary + examples agree.
+
+**Scope:**
+
+- Confirm [design-workflow-restructure.md](./design-workflow-restructure.md) is the implementation spec and [adr/0001-phase-outputs-and-fixed-lifecycle.md](./adr/0001-phase-outputs-and-fixed-lifecycle.md) is the rationale trail.
+- Confirm [CONTEXT.md](../CONTEXT.md) glossary matches the design.
+- Confirm [examples/static-branch.yaml](../examples/static-branch.yaml) and [examples/dynamic-branch.yaml](../examples/dynamic-branch.yaml) reflect the trimmed `change_request` shape (no `labels`, no `draft`).
+- Decide what the live `workflow.yaml` at the repo root should be. The loader hardcodes `workflow.yaml`; without one, `pnpm dev` fails. Pin a starting workflow (likely a copy of `examples/static-branch.yaml` adapted to the repo's current behaviour) so subsequent slices can run end-to-end.
+- Record baseline coverage before implementation begins.
+
+**Tests:**
+
+- No new tests; this slice is documentation + workflow.yaml + coverage capture only.
+
+**Quality gates:**
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:coverage` — record the numbers in `Completed changes` for comparison after each feature slice.
+- `rg -n 'labels:|draft:' docs/design-workflow-restructure.md CONTEXT.md examples/*.yaml` returns nothing (or only intentional references).
+- A live `workflow.yaml` exists at the repo root and `pnpm dev` boots without an immediate workflow load failure.
+
+**Risks:**
+
+- The `examples/*.yaml` files reference output substitution and dynamic branch features that don't exist yet. The live `workflow.yaml` must use only features supported by the *current* code (single-prompt or phases, static branch, no `change_request` block) — not the post-restructure shape — until slice 2 lands. Be explicit about this; it's the easiest place to break the dev loop.
+
+## Slice 1 — Foundation
+
+**Status:** Not started
+
+**Purpose:** Settle the surface before adding new behaviour. Rename phases → steps, remove the top-level `prompt:` and `hooks:` forms, add `.agent/setup.sh` invocation, and add the `run_step_outputs` table without yet writing to it.
+
+**Scope:**
+
+- Rename `phases` → `steps` across `server/`, `dashboard/`, `db/schema.ts`, and tests.
+- Rename `runs.phase_index` → `runs.step_index` (Drizzle migration; no backfill of historic event-type strings).
+- Rename `RunEventType` literals `phase.started` / `phase.completed` / `phase.failed` → `step.started` / `step.completed` / `step.failed`. Historic `run_events` rows keep their old type strings — no backfill, dashboard renders both for as long as old rows exist or stops rendering them entirely (decide in this slice; document the call).
+- Rename `server/orchestrator/phase-runner.ts` → `step-runner.ts`. No new behaviour in the runner itself this slice; output schema lands in slice 3.
+- Remove the top-level `prompt:` form from the workflow schema. Every workflow is a `steps:` array; a single-step array is the smallest valid workflow.
+- Remove the `hooks: { after_create, before_run, after_run }` block from the workflow schema. Remove all hook invocations from `run-lifecycle.ts` and `workspace.ts`.
+- Add `.agent/setup.sh` invocation at lifecycle pin 3 (after branch creation, before the first step). Run as `bash .agent/setup.sh` in the cloned repo's cwd. Non-zero exit aborts the run before any step fires. Capture stdout/stderr to the canonical log. No script → no setup runs.
+- Add `run_step_outputs(run_id, step_name, output_json, created_at)` table with PK `(run_id, step_name)` and a Drizzle migration. No writes from this slice; the schema is staged for slice 3.
+
+**Natural code areas:**
+
+- `server/workflow/workflow.ts`
+- `server/workflow/workflow-loader.ts`
+- `server/orchestrator/phase-runner.ts` → `step-runner.ts`
+- `server/orchestrator/run-lifecycle.ts`
+- `server/orchestrator/workspace.ts`
+- `server/orchestrator/orchestrator.ts`
+- `server/event-bus.ts`
+- `server/db/schema.ts`
+- `server/db/` migration files
+- `server/run-repository.ts`
+- `dashboard/` references to `phase.*`
+- `examples/*.yaml` (already aligned, but verify)
+- Live `workflow.yaml` (must convert to `steps:` shape)
+
+**Tests:**
+
+- Workflow parse rejects top-level `prompt:` form.
+- Workflow parse rejects `hooks:` block.
+- Workflow parse rejects `phases:` key (must be `steps:`).
+- Workflow parse accepts a one-element `steps:` array.
+- Lifecycle runs `.agent/setup.sh` from the cloned repo when present.
+- Lifecycle skips setup when `.agent/setup.sh` is absent.
+- Lifecycle aborts the run when `.agent/setup.sh` exits non-zero, and emits no `step.started` event.
+- `step.started` / `step.completed` / `step.failed` events are emitted with the same shape as the old `phase.*` events.
+- `runs.step_index` column is written on each step boundary.
+- `run_step_outputs` table exists in the schema (assert via Drizzle introspection or migration test).
+- Existing GitHub-only orchestration tests still pass under the renamed surface.
+
+**Quality gates:**
+
+- No production code references `phase` (search for `phase` in `server/` and `dashboard/`, ignoring historic event type literals if intentionally preserved).
+- No production code references `hooks` from the workflow schema.
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:coverage` — should match or exceed the slice 0 baseline.
+
+**Risks:**
+
+- The rename + removals + setup wiring is a wide blast radius. Resist the urge to ship as one mega-PR with no boundaries; if review feedback piles up, split into "rename only" + "remove hooks + add setup.sh" + "rename db column + add table" sub-PRs against this branch.
+- The dashboard event-type rename is easy to miss. Check `dashboard/` for any literal `"phase.started"` strings.
+- `RunEventType` is an exported type union — downstream code may switch on it exhaustively. Update every switch site or accept TS errors as the audit trail.
+- The Drizzle migration for the `phase_index` rename is destructive on local sqlite dbs; remind devs to wipe their local db or run the migration cleanly.
+- `RunContext` has `setPhaseIndex` — this name needs renaming too, alongside any retry path that reads `failedRun.phaseIndex`.
+
+## Slice 2 — Change Request Block
+
+**Status:** Not started
+
+**Purpose:** Replace the hardcoded PR title (`issue.title`) and body (`Closes ${issue.key}`) in `finalizeSuccess` with a templated `change_request: { title, body }` block from the workflow.
+
+**Scope:**
+
+- Add required `change_request: { title: string, body: string }` to the workflow schema. Both fields required at parse; missing fields fail at workflow load with a clear error.
+- Add `server/orchestrator/change-request-renderer.ts`. Renders `title` and `body` against the merged context: `{ issue, attempt, branch }`. Output substitution lands in slice 4 — this slice intentionally does not add `{{ steps.*.output.* }}` support yet.
+- Reuse `renderPrompt` from `server/workflow/workflow.ts` for variable interpolation; do not duplicate the substitution logic.
+- Wire the renderer into `run-lifecycle.ts` at lifecycle pin 6 (`finalizeSuccess`). Pass the rendered values to `codeHost.createChangeRequest`. The adapter signature is unchanged.
+- Update the live `workflow.yaml` to include a `change_request` block (using only `{{ issue.* }}` and `{{ branch }}` interpolations for now).
+- Documentation in `README.md` / `docs/architecture.md` if either currently describes the hardcoded PR shape.
+
+**Natural code areas:**
+
+- `server/workflow/workflow.ts`
+- `server/workflow/workflow-loader.ts`
+- `server/orchestrator/change-request-renderer.ts` (new)
+- `server/orchestrator/run-lifecycle.ts`
+- `server/orchestrator/__tests__/*`
+- `server/workflow/__tests__/*`
+- Live `workflow.yaml`
+
+**Tests:**
+
+- Workflow parse rejects missing `change_request`.
+- Workflow parse rejects `change_request` missing `title`.
+- Workflow parse rejects `change_request` missing `body`.
+- Workflow parse accepts a complete `change_request` block.
+- Renderer substitutes `{{ issue.key }}`, `{{ issue.title }}`, `{{ attempt }}`, `{{ branch }}` in both `title` and `body`.
+- Renderer preserves multi-line bodies and markdown formatting.
+- Lifecycle calls `codeHost.createChangeRequest` with the rendered values, not the old hardcoded ones.
+- Static branch workflows produce a `{{ branch }}` value the renderer can read.
+
+**Quality gates:**
+
+- `finalizeSuccess` no longer hardcodes `issue.title` or `Closes ${issue.key}`.
+- The renderer is a pure function (input → string) — no side effects, no I/O. Easy to unit test.
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:coverage` — should match or exceed the slice 1 baseline.
+
+**Risks:**
+
+- Making `change_request` required will break any local `workflow.yaml` that doesn't have one. Update the live file in the same PR.
+- The renderer needs a `branch` value at lifecycle pin 6 — confirm `RunContext.branch` is set by branch creation in slice 1's foundation work, otherwise either set it here or note the gap.
+- If `body` references a variable that doesn't exist (e.g. `{{ issue.foo }}`), `renderPrompt` currently returns empty string. That's consistent but silent — the slice 6 validator catches `{{ steps.* }}` issues, but generic typo'd variables stay silent. Acceptable for V1; flag if it becomes a problem.
+
+## Slice 3 — Output Steps
+
+**Status:** Not started
+
+**Purpose:** Add `output_schema` to step definitions, plumb `outputFormat` through to the SDK, capture validated outputs, persist them, and hydrate them on retry.
+
+**Scope:**
+
+- Add optional `output_schema` (raw JSON Schema) to the step schema in `workflow.ts`.
+- Extend `AgentInvokeOptions` in `agent-invoker.ts` with optional `outputFormat`. Thread through to `query()`.
+- Teach `step-runner.ts` to consume the SDK's terminal `result` message:
+  - `msg.type === "result" && msg.subtype === "success"` → store `msg.structured_output` on `RunContext.outputs[step.name]`, persist a row to `run_step_outputs`, append a canonical log event.
+  - `msg.type === "result" && msg.subtype === "error_max_structured_output_retries"` → emit `step.failed` with the SDK's error subtype, abort the run.
+- Add `RunContext.outputs: Record<string, unknown>` and a setter on the runner.
+- Add `RunRepository` methods to write and read `run_step_outputs` rows (write keyed by `(runId, stepName)`; read by `runId` returns the full map).
+- On retry in `run-lifecycle.ts`, hydrate `RunContext.outputs` from the *parent* run's `run_step_outputs` rows before invoking `runWorkflowSteps`. The retry creates a new `runId`; reads come from `parentRunId`.
+- A canonical log event type for validated outputs (`step.output` or similar). Decide the shape; keep the structured value's size in mind.
+
+**Natural code areas:**
+
+- `server/workflow/workflow.ts`
+- `server/orchestrator/agent-invoker.ts`
+- `server/orchestrator/step-runner.ts`
+- `server/orchestrator/run-lifecycle.ts`
+- `server/runner/runner.ts`
+- `server/run-repository.ts`
+- `server/db/schema.ts` (already added in slice 1; this slice writes to it)
+- `server/canonical-log.ts`
+- `server/orchestrator/__tests__/*`
+- `server/workflow/__tests__/*`
+
+**Tests:**
+
+- Action step (no `output_schema`) behaves unchanged — no `outputFormat` passed to invoker, no `run_step_outputs` row written.
+- Output step passes `outputFormat: { type: "json_schema", schema }` to invoker.
+- On `result.subtype === "success"`, validated value is on `RunContext.outputs[name]`.
+- On `result.subtype === "success"`, a row is written to `run_step_outputs` with `(runId, stepName, output_json)`.
+- On `result.subtype === "error_max_structured_output_retries"`, `step.failed` is emitted with the error subtype as the error message and the run aborts (subsequent steps do not start).
+- Retry of a run that previously completed step `summarise` hydrates `RunContext.outputs.summarise` from the parent's `run_step_outputs` row before any step fires.
+- Retry of a run whose failure was the output step itself does *not* skip that step — it re-runs from the failed step (existing retry semantics).
+- Mixed action + output steps in one workflow work end-to-end.
+
+**Quality gates:**
+
+- The mock `AgentInvoker` used in tests must be able to emit a `result` message (not just `assistant` messages). Update test helpers if needed.
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:coverage` — feature slice; coverage should rise.
+
+**Risks:**
+
+- The exact terminal-message contract (does the SDK *always* emit a `result` message at end of stream when `outputFormat` is set? what about on caller-side abort via signal?) needs to be confirmed against the live SDK, not just the docs. Write a smoke test that invokes the real SDK against a trivial schema if practical.
+- Hydration on retry is the bug magnet of this slice. Easy failure mode: new runId reads its own (empty) outputs instead of the parent's. Test specifically for retry-skip-and-substitute behaviour, not just "outputs are persisted".
+- `output_json` size: structured outputs can be large (the SDK example `todoSchema` returns an array). Sqlite TEXT handles it, but consider whether to log the full value to the canonical log or just a checksum / first-N-chars summary.
+- `RunContext.outputs` is shared between fresh runs and resumed runs; the type signature must reflect that it can be partially populated.
+
+## Slice 4 — Output Substitution
+
+**Status:** Not started
+
+**Purpose:** Make `{{ steps.X.output.Y }}` (including nested paths) resolve in step prompts and in `change_request` templates against the in-memory outputs map.
+
+**Scope:**
+
+- Extend `renderPrompt` in `server/workflow/workflow.ts` to accept an `outputs` parameter (`Record<string, unknown>`) and resolve dotted paths starting with `steps.<name>.output.`. The existing variable interpolation (`issue.*`, `attempt`, `branch`) keeps working unchanged.
+- Nested paths walk through objects and array indices. Scalars render as-is via `String(value)`. Nested objects and arrays render as `JSON.stringify(value)`.
+- Missing references render as empty string (consistent with existing behaviour); slice 6's validator is the safety net.
+- Wire the outputs map into both call sites:
+  - `step-runner.ts` passes the current `RunContext.outputs` snapshot to `renderPrompt` for each step.
+  - `change-request-renderer.ts` passes the final `RunContext.outputs` to `renderPrompt` for `title` and `body`.
+- Add a regression test for re-rendering safety: an output value that contains `{{ ... }}` substrings does *not* trigger a second pass of substitution (single-pass replace is current behaviour; lock it in).
+
+**Natural code areas:**
+
+- `server/workflow/workflow.ts` (`renderPrompt`)
+- `server/orchestrator/step-runner.ts`
+- `server/orchestrator/change-request-renderer.ts`
+- `server/workflow/__tests__/*`
+
+**Tests:**
+
+- `{{ steps.foo.output.title }}` resolves to the scalar value from `outputs.foo.title`.
+- Nested `{{ steps.foo.output.summary.title }}` resolves through `outputs.foo.summary.title`.
+- Object value at the referenced path renders as `JSON.stringify(value)`.
+- Array value at the referenced path renders as `JSON.stringify(value)`.
+- Missing step reference renders as empty string.
+- Missing field reference renders as empty string.
+- Output value containing literal `{{ issue.key }}` is *not* re-substituted (single-pass).
+- `change_request.title` substitution works against the final outputs map.
+- Step prompt substitution works against the running outputs map (only earlier steps' outputs are available).
+
+**Quality gates:**
+
+- `prompt-preprocessor.ts` is *not* modified — substitution lives next to existing variable interpolation in `workflow.ts`.
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:coverage` — feature slice; coverage should rise.
+
+**Risks:**
+
+- The path walk needs to handle edge cases: keys with dots in them aren't supported (treated as nested), array index syntax (`steps.foo.output.items.0`) is a design choice — pick "no array index in V1, only object property names" and document it.
+- `JSON.stringify` on a value containing a function or symbol returns surprising results. Validated outputs from the SDK are JSON, so this shouldn't happen, but type the outputs map as `Record<string, unknown>` and accept that consumers pass JSON-shaped values.
+
+## Slice 5 — Dynamic Branch Agent
+
+**Status:** Not started
+
+**Purpose:** Let `branch` be either a static template string or a `{ prompt, schema }` object that runs a one-shot agent at clone-time to propose a branch name.
+
+**Scope:**
+
+- Update the workflow schema in `workflow.ts` so `branch` accepts `string | { prompt: string, schema: JSONSchema }`.
+- Branch resolution path in `run-lifecycle.ts` (or `workspace.ts`, wherever branch creation lives after slice 1):
+  - String form: render template, `git checkout -b`.
+  - Object form: render the `prompt` against `{ issue, attempt }`. Invoke `agent-invoker.ts` with `outputFormat: { type: "json_schema", schema }`. Branch on the terminal `result` subtype:
+    - Success: take `structured_output.name`, store on `RunContext.branch`, `git checkout -b`.
+    - `error_max_structured_output_retries`: abort the run before any step fires; emit a clear lifecycle event.
+- The dynamic form runs at lifecycle pin 2 (after clone, before setup, before any step).
+- Document explicitly that the branch agent inherits the step agent's allowed-tools list (Read/Write/Edit/Bash/Glob/Grep). Per-invocation tool scoping is in deferred scope.
+
+**Natural code areas:**
+
+- `server/workflow/workflow.ts`
+- `server/orchestrator/run-lifecycle.ts`
+- `server/orchestrator/workspace.ts`
+- `server/orchestrator/__tests__/*`
+- `server/workflow/__tests__/*`
+
+**Tests:**
+
+- Workflow parse accepts `branch: "static-template-{{ issue.number }}"`.
+- Workflow parse accepts `branch: { prompt: "...", schema: {...} }`.
+- Workflow parse rejects malformed shapes (e.g. object without `prompt` or `schema`).
+- Static branch path is unchanged from current behaviour.
+- Dynamic branch invokes `agent-invoker` with `outputFormat`.
+- On success, `RunContext.branch` is set to `structured_output.name` and `git checkout -b` is called with that name.
+- `{{ branch }}` resolves in step prompts and `change_request` templates to the validated name.
+- On `error_max_structured_output_retries`, the run aborts before `.agent/setup.sh` or any step fires.
+- Branch agent runs at lifecycle pin 2 (after clone, before setup).
+
+**Quality gates:**
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:coverage` — feature slice; coverage should rise.
+
+**Risks:**
+
+- The branch agent has full Bash access in V1. A misbehaving branch prompt could run arbitrary commands in the workspace. Document this clearly; the deferred per-invocation tool scoping item is the mitigation.
+- Branch-name collision (the proposed name already exists on the remote) is in deferred scope. The current behaviour will be a `git checkout -b` failure that aborts the run — acceptable for V1, document the failure mode.
+- The mock invoker needs to emit a `result` message with `structured_output` for tests; reuse the helper from slice 3.
+
+## Slice 6 — Static Reference Validation
+
+**Status:** Not started
+
+**Purpose:** Catch bad `{{ steps.X.output.Y }}` references at workflow load instead of 20 minutes into a run.
+
+**Scope:**
+
+- After Zod schema parse succeeds in `workflow-loader.ts`, walk every step `prompt` string and the `change_request.title` and `change_request.body` templates. Extract every `{{ steps.X.output.Y... }}` reference.
+- For each reference:
+  - Step `X` must exist in `steps[]`.
+  - For step prompts: step `X` must appear *earlier* than the referencing step. Forward references fail.
+  - The dotted path after `output.` must resolve through step `X`'s `output_schema`. The validator walks the schema's `properties` tree and `items` for arrays. Top-level paths and nested paths both supported.
+- `change_request` references are not subject to the forward-reference rule (all steps have completed by the time it renders).
+- Errors include the file path, the offending reference, and the reason (unknown step, forward reference, unknown field, schema uses unsupported composition).
+- Declare `$ref`, `anyOf`, `oneOf`, `allOf` unsupported in the validator's path walker for V1. If the referenced step's schema uses any of these, validation fails closed with a clear "validator does not support schema composition keywords" message.
+
+**Natural code areas:**
+
+- `server/workflow/workflow-loader.ts`
+- `server/workflow/__tests__/*`
+
+**Tests:**
+
+- Reference to unknown step fails at load with file path + reference + reason.
+- Forward reference in step prompt fails (step `B` references `steps.C.output.x` where `C` comes after `B`).
+- Forward reference in `change_request` is allowed.
+- Reference to unknown top-level field fails.
+- Reference to unknown nested field fails.
+- Reference to known top-level field passes.
+- Reference to known nested field passes.
+- Reference to a step without `output_schema` fails with a clear message.
+- Schema using `anyOf` / `oneOf` / `allOf` / `$ref` triggers the "unsupported composition" error rather than silently passing.
+- `loadWorkflow()` for a workflow with no `{{ steps.* }}` references runs the validator and returns successfully.
+- A workflow with both valid step prompts and valid `change_request` references passes.
+
+**Quality gates:**
+
+- The validator runs only after the Zod parse succeeds — never against a partially-valid YAML object.
+- Validator error messages are user-facing; they should make a workflow author's next move obvious.
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:coverage` — feature slice; coverage should rise.
+
+**Risks:**
+
+- JSON Schema is open-ended. The walker covers `properties` + `items` for V1; anything else fails closed. A future workflow author hitting the unsupported-composition error is the signal to extend it, not break out of the design.
+- The reference extractor must not match `{{ issue.* }}` or `{{ branch }}` (those are valid templates, just not output references). Anchor the regex on `steps.`.
+- A multi-line prompt string can contain `{{ }}` inside a fenced code block intended literally for the LLM. Decide: validator treats *all* `{{ steps.* }}` as references regardless of context (simpler, document it), or skips fenced blocks (more permissive, more code). Recommend the simpler rule.
+
+## Release-Level Acceptance
+
+The overall work is complete when:
+
+- `phases` → `steps` rename is fully applied across server, dashboard, db, and tests.
+- Top-level `prompt:` form and `hooks:` block are removed from the workflow schema.
+- `.agent/setup.sh` runs at lifecycle pin 3 with strict failure on non-zero exit.
+- `change_request: { title, body }` is required at parse time and rendered at lifecycle pin 6.
+- Output steps work end-to-end: `outputFormat` is passed to the SDK, validated values are stored on `RunContext.outputs`, persisted to `run_step_outputs`, and addressable as `{{ steps.X.output.Y }}` (including nested paths) in later step prompts and in `change_request` templates.
+- Retry hydrates outputs from the parent run's `run_step_outputs` rows so skipped steps' outputs remain available to downstream renders.
+- Dynamic branch agent works for the `branch: { prompt, schema }` form and aborts the run on schema-retry exhaustion.
+- Static reference validator catches unknown steps, forward references, unknown fields, and unsupported schema composition at workflow load.
+- GitHub-only behaviour still works under the new surface.
+- `pnpm lint`, `pnpm typecheck`, `pnpm test`, and final `pnpm test:coverage` pass; coverage matches or exceeds the slice 0 baseline.
+
+## Deferred Scope
+
+Do not include these in the initial implementation (mirrors the design doc's deferred section):
+
+- alternative agent runtimes (codex, aider, etc.) — Claude Agent SDK only for V1
+- alternative sandboxes — current workspace model only
+- per-step wall-clock timeout override
+- output gating (a step declaring its output blocks the run if invalid)
+- per-repo workflow override
+- workflow file watch or reload without restart
+- a `completion_signal` sentinel (Sandcastle-style early exit)
+- branch-name conflict resolution when the agent proposes an already-existing branch
+- `change_request` updates on retry vs always opening fresh
+- `change_request.labels` and `change_request.draft` (hardcoded in the code-host adapter for V1 if needed)
+- per-invocation tool scoping for the branch agent (currently inherits the step agent's tool set)

--- a/examples/dynamic-branch.yaml
+++ b/examples/dynamic-branch.yaml
@@ -1,0 +1,149 @@
+branch:
+  prompt: |
+    Propose a branch name for issue {{ issue.key }}: {{ issue.title }}.
+
+    <issue-description>
+    {{ issue.description }}
+    </issue-description>
+
+    Format: `<type>/<issue-key>-<short-desc>`
+
+    - `type` is one of: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`.
+      Pick the one that best matches the work — `feat` for new behaviour,
+      `fix` for bugs, `refactor` for non-behavioural restructuring, etc.
+    - `issue-key` is the tracker key verbatim (e.g. `AINENG-2310`).
+    - `short-desc` is a kebab-case 2-5 word summary of the change. Lowercase
+      letters, digits, and hyphens only.
+
+    Examples:
+    - `feat/AINENG-2310-state-clear-command`
+    - `fix/AINENG-1180-token-refresh-race`
+    - `refactor/AINENG-905-extract-run-lifecycle`
+  schema:
+    type: object
+    properties:
+      name:
+        type: string
+        pattern: "^(feat|fix|chore|docs|refactor|test)/[A-Z]+-[0-9]+-[a-z0-9-]+$"
+    required: [name]
+
+base_branch: main
+
+steps:
+  - name: implement
+    prompt: |
+      # Task
+
+      Work on issue {{ issue.key }}: {{ issue.title }}
+
+      <issue-description>
+      {{ issue.description }}
+      </issue-description>
+
+      Only work on this one issue. The orchestrator has cloned the repo fresh
+      and created branch `{{ branch }}` from `main` for you. Make commits as
+      you go — the orchestrator pushes the branch and opens the change request
+      after the final step completes.
+
+      # Project Context
+
+      Read `AGENTS.md` first if it exists, then `README.md`. Then read any
+      project docs relevant to the change, especially anything under `docs/`.
+
+      Recent commits:
+
+      <recent-commits>
+      !`git log -n 10 --format="%H%n%ad%n%B---" --date=short`
+      </recent-commits>
+
+      Top-level layout:
+
+      <repo-tree>
+      !`ls -1`
+      </repo-tree>
+
+      # Execution
+
+      1. Explore the implementation and tests before editing.
+      2. Keep the change as small as possible.
+      3. Add or update tests when behaviour changes.
+      4. Update docs when shipped behaviour, installation, usage, or document
+         structure changes.
+      5. Run the project's typecheck, test, and lint commands. Discover them
+         from `package.json` scripts or project docs — do not assume.
+      6. Commit the result with a Conventional Commit message
+         (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, or `test:`).
+
+      If you are blocked or the issue is incomplete, leave a clear final
+      message explaining the state and stop without committing speculative
+      work. Do not push, open a PR, or transition the tracker — those are
+      orchestrator-owned.
+
+  - name: review
+    prompt: |
+      # Task
+
+      Review the code changes on branch `{{ branch }}` for issue
+      {{ issue.key }}: {{ issue.title }}.
+
+      <issue-description>
+      {{ issue.description }}
+      </issue-description>
+
+      Diff against the base branch:
+
+      <diff>
+      !`git diff main...HEAD`
+      </diff>
+
+      Commits on this branch:
+
+      <commits>
+      !`git log main..HEAD --oneline`
+      </commits>
+
+      # Review Focus
+
+      Review for correctness, maintainability, test coverage, and fit with
+      project conventions (`AGENTS.md`, `CODING_STANDARDS.md`, anything under
+      `docs/coding-standards*` or `docs/adr/`).
+
+      Check that:
+
+      - behaviour matches the issue
+      - tests cover meaningful changed behaviour
+      - typecheck, test, and lint all pass
+      - docs are updated when shipped behaviour changed
+
+      If you find issues, fix them directly on this branch and commit the
+      refinements with a Conventional Commit message. If the branch is
+      already good, make no changes.
+
+  - name: summarise
+    prompt: |
+      Summarise the change on branch `{{ branch }}` for reviewers of issue
+      {{ issue.key }}.
+
+      <diff>
+      !`git diff main...HEAD`
+      </diff>
+
+      <commits>
+      !`git log main..HEAD --oneline`
+      </commits>
+
+      Produce a one-line title and a short markdown body explaining what
+      changed and why. Body should be reviewer-facing, not a commit log.
+    output_schema:
+      type: object
+      properties:
+        title: { type: string }
+        body: { type: string }
+      required: [title, body]
+
+change_request:
+  title: "{{ steps.summarise.output.title }}"
+  body: |
+    Closes {{ issue.key }}: {{ issue.title }}.
+
+    {{ steps.summarise.output.body }}

--- a/examples/static-branch.yaml
+++ b/examples/static-branch.yaml
@@ -1,23 +1,7 @@
 branch: "agent/issue-{{ issue.number }}"
 base_branch: main
 
-hooks:
-  after_create: |
-    git checkout -b agent/issue-{{ issue.number }}
-    if [ -f pnpm-lock.yaml ]; then
-      pnpm install --frozen-lockfile
-    elif [ -f yarn.lock ]; then
-      yarn install --frozen-lockfile
-    elif [ -f package-lock.json ]; then
-      npm ci
-    fi
-  before_run: |
-    git fetch origin main
-    git rebase origin/main
-  after_run: |
-    git push -u origin agent/issue-{{ issue.number }}
-
-phases:
+steps:
   - name: implement
     prompt: |
       # Task
@@ -28,10 +12,10 @@ phases:
       {{ issue.description }}
       </issue-description>
 
-      Only work on this one issue. The orchestrator created branch
-      `agent/issue-{{ issue.number }}` and rebased it on `origin/main` for you.
-      Make commits before finishing — the branch is pushed and a pull request
-      is opened by the orchestrator after the review phase completes.
+      Only work on this one issue. The orchestrator has cloned the repo fresh
+      and created branch `agent/issue-{{ issue.number }}` from `main` for you.
+      Make commits as you go — the orchestrator pushes the branch and opens
+      the change request after the final step completes.
 
       # Project Context
 
@@ -64,8 +48,8 @@ phases:
 
       If you are blocked or the issue is incomplete, leave a clear final
       message explaining the state and stop without committing speculative
-      work. Do not transition the issue yourself — the orchestrator owns
-      tracker state.
+      work. Do not push, open a PR, or transition the tracker — those are
+      orchestrator-owned.
 
   - name: review
     prompt: |
@@ -78,23 +62,23 @@ phases:
       {{ issue.description }}
       </issue-description>
 
-      Diff against the target branch:
+      Diff against the base branch:
 
       <diff>
-      !`git diff origin/main...HEAD`
+      !`git diff main...HEAD`
       </diff>
 
       Commits on this branch:
 
       <commits>
-      !`git log origin/main..HEAD --oneline`
+      !`git log main..HEAD --oneline`
       </commits>
 
       # Review Focus
 
       Review for correctness, maintainability, test coverage, and fit with
       project conventions (`AGENTS.md`, `CODING_STANDARDS.md`, anything under
-      `docs/coding-standards*` or `docs/adrs/`).
+      `docs/coding-standards*` or `docs/adr/`).
 
       Check that:
 
@@ -106,3 +90,32 @@ phases:
       If you find issues, fix them directly on this branch and commit the
       refinements with a Conventional Commit message. If the branch is
       already good, make no changes.
+
+  - name: summarise
+    prompt: |
+      Summarise the change on branch `agent/issue-{{ issue.number }}` for
+      reviewers of issue {{ issue.key }}.
+
+      <diff>
+      !`git diff main...HEAD`
+      </diff>
+
+      <commits>
+      !`git log main..HEAD --oneline`
+      </commits>
+
+      Produce a one-line title and a short markdown body explaining what
+      changed and why. Body should be reviewer-facing, not a commit log.
+    output_schema:
+      type: object
+      properties:
+        title: { type: string }
+        body: { type: string }
+      required: [title, body]
+
+change_request:
+  title: "{{ steps.summarise.output.title }}"
+  body: |
+    Closes {{ issue.key }}: {{ issue.title }}.
+
+    {{ steps.summarise.output.body }}


### PR DESCRIPTION
## Summary
- Adds the workflow-restructure design docs: `CONTEXT.md` glossary, `docs/adr/0001-phase-outputs-and-fixed-lifecycle.md`, and the design + implementation-plan documents under `docs/`.
- Splits the single `workflow.yaml` into two examples — `examples/static-branch.yaml` (template branch name) and `examples/dynamic-branch.yaml` (branch-naming agent) — to illustrate both forms of the new first-class `branch:` field.
- Introduces `.agent/setup.sh` as the repo-owned bootstrap contract and documents the pre-launch stance in `AGENTS.md` (no migrations, no compat shims).

No code changes — docs, examples, and the bootstrap script only.

## Test plan
- [ ] Skim `CONTEXT.md` and ADR-0001 for terminology consistency.
- [ ] Confirm both example workflows parse against the eventual workflow loader.
- [ ] `bash .agent/setup.sh` runs cleanly from a fresh clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)