### PR TITLE
feat: workflow-restructure slice 3 — output steps

### DIFF
--- a/docs/workflow-restructure-implementation-plan.md
+++ b/docs/workflow-restructure-implementation-plan.md
@@ -333,7 +333,9 @@ Use this handoff template when a slice is interrupted:
 
 ## Slice 3 — Output Steps
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Started:** 2026-05-01 on `main` (single sweep — schema + invoker + step runner + repo + lifecycle hydration; reviewable as one PR).
 
 **Purpose:** Add `output_schema` to step definitions, plumb `outputFormat` through to the SDK, capture validated outputs, persist them, and hydrate them on retry.
 
@@ -387,6 +389,33 @@ Use this handoff template when a slice is interrupted:
 - Hydration on retry is the bug magnet of this slice. Easy failure mode: new runId reads its own (empty) outputs instead of the parent's. Test specifically for retry-skip-and-substitute behaviour, not just "outputs are persisted".
 - `output_json` size: structured outputs can be large (the SDK example `todoSchema` returns an array). Sqlite TEXT handles it, but consider whether to log the full value to the canonical log or just a checksum / first-N-chars summary.
 - `RunContext.outputs` is shared between fresh runs and resumed runs; the type signature must reflect that it can be partially populated.
+
+**Completed changes:**
+
+- **Workflow schema**: optional `output_schema: Record<string, unknown>` added to `workflowStepSchema` in `server/workflow/workflow.ts`. Strict step parse still rejects other unknown keys.
+- **Agent invoker**: `AgentInvokeOptions` gained optional `outputFormat: { type: "json_schema", schema }` (new `OutputFormat` type re-exported). `claudeSdkAgentInvoker` threads it into `query()` only when set, so action-step calls remain identical to before.
+- **Step runner** (`server/orchestrator/step-runner.ts`):
+  - When `step.output_schema` is present, builds `{ type: "json_schema", schema }` and passes to the invoker.
+  - Iterates the message stream and now consumes terminal `result` messages too (not just `assistant`). On `result.subtype === "success"` for an output step, captures `structured_output` via `ctx.setStepOutput(step.name, value)` and appends a `step_outputs` canonical-log entry. On `result.subtype === "error_max_structured_output_retries"` (and other error subtypes), throws — the existing `catch` in the runner emits `step.failed` with the subtype as the error message and aborts the run before subsequent steps fire.
+  - Action steps (no `output_schema`) ignore terminal `result` messages silently — preserves backwards compatibility with the SDK now always emitting one.
+- **`RunContext`** (`server/runner/runner.ts`):
+  - New `outputs: Record<string, unknown>` (the readable map, populated from `job.initialOutputs` at enqueue) and `setStepOutput(stepName, value)` setter (updates the in-memory map AND persists via `repo.writeStepOutput`).
+  - `AgentJob.initialOutputs?: Record<string, unknown>` carries hydrated parent outputs into the runner.
+- **Run repository** (`server/run-repository.ts`): two new methods. `writeStepOutput(runId, stepName, value)` upserts a `run_step_outputs` row keyed by the composite primary key. `getStepOutputs(runId)` returns `Record<stepName, value>` (empty object for unknown runs).
+- **Run lifecycle**: now takes `repo: RunRepository` in its deps. On dispatch, when `resume.parentRunId` is set, calls `repo.getStepOutputs(parentRunId)` and threads the result through `AgentJob.initialOutputs`. Hydration is purely in-memory — the runner does not re-persist parent outputs under the new run id, so `run_step_outputs` only ever contains rows for steps that *actually executed and produced output* in their own run.
+- **Test seam**: no changes to the scripted-agent contract. The new `step-runner.test.ts` constructs a fake `RunContext` directly to exercise hydration and result-message handling in isolation. The lifecycle integration tests cover the wiring (output rows persisted, `outputFormat` reaches the invoker, retry doesn't crash and doesn't re-persist parent outputs).
+
+**Verification:**
+
+- `pnpm lint` — pass (129 files, no fixes applied).
+- `pnpm typecheck` — pass (server + dashboard).
+- `pnpm test` — pass (41 files, 263 tests; up from 250 in slice 2). New tests: 5 in `step-runner.test.ts` (action step path, output-step success path, max-retries abort, action step with terminal result, initialOutputs hydration), 4 in `run-repository.test.ts` (write/upsert/read/empty), 1 in `workflow.test.ts` (`output_schema` accepted), 3 in `run-lifecycle.test.ts` (output step end-to-end, max-retries abort, retry-without-re-persisting-parent).
+- `pnpm test:coverage` — Statements **99.35%** / Branches **98.48%** / Functions **98.18%** / Lines **99.3%**. Statements/lines/functions all up vs the slice 2 baseline; branches dropped 0.45pp because the SDK `SDKResultError` union has multiple subtypes (`error_during_execution`, `error_max_turns`, `error_max_budget_usd`, `error_max_structured_output_retries`) and only the named one is exercised in tests — the others are caught by the same `throw new Error(msg.subtype)` path so further coverage would be redundant.
+
+**Deferred:**
+
+- `change_request` rendering does not yet read `RunContext.outputs` — that's slice 4. The lifecycle still calls `renderChangeRequest({ template, issue, attempt, branch })` without an outputs argument, by design.
+- Step prompt rendering (`{{ steps.X.output.Y }}`) is also slice 4. The hydrated `ctx.outputs` map exists but isn't read by `renderPrompt` yet.
 
 ## Slice 4 — Output Substitution
 

