### PR TITLE
refactor: workflow-restructure slice 2 — change_request block

### DIFF
--- a/docs/workflow-restructure-implementation-plan.md
+++ b/docs/workflow-restructure-implementation-plan.md
@@ -263,7 +263,9 @@ Use this handoff template when a slice is interrupted:
 
 ## Slice 2 — Change Request Block
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Started:** 2026-05-01 on `main` (single sweep — small, focused change touching schema, renderer, lifecycle, and live workflow).
 
 **Purpose:** Replace the hardcoded PR title (`issue.title`) and body (`Closes ${issue.key}`) in `finalizeSuccess` with a templated `change_request: { title, body }` block from the workflow.
 
@@ -311,6 +313,23 @@ Use this handoff template when a slice is interrupted:
 - Making `change_request` required will break any local `workflow.yaml` that doesn't have one. Update the live file in the same PR.
 - The renderer needs a `branch` value at lifecycle pin 6 — confirm `RunContext.branch` is set by branch creation in slice 1's foundation work, otherwise either set it here or note the gap.
 - If `body` references a variable that doesn't exist (e.g. `{{ issue.foo }}`), `renderPrompt` currently returns empty string. That's consistent but silent — the slice 6 validator catches `{{ steps.* }}` issues, but generic typo'd variables stay silent. Acceptable for V1; flag if it becomes a problem.
+
+**Completed changes:**
+
+- **Workflow schema**: required `change_request: { title, body }` block added to `repoWorkflowSchema` in `server/workflow/workflow.ts`. Both fields are `z.string().min(1)`. The block is itself `.strict()`, so unknown keys (`labels`, `draft`, etc.) fail at parse with a clear Zod error. Top-level workflow stays `.strict()`, so missing `change_request` fails too.
+- **Renderer**: new `server/orchestrator/change-request-renderer.ts` exports a pure `renderChangeRequest({ template, issue, attempt, branch })` that returns `{ title, body }`. Reuses `renderPrompt` from `workflow.ts` for variable interpolation rather than duplicating substitution logic.
+- **`renderPrompt` extension**: the variable parameter type now accepts an optional `branch?: string`. The dynamic path-walk implementation already supported this; only the type widened. Step prompt callers continue to pass `{ issue, attempt }` unchanged.
+- **`finalizeSuccess` rewire**: `run-lifecycle.ts` calls `renderChangeRequest` with the workflow's template and the rendered `branch` value, then passes the rendered `title` and `body` to `codeHost.createChangeRequest`. The hardcoded `issue.title` / `Closes ${issue.key}` is gone. The adapter signature is unchanged.
+- **Live `workflow.yaml`**: added a `change_request` block using only `{{ issue.* }}` and `{{ branch }}` — no `{{ steps.*.output.* }}` (slice 4 will introduce that).
+- **Test fixture**: `createTestWorkflow` in `server/testing/support/fixtures.ts` and the inline `baseWorkflow` / `multiStepWorkflow` in the lifecycle tests now include a minimal `change_request` matching the previous hardcoded values, so existing assertions on `codeHost.changeRequests` continue to pass without change. A new lifecycle test covers the templated path explicitly with a custom title/body that reads `{{ issue.key }}`, `{{ issue.title }}`, `{{ attempt }}`, and `{{ branch }}`.
+
+**Verification:**
+
+- `pnpm lint` — pass (128 files, no fixes applied).
+- `pnpm typecheck` — pass (server + dashboard).
+- `pnpm test` — pass (40 files, 250 tests; up from 242 in slice 1).
+- `pnpm test:coverage` — Statements **99.22%** / Branches **98.93%** / Functions **98.16%** / Lines **99.28%**. Matches the slice 1 baseline; functions ticked up by 0.01pp from the new pure renderer.
+- New tests cover: schema rejection of missing `change_request`, missing `title`, missing `body`, and unknown keys; renderer substitutes `{{ issue.* }}`, `{{ attempt }}`, and `{{ branch }}` in title and body; renderer preserves multi-line markdown bodies; renderer returns empty string for unknown vars; lifecycle calls `codeHost.createChangeRequest` with templated values that include the rendered branch.
 
 ## Slice 3 — Output Steps
 

