### PR TITLE
feat: gitlab clone token + jira labels filter

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,19 @@
 tracker:
-  kind: github
+  kind: jira
+  base_url: todo
+  project: AIENG
+  statuses:
+    pending: "To Do"
+    running: "In Progress"
+    awaiting_review: "In Review"
+  labels:
+    - software-factory-poc
 
 code_host:
-  kind: github
+  kind: gitlab
+  base_url: https://gitlab.com
   repos:
-    - nhollas/target-dummy
+    - todo
 
 defaults:
   polling_interval_ms: 30000

--- a/server/__tests__/config.test.ts
+++ b/server/__tests__/config.test.ts
@@ -125,6 +125,52 @@ ${fullDefaults}`);
 		});
 	});
 
+	it("accepts jira tracker with optional labels", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: jira
+  base_url: https://jira.example.test
+  project: PROJ
+  statuses:
+    pending: To Do
+    running: In Progress
+    awaiting_review: In Review
+  labels:
+    - software-factory-poc
+code_host:
+  kind: github
+  repos:
+    - owner/repo
+${fullDefaults}`);
+
+		const config = loadConfig(configFile.path);
+
+		expect(config.tracker).toMatchObject({
+			kind: "jira",
+			labels: ["software-factory-poc"],
+		});
+	});
+
+	it("rejects jira tracker with an empty labels list", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: jira
+  base_url: https://jira.example.test
+  project: PROJ
+  statuses:
+    pending: To Do
+    running: In Progress
+    awaiting_review: In Review
+  labels: []
+code_host:
+  kind: github
+  repos:
+    - owner/repo
+${fullDefaults}`);
+
+		expect(() => loadConfig(configFile.path)).toThrow();
+	});
+
 	it("rejects jira tracker with zero code host repos", () => {
 		using configFile = writeConfig(`
 tracker:

--- a/server/code-hosts/__tests__/gitlab.integration.test.ts
+++ b/server/code-hosts/__tests__/gitlab.integration.test.ts
@@ -19,6 +19,20 @@ describe("cloneUrl", () => {
 		);
 	});
 
+	it("embeds the configured token as HTTP basic auth when provided", () => {
+		const tokenAdapter = gitlabCodeHostAdapter(
+			createGitLabClient(gitlabToken("test-token"), {
+				baseUrl: GITLAB_BASE_URL,
+			}),
+			GITLAB_BASE_URL,
+			gitlabToken("token-with/special:chars"),
+		);
+
+		expect(tokenAdapter.cloneUrl(REPO)).toBe(
+			"https://oauth2:token-with%2Fspecial%3Achars@gitlab.example.test/group/subgroup/project.git",
+		);
+	});
+
 	it("defaults to gitlab.com when no base URL is configured", async () => {
 		const defaultAdapter = gitlabCodeHostAdapter(
 			createGitLabClient(gitlabToken("test-token")),

--- a/server/code-hosts/gitlab.ts
+++ b/server/code-hosts/gitlab.ts
@@ -1,4 +1,5 @@
 import type { GitLabClient } from "../gitlab-client.ts";
+import type { GitLabToken } from "../types/brands.ts";
 import { decorateCodeHost } from "./decorator.ts";
 import type { ChangeRequest, CodeHostAdapter } from "./types.ts";
 
@@ -9,6 +10,7 @@ function trimTrailingSlash(value: string): string {
 export function gitlabCodeHostAdapter(
 	client: GitLabClient,
 	baseUrl = "https://gitlab.com",
+	cloneToken?: GitLabToken,
 ): CodeHostAdapter {
 	const cloneBaseUrl = trimTrailingSlash(baseUrl);
 
@@ -23,7 +25,14 @@ export function gitlabCodeHostAdapter(
 		},
 
 		cloneUrl(repo): string {
-			return `${cloneBaseUrl}/${repo}.git`;
+			const url = `${cloneBaseUrl}/${repo}.git`;
+			if (!cloneToken) return url;
+			// Embed the token as HTTP basic auth so `git clone` (and later
+			// push/fetch from the same remote) authenticate to GitLab.
+			return url.replace(
+				/^(https?:\/\/)/,
+				`$1oauth2:${encodeURIComponent(cloneToken)}@`,
+			);
 		},
 
 		async createChangeRequest(

--- a/server/config.ts
+++ b/server/config.ts
@@ -17,6 +17,7 @@ export type Config = {
 					running: string;
 					awaiting_review: string;
 				};
+				labels?: string[] | undefined;
 		  };
 	code_host:
 		| {
@@ -59,6 +60,7 @@ const configSchema = z
 							awaiting_review: z.string().min(1),
 						})
 						.strict(),
+					labels: z.array(z.string().min(1)).min(1).optional(),
 				})
 				.strict(),
 		]),