--- a/server/__tests__/run-repository.test.ts
+++ b/server/__tests__/run-repository.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { runs } from "../db/schema.ts";
+import { runStepOutputs, runs } from "../db/schema.ts";
 import { createRunRepository } from "../run-repository.ts";
 import { createTestDb } from "../testing/support/test-db.ts";
 import { issueKey, runId } from "../types/brands.ts";
@@ -74,5 +74,56 @@ describe("run repository row projection", () => {
 			parentRunId: null,
 			stepIndex: 0,
 		});
+	});
+});
+
+describe("step outputs", () => {
+	it("writeStepOutput persists a row keyed by (runId, stepName)", () => {
+		const db = createTestDb();
+		const repo = createRunRepository(db);
+		repo.writeStepOutput(runId("r1"), "summarise", {
+			title: "Hello",
+			tags: ["a", "b"],
+		});
+
+		const rows = db.select().from(runStepOutputs).all();
+		expect(rows).toEqual([
+			{
+				runId: "r1",
+				stepName: "summarise",
+				outputJson: { title: "Hello", tags: ["a", "b"] },
+				createdAt: expect.any(String),
+			},
+		]);
+	});
+
+	it("writeStepOutput overwrites an existing row for the same (runId, stepName)", () => {
+		const db = createTestDb();
+		const repo = createRunRepository(db);
+		repo.writeStepOutput(runId("r1"), "summarise", { v: 1 });
+		repo.writeStepOutput(runId("r1"), "summarise", { v: 2 });
+
+		const rows = db.select().from(runStepOutputs).all();
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.outputJson).toEqual({ v: 2 });
+	});
+
+	it("getStepOutputs returns the full map keyed by stepName for a run", () => {
+		const db = createTestDb();
+		const repo = createRunRepository(db);
+		repo.writeStepOutput(runId("r1"), "summarise", { title: "T" });
+		repo.writeStepOutput(runId("r1"), "tag", { tags: ["x"] });
+		repo.writeStepOutput(runId("r2"), "other", { ignored: true });
+
+		expect(repo.getStepOutputs(runId("r1"))).toEqual({
+			summarise: { title: "T" },
+			tag: { tags: ["x"] },
+		});
+	});
+
+	it("getStepOutputs returns an empty map when there are no rows for the run", () => {
+		const db = createTestDb();
+		const repo = createRunRepository(db);
+		expect(repo.getStepOutputs(runId("missing"))).toEqual({});
 	});
 });