--- a/server/orchestrator/__tests__/change-request-renderer.test.ts
+++ b/server/orchestrator/__tests__/change-request-renderer.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { Issue } from "../../trackers/types.ts";
+import { branchName, issueKey, issueNumber } from "../../types/brands.ts";
+import { renderChangeRequest } from "../change-request-renderer.ts";
+
+const issue: Issue = {
+	key: issueKey("owner/repo#42"),
+	number: issueNumber(42),
+	title: "Fix login bug",
+	description: "Login throws on null email",
+	labels: ["bug"],
+	url: "https://example.test/owner/repo/42",
+	createdAt: "2026-01-01T00:00:00Z",
+};
+
+describe("renderChangeRequest", () => {
+	it("substitutes issue, attempt, and branch in title and body", () => {
+		const result = renderChangeRequest({
+			template: {
+				title: "[{{ issue.key }}] {{ issue.title }}",
+				body: "Closes {{ issue.key }}\nBranch: {{ branch }}\nAttempt: {{ attempt }}",
+			},
+			issue,
+			attempt: 2,
+			branch: branchName("agent/issue-42"),
+		});
+
+		expect(result).toEqual({
+			title: "[owner/repo#42] Fix login bug",
+			body: "Closes owner/repo#42\nBranch: agent/issue-42\nAttempt: 2",
+		});
+	});
+
+	it("preserves multi-line body and markdown formatting", () => {
+		const body = [
+			"## Summary",
+			"",
+			"- Closes {{ issue.key }}",
+			"- Title: **{{ issue.title }}**",
+			"",
+			"```",
+			"branch: {{ branch }}",
+			"```",
+		].join("\n");
+
+		const result = renderChangeRequest({
+			template: { title: "{{ issue.title }}", body },
+			issue,
+			attempt: 1,
+			branch: branchName("agent/issue-42"),
+		});
+
+		expect(result.body).toBe(
+			[
+				"## Summary",
+				"",
+				"- Closes owner/repo#42",
+				"- Title: **Fix login bug**",
+				"",
+				"```",
+				"branch: agent/issue-42",
+				"```",
+			].join("\n"),
+		);
+	});
+
+	it("renders missing variables as empty string", () => {
+		const result = renderChangeRequest({
+			template: {
+				title: "{{ issue.nonexistent }}",
+				body: "{{ steps.summarise.output.title }}",
+			},
+			issue,
+			attempt: 1,
+			branch: branchName("agent/issue-42"),
+		});
+
+		expect(result).toEqual({ title: "", body: "" });
+	});
+});

--- a/server/orchestrator/__tests__/run-lifecycle.test.ts
+++ b/server/orchestrator/__tests__/run-lifecycle.test.ts
@@ -20,6 +20,11 @@ import type { RepoWorkflow } from "../../workflow/workflow.ts";
 
 const exec = promisify(execFile);
 
+const baseChangeRequest = {
+	title: "{{ issue.title }}",
+	body: "Closes {{ issue.key }}",
+};
+
 const baseWorkflow: RepoWorkflow = {
 	branch: "agent/issue-{{ issue.number }}",
 	base_branch: "main",
@@ -30,6 +35,7 @@ const baseWorkflow: RepoWorkflow = {
 			resume_previous: false,
 		},
 	],
+	change_request: baseChangeRequest,
 };
 
 const multiStepWorkflow: RepoWorkflow = {
@@ -43,6 +49,7 @@ const multiStepWorkflow: RepoWorkflow = {
 			resume_previous: true,
 		},
 	],
+	change_request: baseChangeRequest,
 };
 
 async function writeSetupScript(
@@ -325,6 +332,7 @@ describe("RunLifecycle.dispatch", () => {
 					resume_previous: true,
 				},
 			],
+			change_request: baseChangeRequest,
 		};
 
 		const handle = await setup.lifecycle.dispatch({
@@ -508,5 +516,36 @@ describe("RunLifecycle.dispatch", () => {
 			(e) => e.type === "step.started",
 		);
 		expect(stepStarted).toEqual([]);
+	});
+
+	it("opens the change request with values rendered from the workflow's change_request template", async () => {
+		await using setup = await createTestRunLifecycle({
+			agent: createScriptedAgent(() => yieldAssistant("sess-final")),
+		});
+		const issue = createTestIssue();
+
+		const handle = await setup.lifecycle.dispatch({
+			issue,
+			repo: TEST_REPO,
+			workflow: {
+				...baseWorkflow,
+				change_request: {
+					title: "[{{ issue.key }}] {{ issue.title }} (attempt {{ attempt }})",
+					body: "Closes {{ issue.key }}\nBranch: {{ branch }}",
+				},
+			},
+			attempt: 3,
+		});
+		await handle.done;
+
+		expect(setup.codeHost.changeRequests).toEqual([
+			{
+				repo: TEST_REPO,
+				head: "agent/issue-1",
+				base: "main",
+				title: `[${issue.key}] ${issue.title} (attempt 3)`,
+				body: `Closes ${issue.key}\nBranch: agent/issue-1`,
+			},
+		]);
 	});
 });