--- a/server/server.ts
+++ b/server/server.ts
@@ -51,6 +51,7 @@ if (config.tracker.kind === "github") {
 		repo: jiraRepo,
 		baseUrl: config.tracker.base_url,
 		statuses: config.tracker.statuses,
+		...(config.tracker.labels && { labels: config.tracker.labels }),
 	});
 }
 let codeHost: CodeHostAdapter;
@@ -63,7 +64,11 @@ if (config.code_host.kind === "github") {
 	const gitlab = createGitLabClient(env.GITLAB_TOKEN, {
 		baseUrl: config.code_host.base_url,
 	});
-	codeHost = gitlabCodeHostAdapter(gitlab, config.code_host.base_url);
+	codeHost = gitlabCodeHostAdapter(
+		gitlab,
+		config.code_host.base_url,
+		env.GITLAB_TOKEN,
+	);
 }
 const repo = createRunRepository(db);
 

--- a/server/trackers/__tests__/jira.integration.test.ts
+++ b/server/trackers/__tests__/jira.integration.test.ts
@@ -149,6 +149,43 @@ describe("jiraTrackerAdapter", () => {
 			expect(issues.map((issue) => issue.key)).toEqual(["PROJ-1"]);
 		});
 
+		it("adds a labels clause to the JQL when labels are configured", async () => {
+			server.use(
+				http.post(`${JIRA_API}/search/jql`, async ({ request }) => {
+					const body = (await request.json()) as { jql?: string };
+					if (
+						body.jql !==
+						'project = "PROJ" AND status = "To Do" AND labels in ("software-factory-poc", "needs-triage") ORDER BY created ASC'
+					) {
+						return new HttpResponse(null, { status: 400 });
+					}
+					return HttpResponse.json({
+						issues: [createJiraIssue("PROJ-1", "To Do")],
+					});
+				}),
+			);
+
+			const tracker = jiraTrackerAdapter(
+				createJiraClient({
+					baseUrl: JIRA_BASE_URL,
+					email: jiraEmail("agent@example.test"),
+					apiToken: jiraApiToken("jira-token"),
+					maxAttempts: 1,
+				}),
+				{
+					project: "PROJ",
+					repo: REPO,
+					baseUrl: JIRA_BASE_URL,
+					statuses,
+					labels: ["software-factory-poc", "needs-triage"],
+				},
+			);
+
+			const issues = await tracker.fetchActiveIssues(REPO, "pending");
+
+			expect(issues.map((issue) => issue.key)).toEqual(["PROJ-1"]);
+		});
+
 		it("escapes quotes and backslashes in custom status names", async () => {
 			server.use(
 				http.post(`${JIRA_API}/search/jql`, async ({ request }) => {

--- a/server/trackers/jira.ts
+++ b/server/trackers/jira.ts
@@ -11,6 +11,7 @@ type JiraTrackerOptions = {
 	repo: RepoSlug;
 	baseUrl: string;
 	statuses: JiraStatuses;
+	labels?: readonly string[];
 };
 
 function jiraIssueKey(project: string, num: number): string {
@@ -81,11 +82,15 @@ export function jiraTrackerAdapter(
 		},
 
 		async fetchActiveIssues(_repo, state): Promise<Issue[]> {
-			const filter = [
+			const clauses = [
 				`project = ${quoteJqlString(options.project)}`,
 				`status = ${quoteJqlString(options.statuses[state])}`,
-			].join(" AND ");
-			const jql = `${filter} ORDER BY created ASC`;
+			];
+			if (options.labels && options.labels.length > 0) {
+				const quoted = options.labels.map(quoteJqlString).join(", ");
+				clauses.push(`labels in (${quoted})`);
+			}
+			const jql = `${clauses.join(" AND ")} ORDER BY created ASC`;
 			const issues = await client.searchIssues({ jql, maxResults: 100 });
 			return issues.map((issue) =>
 				mapJiraIssue(options.project, options.baseUrl, issue),


### PR DESCRIPTION
## Summary

- **GitLab clone token**: `gitlabCodeHostAdapter` accepts an optional `cloneToken` and embeds it in the clone URL as `oauth2:<token>@…`, so subsequent fetch/push against the same remote authenticate against GitLab. `server.ts` wires `GITLAB_TOKEN` through.
- **Jira labels filter**: `jiraTrackerAdapter` accepts an optional `labels` list and adds a `labels in (…)` clause to the JQL when present, so a shared Jira project can be scoped to a subset of issues. Schema validates a non-empty list when supplied.
- **Example config**: `config.yaml` flipped from the GitHub example to a Jira + GitLab one. `base_url` and `repos` are left as `todo` placeholders for now — that's intentional, will be replaced when the canonical values are confirmed.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — new coverage for `cloneUrl` token embedding, JQL labels clause, and config schema (accepts labels / rejects empty list)
- [ ] Smoke-run against the real GitLab + Jira project once `todo` values are filled in