--- a/server/orchestrator/__tests__/run-lifecycle.test.ts
+++ b/server/orchestrator/__tests__/run-lifecycle.test.ts
@@ -3,7 +3,7 @@ import { access, chmod, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
-import { runs } from "../../db/schema.ts";
+import { runStepOutputs, runs } from "../../db/schema.ts";
 import { getEvents } from "../../testing/support/test-db.ts";
 import {
 	createInMemoryCodeHost,
@@ -547,5 +547,178 @@ describe("RunLifecycle.dispatch", () => {
 				body: `Closes ${issue.key}\nBranch: agent/issue-1`,
 			},
 		]);
+	});
+
+	it("output step: passes outputFormat to invoker and persists structured_output to run_step_outputs", async () => {
+		const summarySchema = {
+			type: "object",
+			properties: { title: { type: "string" } },
+			required: ["title"],
+		};
+		const structured = { title: "It broke" };
+		const agent = createScriptedAgent(async function* () {
+			yield {
+				type: "result",
+				subtype: "success",
+				duration_ms: 1,
+				duration_api_ms: 1,
+				is_error: false,
+				num_turns: 1,
+				result: "ok",
+				stop_reason: "end_turn",
+				total_cost_usd: 0,
+				usage: {} as never,
+				modelUsage: {},
+				permission_denials: [],
+				structured_output: structured,
+				uuid: "00000000-0000-0000-0000-000000000050",
+				session_id: "sess-out",
+			} as never;
+		});
+		await using setup = await createTestRunLifecycle({ agent });
+
+		const handle = await setup.lifecycle.dispatch({
+			issue: createTestIssue(),
+			repo: TEST_REPO,
+			workflow: {
+				...baseWorkflow,
+				steps: [
+					{
+						name: "summarise",
+						prompt: "Summarise",
+						resume_previous: false,
+						output_schema: summarySchema,
+					},
+				],
+			},
+			attempt: 1,
+		});
+		const result = await handle.done;
+
+		expect(result).toMatchObject({ status: "completed" });
+		expect(agent.calls[0]?.outputFormat).toEqual({
+			type: "json_schema",
+			schema: summarySchema,
+		});
+
+		const outputRows = setup.db.select().from(runStepOutputs).all();
+		expect(outputRows).toEqual([
+			{
+				runId: handle.runId,
+				stepName: "summarise",
+				outputJson: structured,
+				createdAt: expect.any(String),
+			},
+		]);
+	});
+
+	it("output step: aborts the run when SDK returns error_max_structured_output_retries", async () => {
+		const agent = createScriptedAgent(async function* () {
+			yield {
+				type: "result",
+				subtype: "error_max_structured_output_retries",
+				duration_ms: 1,
+				duration_api_ms: 1,
+				is_error: true,
+				num_turns: 1,
+				stop_reason: null,
+				total_cost_usd: 0,
+				usage: {} as never,
+				modelUsage: {},
+				permission_denials: [],
+				errors: [],
+				uuid: "00000000-0000-0000-0000-000000000060",
+				session_id: "sess-err",
+			} as never;
+		});
+		await using setup = await createTestRunLifecycle({ agent, maxRetries: 0 });
+
+		const handle = await setup.lifecycle.dispatch({
+			issue: createTestIssue(),
+			repo: TEST_REPO,
+			workflow: {
+				...baseWorkflow,
+				steps: [
+					{
+						name: "summarise",
+						prompt: "Summarise",
+						resume_previous: false,
+						output_schema: { type: "object" },
+					},
+					{ name: "after", prompt: "after", resume_previous: false },
+				],
+			},
+			attempt: 1,
+		});
+		const result = await handle.done;
+
+		expect(result).toMatchObject({
+			status: "failed",
+			error: "error_max_structured_output_retries",
+		});
+		expect(agent.calls).toHaveLength(1);
+		expect(setup.db.select().from(runStepOutputs).all()).toEqual([]);
+	});
+
+	it("retry: only writes the new run's outputs, leaving the parent's row untouched (hydration is in-memory)", async () => {
+		const parentRunIdValue = "parent-run" as never;
+		const agent = createScriptedAgent(() => yieldAssistant("sess-resume"));
+		await using setup = await createTestRunLifecycle({ agent });
+
+		setup.db
+			.insert(runs)
+			.values({
+				id: parentRunIdValue,
+				agentName: "issue-1",
+				status: "failed",
+				startedAt: "2026-01-01T00:00:00Z",
+				completedAt: "2026-01-01T00:00:01Z",
+				durationMs: 1,
+				error: "boom",
+			})
+			.run();
+		setup.db
+			.insert(runStepOutputs)
+			.values({
+				runId: parentRunIdValue,
+				stepName: "summarise",
+				outputJson: { title: "from-parent" },
+				createdAt: "2026-01-01T00:00:00Z",
+			})
+			.run();
+
+		const handle = await setup.lifecycle.dispatch({
+			issue: createTestIssue(),
+			repo: TEST_REPO,
+			workflow: {
+				...baseWorkflow,
+				steps: [
+					{
+						name: "summarise",
+						prompt: "Summarise",
+						resume_previous: false,
+						output_schema: { type: "object" },
+					},
+					{ name: "after", prompt: "after", resume_previous: false },
+				],
+			},
+			attempt: 2,
+			resume: {
+				parentRunId: parentRunIdValue,
+				startStepIndex: 1,
+			},
+		});
+		await handle.done;
+
+		const rows = setup.db.select().from(runStepOutputs).all();
+		expect(rows).toEqual([
+			{
+				runId: parentRunIdValue,
+				stepName: "summarise",
+				outputJson: { title: "from-parent" },
+				createdAt: "2026-01-01T00:00:00Z",
+			},
+		]);
+		expect(agent.calls).toHaveLength(1);
 	});
 });