--- a/server/orchestrator/change-request-renderer.ts
+++ b/server/orchestrator/change-request-renderer.ts
@@ -1,0 +1,24 @@
+import type { Issue } from "../trackers/types.ts";
+import type { BranchName } from "../types/brands.ts";
+import type { ChangeRequestTemplate } from "../workflow/workflow.ts";
+import { renderPrompt } from "../workflow/workflow.ts";
+
+type RenderChangeRequestParams = {
+	template: ChangeRequestTemplate;
+	issue: Issue;
+	attempt: number;
+	branch: BranchName;
+};
+
+export function renderChangeRequest({
+	template,
+	issue,
+	attempt,
+	branch,
+}: RenderChangeRequestParams): { title: string; body: string } {
+	const vars = { issue, attempt, branch };
+	return {
+		title: renderPrompt(template.title, vars),
+		body: renderPrompt(template.body, vars),
+	};
+}

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -12,6 +12,7 @@ import {
 import type { RepoWorkflow } from "../workflow/workflow.ts";
 import { renderPrompt } from "../workflow/workflow.ts";
 import type { AgentInvoker } from "./agent-invoker.ts";
+import { renderChangeRequest } from "./change-request-renderer.ts";
 import type { Clock } from "./clock.ts";
 import { runWorkflowSteps } from "./step-runner.ts";
 import {
@@ -129,7 +130,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 						});
 
 						if (result.status === "completed") {
-							await finalizeSuccess(repo, issue, workflow, branch);
+							await finalizeSuccess(repo, issue, workflow, branch, attempt);
 						}
 
 						const retriesExhausted = maxRetries - attempt < 0;
@@ -156,14 +157,21 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 		issue: Issue,
 		workflow: RepoWorkflow,
 		branch: BranchName,
+		attempt: number,
 	): Promise<void> {
+		const { title, body } = renderChangeRequest({
+			template: workflow.change_request,
+			issue,
+			attempt,
+			branch,
+		});
 		try {
 			await codeHost.createChangeRequest(
 				repo,
 				branch,
 				branchName(workflow.base_branch),
-				issue.title,
-				`Closes ${issue.key}`,
+				title,
+				body,
 			);
 		} catch (err) {
 			canonicalLog.append(

--- a/server/testing/support/fixtures.ts
+++ b/server/testing/support/fixtures.ts
@@ -96,6 +96,10 @@ export function createTestWorkflow(
 				resume_previous: false,
 			},
 		],
+		change_request: {
+			title: "{{ issue.title }}",
+			body: "Closes {{ issue.key }}",
+		},
 		...overrides,
 	};
 }

--- a/server/workflow/__tests__/workflow-loader.test.ts
+++ b/server/workflow/__tests__/workflow-loader.test.ts
@@ -11,6 +11,9 @@ base_branch: "main"
 steps:
   - name: implement
     prompt: "Fix the issue"
+change_request:
+  title: "PR for {{ issue.key }}"
+  body: "Closes {{ issue.key }}"
 `;
 
 type TestWorkflowFile = {
@@ -42,6 +45,10 @@ describe("loadWorkflow", () => {
 			steps: [
 				{ name: "implement", prompt: "Fix the issue", resume_previous: false },
 			],
+			change_request: {
+				title: "PR for {{ issue.key }}",
+				body: "Closes {{ issue.key }}",
+			},
 		});
 	});
 

--- a/server/workflow/__tests__/workflow.test.ts
+++ b/server/workflow/__tests__/workflow.test.ts
@@ -48,6 +48,12 @@ describe("renderPrompt", () => {
 	});
 });
 
+const validChangeRequest = `
+change_request:
+  title: "PR for {{ issue.key }}"
+  body: "Closes {{ issue.key }}"
+`;
+
 describe("parseRepoWorkflow", () => {
 	it("accepts a single-step workflow", () => {
 		const yaml = `
@@ -56,7 +62,7 @@ base_branch: main
 steps:
   - name: implement
     prompt: Fix this issue
-`;
+${validChangeRequest}`;
 
 		const result = parseRepoWorkflow(yaml);
 
@@ -66,6 +72,10 @@ steps:
 			steps: [
 				{ name: "implement", prompt: "Fix this issue", resume_previous: false },
 			],