--- a/server/orchestrator/__tests__/step-runner.test.ts
+++ b/server/orchestrator/__tests__/step-runner.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from "vitest";
+import type { StepEvent } from "../../event-bus.ts";
+import type { RunContext } from "../../runner/runner.ts";
+import type { Issue } from "../../trackers/types.ts";
+import { issueKey, issueNumber, runId } from "../../types/brands.ts";
+import type { RepoWorkflow } from "../../workflow/workflow.ts";
+import type {
+	AgentInvokeOptions,
+	AgentInvoker,
+	AgentMessage,
+} from "../agent-invoker.ts";
+import { runWorkflowSteps } from "../step-runner.ts";
+
+const issue: Issue = {
+	key: issueKey("owner/repo#1"),
+	number: issueNumber(1),
+	title: "Fix it",
+	description: "",
+	labels: [],
+	url: "https://example.test",
+	createdAt: "2026-01-01T00:00:00Z",
+};
+
+type ContextRecorder = {
+	ctx: RunContext;
+	stepEvents: StepEvent[];
+	stepOutputs: { name: string; value: unknown }[];
+	outputs: Record<string, unknown>;
+};
+
+function createCtx(
+	initialOutputs: Record<string, unknown> = {},
+): ContextRecorder {
+	const stepEvents: StepEvent[] = [];
+	const stepOutputs: { name: string; value: unknown }[] = [];
+	const outputs: Record<string, unknown> = { ...initialOutputs };
+	const ctx: RunContext = {
+		runId: runId("test-run"),
+		emitToolUse: () => {},
+		emitStepEvent: (event) => stepEvents.push(event),
+		setSessionId: () => {},
+		setStepIndex: () => {},
+		setStepOutput: (name, value) => {
+			stepOutputs.push({ name, value });
+			outputs[name] = value;
+		},
+		signal: new AbortController().signal,
+		outputs,
+	};
+	return { ctx, stepEvents, stepOutputs, outputs };
+}
+
+type ScriptedCall = AgentInvokeOptions;
+
+function createAgent(
+	script: (call: ScriptedCall) => AsyncIterable<AgentMessage>,
+): AgentInvoker & { calls: ScriptedCall[] } {
+	const calls: ScriptedCall[] = [];
+	return {
+		calls,
+		invoke(opts) {
+			calls.push(opts);
+			return script(opts);
+		},
+	};
+}
+
+const baseChangeRequest = { title: "t", body: "b" };
+
+const outputSchema = {
+	type: "object",
+	properties: { title: { type: "string" } },
+	required: ["title"],
+};
+
+async function* yieldAssistant(sessionId: string): AsyncIterable<AgentMessage> {
+	yield {
+		type: "assistant",
+		session_id: sessionId,
+		// biome-ignore lint/suspicious/noExplicitAny: decouple from SDK shape
+		message: { content: [] } as any,
+		parent_tool_use_id: null,
+		uuid: "00000000-0000-0000-0000-000000000010",
+	} as AgentMessage;
+}
+
+describe("runWorkflowSteps", () => {
+	it("does not pass outputFormat for an action step (no output_schema)", async () => {
+		const recorder = createCtx();
+		const agent = createAgent(() => yieldAssistant("sess"));
+		const workflow: RepoWorkflow = {
+			branch: "b",
+			base_branch: "main",
+			steps: [{ name: "implement", prompt: "do it", resume_previous: false }],
+			change_request: baseChangeRequest,
+		};
+
+		await runWorkflowSteps({
+			ctx: recorder.ctx,
+			agent,
+			workflow,
+			issue,
+			attempt: 1,
+			cwd: "/work",
+			model: "test-model",
+		});
+
+		expect(agent.calls[0]?.outputFormat).toBeUndefined();
+		expect(recorder.stepOutputs).toEqual([]);
+	});
+
+	it("passes outputFormat and captures structured_output for an output step", async () => {
+		const recorder = createCtx();
+		const structured = { title: "Hello", tags: ["a"] };
+		const agent = createAgent(async function* () {
+			yield {
+				type: "assistant",
+				session_id: "sess",
+				// biome-ignore lint/suspicious/noExplicitAny: decouple from SDK shape
+				message: { content: [] } as any,
+				parent_tool_use_id: null,
+				uuid: "00000000-0000-0000-0000-000000000010",
+			} as AgentMessage;
+			yield {
+				type: "result",
+				subtype: "success",
+				duration_ms: 1,
+				duration_api_ms: 1,
+				is_error: false,
+				num_turns: 1,
+				result: "ok",
+				stop_reason: "end_turn",
+				total_cost_usd: 0,
+				usage: {} as never,
+				modelUsage: {},
+				permission_denials: [],
+				structured_output: structured,
+				uuid: "00000000-0000-0000-0000-000000000020",
+				session_id: "sess",
+			} as AgentMessage;
+		});
+		const workflow: RepoWorkflow = {
+			branch: "b",
+			base_branch: "main",
+			steps: [
+				{
+					name: "summarise",
+					prompt: "Summarise",
+					resume_previous: false,
+					output_schema: outputSchema,
+				},
+			],
+			change_request: baseChangeRequest,
+		};
+
+		await runWorkflowSteps({
+			ctx: recorder.ctx,
+			agent,
+			workflow,
+			issue,
+			attempt: 1,
+			cwd: "/work",
+			model: "test-model",
+		});
+
+		expect(agent.calls[0]?.outputFormat).toEqual({
+			type: "json_schema",
+			schema: outputSchema,
+		});
+		expect(recorder.stepOutputs).toEqual([
+			{ name: "summarise", value: structured },
+		]);
+		expect(recorder.outputs["summarise"]).toEqual(structured);
+		expect(recorder.stepEvents.map((e) => e.type)).toEqual([
+			"step.started",
+			"step.completed",
+		]);
+	});
+
+	it("aborts with step.failed when result.subtype is error_max_structured_output_retries", async () => {
+		const recorder = createCtx();
+		const agent = createAgent(async function* () {
+			yield {
+				type: "result",
+				subtype: "error_max_structured_output_retries",
+				duration_ms: 1,
+				duration_api_ms: 1,
+				is_error: true,
+				num_turns: 1,
+				stop_reason: null,
+				total_cost_usd: 0,
+				usage: {} as never,
+				modelUsage: {},
+				permission_denials: [],
+				errors: [],
+				uuid: "00000000-0000-0000-0000-000000000030",
+				session_id: "sess",
+			} as AgentMessage;
+		});
+		const workflow: RepoWorkflow = {
+			branch: "b",
+			base_branch: "main",
+			steps: [
+				{
+					name: "summarise",
+					prompt: "Summarise",
+					resume_previous: false,
+					output_schema: outputSchema,
+				},
+				{ name: "after", prompt: "after", resume_previous: false },
+			],
+			change_request: baseChangeRequest,
+		};
+
+		await expect(
+			runWorkflowSteps({
+				ctx: recorder.ctx,
+				agent,
+				workflow,
+				issue,
+				attempt: 1,
+				cwd: "/work",
+				model: "test-model",
+			}),
+		).rejects.toThrow(/error_max_structured_output_retries/);
+
+		expect(agent.calls).toHaveLength(1);
+		expect(recorder.stepEvents.map((e) => e.type)).toEqual([
+			"step.started",
+			"step.failed",
+		]);
+		expect(recorder.stepOutputs).toEqual([]);
+	});
+
+	it("ignores a result.success message on an action step (no output_schema)", async () => {
+		const recorder = createCtx();
+		const agent = createAgent(async function* () {
+			yield* yieldAssistant("sess");
+			yield {
+				type: "result",
+				subtype: "success",
+				duration_ms: 1,
+				duration_api_ms: 1,
+				is_error: false,
+				num_turns: 1,
+				result: "ok",
+				stop_reason: "end_turn",
+				total_cost_usd: 0,
+				usage: {} as never,
+				modelUsage: {},
+				permission_denials: [],
+				structured_output: { ignored: true },
+				uuid: "00000000-0000-0000-0000-000000000040",
+				session_id: "sess",
+			} as AgentMessage;
+		});
+		const workflow: RepoWorkflow = {
+			branch: "b",
+			base_branch: "main",
+			steps: [{ name: "implement", prompt: "do it", resume_previous: false }],
+			change_request: baseChangeRequest,
+		};
+
+		await runWorkflowSteps({
+			ctx: recorder.ctx,
+			agent,
+			workflow,
+			issue,
+			attempt: 1,
+			cwd: "/work",
+			model: "test-model",
+		});
+
+		expect(recorder.stepOutputs).toEqual([]);
+		expect(recorder.stepEvents.map((e) => e.type)).toEqual([
+			"step.started",
+			"step.completed",
+		]);
+	});
+
+	it("exposes initialOutputs on ctx.outputs throughout the run", async () => {
+		const recorder = createCtx({ earlier: { x: "from-parent" } });
+		let observed: Record<string, unknown> | undefined;
+		const agent = createAgent(async function* (_opts) {
+			observed = { ...recorder.ctx.outputs };
+			yield* yieldAssistant("sess");
+		});
+		const workflow: RepoWorkflow = {
+			branch: "b",
+			base_branch: "main",
+			steps: [{ name: "after", prompt: "after", resume_previous: false }],
+			change_request: baseChangeRequest,
+		};
+
+		await runWorkflowSteps({
+			ctx: recorder.ctx,
+			agent,
+			workflow,
+			issue,
+			attempt: 1,
+			cwd: "/work",
+			model: "test-model",
+		});
+
+		expect(observed).toEqual({ earlier: { x: "from-parent" } });
+	});
+});

--- a/server/orchestrator/agent-invoker.ts
+++ b/server/orchestrator/agent-invoker.ts
@@ -3,12 +3,18 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 export type AgentMessage =
 	ReturnType<typeof query> extends AsyncGenerator<infer T> ? T : never;
 
+export type OutputFormat = {
+	type: "json_schema";
+	schema: Record<string, unknown>;
+};
+
 export type AgentInvokeOptions = {
 	prompt: string;
 	cwd: string;
 	model: string;
 	resumeSessionId?: string;
 	signal: AbortSignal;
+	outputFormat?: OutputFormat;
 };
 
 export type AgentInvoker = {
@@ -26,7 +32,7 @@ export const ALLOWED_TOOLS = [
 
 export function claudeSdkAgentInvoker(): AgentInvoker {
 	return {
-		invoke({ prompt, cwd, model, resumeSessionId }) {
+		invoke({ prompt, cwd, model, resumeSessionId, outputFormat }) {
 			return query({
 				prompt,
 				options: {
@@ -35,6 +41,7 @@ export function claudeSdkAgentInvoker(): AgentInvoker {
 					allowedTools: [...ALLOWED_TOOLS],
 					permissionMode: "dontAsk" as const,
 					...(resumeSessionId && { resume: resumeSessionId }),
+					...(outputFormat && { outputFormat }),
 				},
 			});
 		},

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -61,6 +61,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 
 	const lifecycle = createRunLifecycle({
 		runner,
+		repo: runRepo,
 		tracker,
 		codeHost,
 		agent,

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -1,6 +1,7 @@
 import * as canonicalLog from "../canonical-log.ts";
 import type { CodeHostAdapter } from "../code-hosts/types.ts";
 import { logger } from "../logger.ts";
+import type { RunRepository } from "../run-repository.ts";
 import type { RunHandle, Runner, RunResult } from "../runner/runner.ts";
 import type { Issue, TrackerAdapter } from "../trackers/types.ts";
 import {
@@ -41,6 +42,7 @@ export type RunLifecycle = {
 
 type RunLifecycleDeps = {
 	runner: Runner;
+	repo: RunRepository;
 	tracker: TrackerAdapter;
 	codeHost: CodeHostAdapter;
 	agent: AgentInvoker;
@@ -54,6 +56,7 @@ type RunLifecycleDeps = {
 export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 	const {
 		runner,
+		repo: runRepo,
 		tracker,
 		codeHost,
 		agent,
@@ -78,7 +81,10 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 			issueKey: issue.key,
 			issueTitle: issue.title,
 			attempt,
-			...(resume?.parentRunId != null && { parentRunId: resume.parentRunId }),
+			...(resume?.parentRunId != null && {
+				parentRunId: resume.parentRunId,
+				initialOutputs: runRepo.getStepOutputs(resume.parentRunId),
+			}),
 			handler: (ctx) =>
 				canonicalLog.run(
 					{

--- a/server/orchestrator/step-runner.ts
+++ b/server/orchestrator/step-runner.ts
@@ -8,7 +8,7 @@ import {
 } from "../workflow/prompt-preprocessor.ts";
 import type { RepoWorkflow, WorkflowStep } from "../workflow/workflow.ts";
 import { renderPrompt } from "../workflow/workflow.ts";
-import type { AgentInvoker } from "./agent-invoker.ts";
+import type { AgentInvoker, OutputFormat } from "./agent-invoker.ts";
 import { logAgentMessage } from "./agent-logging.ts";
 
 type RunWorkflowStepsParams = {
@@ -109,16 +109,37 @@ async function runWorkflowStep({
 		});
 		const prompt = await expandMarkedShellBlocks(renderedPrompt, { cwd });
 
+		const outputFormat: OutputFormat | undefined = step.output_schema
+			? { type: "json_schema", schema: step.output_schema }
+			: undefined;
+
 		for await (const msg of agent.invoke({
 			prompt,
 			cwd,
 			model,
 			signal: ctx.signal,
 			...(resumeSessionId && { resumeSessionId }),
+			...(outputFormat && { outputFormat }),
 		})) {
-			if (msg.type !== "assistant") continue;
-			logAgentMessage(msg, cwd, ctx.emitToolUse);
-			currentSessionId = msg.session_id;
+			if (msg.type === "assistant") {
+				logAgentMessage(msg, cwd, ctx.emitToolUse);
+				currentSessionId = msg.session_id;
+				continue;
+			}
+			if (msg.type === "result") {
+				currentSessionId = msg.session_id;
+				if (msg.subtype === "success") {
+					if (outputFormat) {
+						ctx.setStepOutput(step.name, msg.structured_output);
+						canonicalLog.append("step_outputs", {
+							name: step.name,
+							output: msg.structured_output,
+						});
+					}
+					continue;
+				}
+				throw new Error(msg.subtype);
+			}
 		}
 
 		ctx.setSessionId(currentSessionId ?? null);

--- a/server/run-repository.ts
+++ b/server/run-repository.ts
@@ -7,6 +7,7 @@ import {
 	type RunEventType,
 	type RunStatus,
 	runEvents,
+	runStepOutputs,
 	runs,
 } from "./db/schema.ts";
 import type { IssueKey, RunId } from "./types/brands.ts";
@@ -124,6 +125,8 @@ export type RunRepository = {
 		limit: number;
 	}): Run[];
 	getRunEvents(runId: RunId): RunEvent[];
+	writeStepOutput(runId: RunId, stepName: string, value: unknown): void;
+	getStepOutputs(runId: RunId): Record<string, unknown>;
 };
 
 export function createRunRepository(db: Db): RunRepository {
@@ -209,6 +212,28 @@ export function createRunRepository(db: Db): RunRepository {
 				.where(eq(runEvents.runId, runId))
 				.orderBy(asc(runEvents.createdAt))
 				.all();
+		},
+
+		writeStepOutput(runId, stepName, value) {
+			const createdAt = new Date().toISOString();
+			db.insert(runStepOutputs)
+				.values({ runId, stepName, outputJson: value, createdAt })
+				.onConflictDoUpdate({
+					target: [runStepOutputs.runId, runStepOutputs.stepName],
+					set: { outputJson: value, createdAt },
+				})
+				.run();
+		},
+
+		getStepOutputs(runId) {
+			const rows = db
+				.select()
+				.from(runStepOutputs)
+				.where(eq(runStepOutputs.runId, runId))
+				.all();
+			const out: Record<string, unknown> = {};
+			for (const row of rows) out[row.stepName] = row.outputJson;
+			return out;
 		},
 	};
 }

--- a/server/runner/runner.ts
+++ b/server/runner/runner.ts
@@ -12,6 +12,8 @@ export type RunContext = {
 	emitStepEvent: (event: StepEvent) => void;
 	setSessionId: (id: string | null) => void;
 	setStepIndex: (index: number) => void;
+	setStepOutput: (stepName: string, value: unknown) => void;
+	outputs: Record<string, unknown>;
 	signal: AbortSignal;
 };
 
@@ -22,6 +24,7 @@ export type AgentJob = {
 	handler: (ctx: RunContext) => Promise<RunResult>;
 	attempt?: number;
 	parentRunId?: RunId;
+	initialOutputs?: Record<string, unknown>;
 };
 
 export type RunResult =
@@ -132,6 +135,13 @@ export function createRunner(config: RunnerConfig): Runner {
 				repo.setStepIndex(id, index);
 			};
 
+			const outputs: Record<string, unknown> = { ...job.initialOutputs };
+
+			const setStepOutput = (stepName: string, value: unknown) => {
+				outputs[stepName] = value;
+				repo.writeStepOutput(id, stepName, value);
+			};
+
 			const emitToolUse = (tool: string, target: string) => {
 				emitEvent(id, job.name, {
 					type: "run:tool_use",
@@ -160,6 +170,8 @@ export function createRunner(config: RunnerConfig): Runner {
 					emitStepEvent,
 					setSessionId,
 					setStepIndex,
+					setStepOutput,
+					outputs,
 					signal: controller.signal,
 				}),
 				abortPromise,

--- a/server/testing/support/test-lifecycle.ts
+++ b/server/testing/support/test-lifecycle.ts
@@ -258,6 +258,7 @@ export async function createTestRunLifecycle(
 
 	const lifecycle = createRunLifecycle({
 		runner,
+		repo,
 		tracker,
 		codeHost,
 		agent: options.agent ?? silentAgent,

--- a/server/workflow/__tests__/workflow.test.ts
+++ b/server/workflow/__tests__/workflow.test.ts
@@ -226,10 +226,41 @@ base_branch: main
 steps:
   - name: implement
     prompt: Fix it
-    output_schema: { type: object }
-`;
+    bogus: value
+${validChangeRequest}`;
 
 		expect(() => parseRepoWorkflow(yaml)).toThrow();
+	});
+
+	it("accepts a step with an output_schema (raw JSON Schema)", () => {
+		const yaml = `
+branch: my-branch
+base_branch: main
+steps:
+  - name: summarise
+    prompt: Summarise the issue
+    output_schema:
+      type: object
+      properties:
+        title:
+          type: string
+      required: [title]
+${validChangeRequest}`;
+
+		const result = parseRepoWorkflow(yaml);
+
+		expect(result.steps).toEqual([
+			{
+				name: "summarise",
+				prompt: "Summarise the issue",
+				resume_previous: false,
+				output_schema: {
+					type: "object",
+					properties: { title: { type: "string" } },
+					required: ["title"],
+				},
+			},
+		]);
 	});
 
 	it("throws on invalid YAML", () => {

--- a/server/workflow/workflow.ts
+++ b/server/workflow/workflow.ts
@@ -8,6 +8,7 @@ const workflowStepSchema = z
 		name: z.string().min(1),
 		prompt: z.string(),
 		resume_previous: z.boolean().optional().default(false),
+		output_schema: z.record(z.string(), z.unknown()).optional(),
 	})
 	.strict();
 


### PR DESCRIPTION
## Summary

- Add optional `output_schema` (raw JSON Schema) to step definitions; thread `outputFormat: { type: "json_schema", schema }` through `AgentInvoker` to the SDK.
- Step runner now consumes terminal `result` messages: on `success` it captures `structured_output` via a new `RunContext.setStepOutput` setter (which persists to `run_step_outputs`); on `error_max_structured_output_retries` (and other error subtypes) it throws and the existing `catch` emits `step.failed`, aborting the run.
- New `RunRepository.writeStepOutput`/`getStepOutputs`. Lifecycle hydrates `RunContext.outputs` from the parent run on retry (in-memory only — parent rows are not re-persisted under the new run id).

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 41 files, 263 tests (up from 250)
- [x] `pnpm test:coverage` — Statements 99.35% / Branches 98.45% / Functions 98.18% / Lines 99.3%
- [x] New unit tests in `server/orchestrator/__tests__/step-runner.test.ts` cover action steps, output-step success, max-retries abort, terminal-result-on-action, and `initialOutputs` hydration.
- [x] Repo tests cover `writeStepOutput` upsert and `getStepOutputs` read.
- [x] Lifecycle integration tests cover output-step end-to-end persistence, abort on max-retries, and retry-without-re-persisting-parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)