+			change_request: {
+				title: "PR for {{ issue.key }}",
+				body: "Closes {{ issue.key }}",
+			},
 		});
 	});
 
@@ -79,7 +89,7 @@ steps:
   - name: implement
     prompt: Implement the plan
     resume_previous: true
-`;
+${validChangeRequest}`;
 
 		const result = parseRepoWorkflow(yaml);
 
@@ -91,6 +101,62 @@ steps:
 				resume_previous: true,
 			},
 		]);
+	});
+
+	it("rejects workflows missing change_request", () => {
+		const yaml = `
+branch: my-branch
+base_branch: main
+steps:
+  - name: implement
+    prompt: Fix it
+`;
+
+		expect(() => parseRepoWorkflow(yaml)).toThrow();
+	});
+
+	it("rejects change_request missing title", () => {
+		const yaml = `
+branch: my-branch
+base_branch: main
+steps:
+  - name: implement
+    prompt: Fix it
+change_request:
+  body: "Closes {{ issue.key }}"
+`;
+
+		expect(() => parseRepoWorkflow(yaml)).toThrow();
+	});
+
+	it("rejects change_request missing body", () => {
+		const yaml = `
+branch: my-branch
+base_branch: main
+steps:
+  - name: implement
+    prompt: Fix it
+change_request:
+  title: "PR"
+`;
+
+		expect(() => parseRepoWorkflow(yaml)).toThrow();
+	});
+
+	it("rejects change_request with unknown keys", () => {
+		const yaml = `
+branch: my-branch
+base_branch: main
+steps:
+  - name: implement
+    prompt: Fix it
+change_request:
+  title: "PR"
+  body: "Closes"
+  labels: [bug]
+`;
+
+		expect(() => parseRepoWorkflow(yaml)).toThrow();
 	});
 
 	it("rejects workflows missing branch", () => {

--- a/server/workflow/workflow.ts
+++ b/server/workflow/workflow.ts
@@ -13,11 +13,21 @@ const workflowStepSchema = z
 
 export type WorkflowStep = z.infer<typeof workflowStepSchema>;
 
+const changeRequestSchema = z
+	.object({
+		title: z.string().min(1),
+		body: z.string().min(1),
+	})
+	.strict();
+
+export type ChangeRequestTemplate = z.infer<typeof changeRequestSchema>;
+
 const repoWorkflowSchema = z
 	.object({
 		branch: z.string().min(1),
 		base_branch: z.string().min(1),
 		steps: z.array(workflowStepSchema).min(1),
+		change_request: changeRequestSchema,
 	})
 	.strict();
 
@@ -36,7 +46,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  */
 export function renderPrompt(
 	template: string,
-	vars: { issue: Issue; attempt?: number },
+	vars: { issue: Issue; attempt?: number; branch?: string },
 ): string {
 	return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (_match, path: string) => {
 		const parts = path.split(".");

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -90,3 +90,10 @@ steps:
       If you find issues, fix them directly on this branch and commit the
       refinements with a Conventional Commit message. If the branch is
       already good, make no changes.
+
+change_request:
+  title: "{{ issue.title }}"
+  body: |
+    Closes {{ issue.key }}.
+
+    Branch: `{{ branch }}`


### PR DESCRIPTION
## Summary

- Adds required `change_request: { title, body }` to the workflow schema (both `.strict()`); top-level workflow stays `.strict()` so missing block fails at parse.
- Replaces the hardcoded PR title (`issue.title`) and body (`Closes ${issue.key}`) in `finalizeSuccess` with rendered values from a new pure `renderChangeRequest` helper that reuses `renderPrompt`. Substitutes `{{ issue.* }}`, `{{ attempt }}`, and `{{ branch }}`.
- Updates the live `workflow.yaml` and test fixtures to include the new required block. No `{{ steps.*.output.* }}` yet — that lands in slice 4.

Plan reference: `docs/workflow-restructure-implementation-plan.md` slice 2.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 250 passing (up from 242)
- [x] `pnpm test:coverage` — 99.22 / 98.93 / 98.16 / 99.28 (matches slice 1 baseline)
- [x] Schema: rejects missing `change_request`, missing `title`, missing `body`, unknown keys
- [x] Renderer: substitutes `{{ issue.* }}`, `{{ attempt }}`, `{{ branch }}`; preserves multi-line markdown; missing vars render empty
- [x] Lifecycle: `codeHost.createChangeRequest` receives templated values including the rendered branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)