### PR TITLE
feat: repo-scoping slice 2 — Issue.repo and TrackerAdapter shape

### DIFF
--- a/docs/repo-scoping-plan.md
+++ b/docs/repo-scoping-plan.md
@@ -82,7 +82,9 @@ Slices 4 → 5 are also sequential. Slice 4's new pending filter (`trigger_label
 
 ## Slice 2 — `Issue.repo` and `TrackerAdapter` Shape
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Verification:** `pnpm lint`, `pnpm typecheck`, `pnpm test` (319 tests).
 
 **Purpose:** Lift the assumption that the orchestrator knows the repo before asking the tracker. Make `Issue` carry its resolved repo, and let adapters return all eligible issues in a single call rather than being asked per repo. This is a pure structural refactor — no user-visible behaviour change.
 

--- a/drizzle/0005_aromatic_adam_warlock.sql
+++ b/drizzle/0005_aromatic_adam_warlock.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `runs` ADD `repo` text NOT NULL;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,222 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "81d63d0e-c12f-4c45-bf95-0469502d550e",
+	"prevId": "0e3a8c7a-1d4b-4e3f-9c5a-72b3e4f5a6b7",
+	"tables": {
+		"run_events": {
+			"name": "run_events",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"data": {
+					"name": "data",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_run_events_run_id": {
+					"name": "idx_run_events_run_id",
+					"columns": ["run_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"run_step_outputs": {
+			"name": "run_step_outputs",
+			"columns": {
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"step_name": {
+					"name": "step_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"output_json": {
+					"name": "output_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"run_step_outputs_run_id_step_name_pk": {
+					"columns": ["run_id", "step_name"],
+					"name": "run_step_outputs_run_id_step_name_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"runs": {
+			"name": "runs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repo": {
+					"name": "repo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"issue_key": {
+					"name": "issue_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"issue_title": {
+					"name": "issue_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"parent_run_id": {
+					"name": "parent_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"step_index": {
+					"name": "step_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
 			"when": 1778017200000,
 			"tag": "0004_workflow_restructure_slice_1",
 			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "6",
+			"when": 1777816449128,
+			"tag": "0005_aromatic_adam_warlock",
+			"breakpoints": true
 		}
 	]
 }

--- a/server/__tests__/run-repository.test.ts
+++ b/server/__tests__/run-repository.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { runStepOutputs, runs } from "../db/schema.ts";
 import { createRunRepository } from "../run-repository.ts";
 import { createTestDb } from "../testing/support/test-db.ts";
-import { issueKey, runId } from "../types/brands.ts";
+import { issueKey, repoSlug, runId } from "../types/brands.ts";
 
 describe("run repository row projection", () => {
 	it("throws when a completed row is missing completedAt", () => {
@@ -13,6 +13,7 @@ describe("run repository row projection", () => {
 				id: runId("bad-completed"),
 				agentName: "agent",
 				status: "completed",
+				repo: repoSlug("acme/widgets"),
 				startedAt: "2025-01-01T00:00:00Z",
 				durationMs: 100,
 			})
@@ -31,6 +32,7 @@ describe("run repository row projection", () => {
 				id: runId("bad-failed"),
 				agentName: "agent",
 				status: "failed",
+				repo: repoSlug("acme/widgets"),
 				startedAt: "2025-01-01T00:00:00Z",
 				completedAt: "2025-01-01T00:00:01Z",
 			})
@@ -49,7 +51,8 @@ describe("run repository row projection", () => {
 				id: runId("failed-1"),
 				agentName: "agent",
 				status: "failed",
-				issueKey: issueKey("owner/repo#1"),
+				repo: repoSlug("acme/widgets"),
+				issueKey: issueKey("acme/widgets#1"),
 				issueTitle: "boom",
 				startedAt: "2025-01-01T00:00:00Z",
 				completedAt: "2025-01-01T00:00:02Z",
@@ -63,7 +66,8 @@ describe("run repository row projection", () => {
 			id: "failed-1",
 			agentName: "agent",
 			status: "failed",
-			issueKey: "owner/repo#1",
+			repo: "acme/widgets",
+			issueKey: "acme/widgets#1",
 			issueTitle: "boom",
 			startedAt: "2025-01-01T00:00:00Z",
 			completedAt: "2025-01-01T00:00:02Z",

--- a/server/api/__tests__/api.test.ts
+++ b/server/api/__tests__/api.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createTestApi } from "../../testing/support/test-api.ts";
-import { issueKey } from "../../types/brands.ts";
+import { issueKey, repoSlug } from "../../types/brands.ts";
 import type { HealthCheck } from "../api.ts";
 
 describe("GET /health", () => {
@@ -61,6 +61,7 @@ describe("GET /events", () => {
 
 			runner.enqueue({
 				name: "sse-agent",
+				repo: repoSlug("test/repo"),
 				issueKey: issueKey("test/repo#42"),
 				issueTitle: "SSE test issue",
 				handler: async () => ({ status: "completed" as const, durationMs: 0 }),

--- a/server/api/__tests__/runs.test.ts
+++ b/server/api/__tests__/runs.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createTestApi } from "../../testing/support/test-api.ts";
 import { seedEvent, seedRun } from "../../testing/support/test-db.ts";
-import { issueKey, runId } from "../../types/brands.ts";
+import { issueKey, repoSlug, runId } from "../../types/brands.ts";
 
 describe("GET /runs", () => {
 	it("returns empty array when no runs exist", async () => {
@@ -29,6 +29,7 @@ describe("GET /runs", () => {
 				agentName: "test-agent",
 				status: "completed",
 				error: null,
+				repo: "test-owner/test-repo",
 				issueKey: null,
 				issueTitle: null,
 				startedAt: "2025-01-03T00:00:00Z",
@@ -44,6 +45,7 @@ describe("GET /runs", () => {
 				agentName: "test-agent",
 				status: "completed",
 				error: null,
+				repo: "test-owner/test-repo",
 				issueKey: null,
 				issueTitle: null,
 				startedAt: "2025-01-02T00:00:00Z",
@@ -59,6 +61,7 @@ describe("GET /runs", () => {
 				agentName: "test-agent",
 				status: "completed",
 				error: null,
+				repo: "test-owner/test-repo",
 				issueKey: null,
 				issueTitle: null,
 				startedAt: "2025-01-01T00:00:00Z",
@@ -95,6 +98,7 @@ describe("GET /runs", () => {
 				agentName: "agent-alpha",
 				status: "completed",
 				error: null,
+				repo: "test-owner/test-repo",
 				issueKey: null,
 				issueTitle: null,
 				startedAt: "2025-01-01T00:00:00Z",
@@ -136,6 +140,7 @@ describe("GET /runs", () => {
 				agentName: "test-agent",
 				status: "running",
 				error: null,
+				repo: "test-owner/test-repo",
 				issueKey: null,
 				issueTitle: null,
 				startedAt: "2025-01-01T00:00:00Z",
@@ -170,6 +175,7 @@ describe("GET /runs", () => {
 				agentName: "test-agent",
 				status: "failed",
 				error: "agent timed out",
+				repo: "test-owner/test-repo",
 				issueKey: null,
 				issueTitle: null,
 				startedAt: "2025-01-03T00:00:00Z",
@@ -199,6 +205,7 @@ describe("GET /runs", () => {
 				agentName: "test-agent",
 				status: "completed",
 				error: null,
+				repo: "test-owner/test-repo",
 				issueKey: null,
 				issueTitle: null,
 				startedAt: "2025-01-03T00:00:00Z",
@@ -246,6 +253,7 @@ describe("GET /runs/:id", () => {
 			agentName: "my-agent",
 			status: "completed",
 			error: null,
+			repo: "test-owner/test-repo",
 			issueKey: null,
 			issueTitle: null,
 			startedAt: "2025-01-01T00:00:00Z",
@@ -295,6 +303,7 @@ describe("POST /runs/:id/kill", () => {
 		const { app, runner } = createTestApi();
 		const { runId } = runner.enqueue({
 			name: "long-job",
+			repo: repoSlug("test/repo"),
 			issueKey: issueKey("test/repo#1"),
 			issueTitle: "Long running job",
 			handler: () => new Promise(() => {}),

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -7,13 +7,14 @@ import {
 	sqliteTable,
 	text,
 } from "drizzle-orm/sqlite-core";
-import type { IssueKey, RunId } from "../types/brands.ts";
+import type { IssueKey, RepoSlug, RunId } from "../types/brands.ts";
 
 export const runs = sqliteTable("runs", {
 	id: text("id").primaryKey().$type<RunId>(),
 	agentName: text("agent_name").notNull(),
 	status: text("status").notNull().$type<RunStatus>(),
 	error: text("error"),
+	repo: text("repo").notNull().$type<RepoSlug>(),
 	issueKey: text("issue_key").$type<IssueKey>(),
 	issueTitle: text("issue_title"),
 	startedAt: text("started_at").notNull(),

--- a/server/orchestrator/__tests__/branch-resolver.test.ts
+++ b/server/orchestrator/__tests__/branch-resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Issue } from "../../trackers/types.ts";
-import { issueKey, issueNumber } from "../../types/brands.ts";
+import { issueKey, issueNumber, repoSlug } from "../../types/brands.ts";
 import type {
 	AgentInvokeOptions,
 	AgentInvoker,
@@ -12,6 +12,7 @@ import { resolveBranch } from "../branch-resolver.ts";
 const issue: Issue = {
 	key: issueKey("owner/repo#1"),
 	number: issueNumber(7),
+	repo: repoSlug("owner/repo"),
 	title: "Fix it",
 	description: "",
 	labels: [],

--- a/server/orchestrator/__tests__/change-request-renderer.test.ts
+++ b/server/orchestrator/__tests__/change-request-renderer.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from "vitest";
 import type { Issue } from "../../trackers/types.ts";
-import { branchName, issueKey, issueNumber } from "../../types/brands.ts";
+import {
+	branchName,
+	issueKey,
+	issueNumber,
+	repoSlug,
+} from "../../types/brands.ts";
 import { renderChangeRequest } from "../change-request-renderer.ts";
 
 const issue: Issue = {
 	key: issueKey("owner/repo#42"),
 	number: issueNumber(42),
+	repo: repoSlug("owner/repo"),
 	title: "Fix login bug",
 	description: "Login throws on null email",
 	labels: ["bug"],

--- a/server/orchestrator/__tests__/orchestrator.reconcile.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.reconcile.integration.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../../testing/support/fixtures.ts";
 import { githubHandlers, server } from "../../testing/support/msw.ts";
 import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
-import { issueKey, runId as rid } from "../../types/brands.ts";
+import { issueKey, repoSlug, runId as rid } from "../../types/brands.ts";
 
 describe("Orchestrator reconciliation", () => {
 	it("kills agent when issue no longer has the running label", async () => {
@@ -45,6 +45,7 @@ describe("Orchestrator reconciliation", () => {
 				agentName: "issue-1",
 				status: "running",
 				error: null,
+				repo: REPO,
 				issueKey: `${REPO}#1`,
 				issueTitle: "Issue 1",
 				startedAt: expect.any(String),
@@ -72,6 +73,7 @@ describe("Orchestrator reconciliation", () => {
 				agentName: "issue-1",
 				status: "failed",
 				error: "Run killed by user",
+				repo: REPO,
 				issueKey: `${REPO}#1`,
 				issueTitle: "Issue 1",
 				startedAt: runsBefore[0]?.startedAt,
@@ -121,6 +123,7 @@ describe("Orchestrator reconciliation", () => {
 				agentName: "issue-2",
 				status: "running",
 				error: null,
+				repo: REPO,
 				issueKey: `${REPO}#2`,
 				issueTitle: "Issue 2",
 				startedAt: expect.any(String),
@@ -211,6 +214,7 @@ describe("Orchestrator reconciliation", () => {
 				agentName: "issue-1",
 				status: "running",
 				error: null,
+				repo: REPO,
 				issueKey: `${REPO}#1`,
 				issueTitle: "Issue 1",
 				startedAt: expect.any(String),
@@ -352,6 +356,7 @@ describe("Orchestrator reconciliation", () => {
 				id: rid("stale-run"),
 				agentName: "issue-5",
 				status: "running",
+				repo: repoSlug(REPO),
 				issueKey: issueKey(`${REPO}#5`),
 				issueTitle: "Stale issue",
 				startedAt: "2025-01-01T00:00:00Z",
@@ -368,6 +373,7 @@ describe("Orchestrator reconciliation", () => {
 				agentName: "issue-5",
 				status: "failed",
 				error: "Stale run from previous session",
+				repo: REPO,
 				issueKey: `${REPO}#5`,
 				issueTitle: "Stale issue",
 				startedAt: "2025-01-01T00:00:00Z",
@@ -425,6 +431,7 @@ describe("Orchestrator reconciliation", () => {
 				id: rid("completed-orphan"),
 				agentName: "issue-1",
 				status: "completed",
+				repo: repoSlug(REPO),
 				issueKey: issueKey(`${REPO}#1`),
 				issueTitle: "Issue 1",
 				startedAt: new Date().toISOString(),

--- a/server/orchestrator/__tests__/run-lifecycle.test.ts
+++ b/server/orchestrator/__tests__/run-lifecycle.test.ts
@@ -892,6 +892,7 @@ describe("RunLifecycle.dispatch", () => {
 				id: parentRunIdValue,
 				agentName: "issue-1",
 				status: "failed",
+				repo: TEST_REPO,
 				startedAt: "2026-01-01T00:00:00Z",
 				completedAt: "2026-01-01T00:00:01Z",
 				durationMs: 1,

--- a/server/orchestrator/__tests__/step-runner.test.ts
+++ b/server/orchestrator/__tests__/step-runner.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { StepEvent } from "../../event-bus.ts";
 import type { RunContext } from "../../runner/runner.ts";
 import type { Issue } from "../../trackers/types.ts";
-import { issueKey, issueNumber, runId } from "../../types/brands.ts";
+import { issueKey, issueNumber, repoSlug, runId } from "../../types/brands.ts";
 import type { RepoWorkflow } from "../../workflow/workflow.ts";
 import type {
 	AgentInvokeOptions,
@@ -14,6 +14,7 @@ import { runWorkflowSteps } from "../step-runner.ts";
 const issue: Issue = {
 	key: issueKey("owner/repo#1"),
 	number: issueNumber(1),
+	repo: repoSlug("owner/repo"),
 	title: "Fix it",
 	description: "",
 	labels: [],

--- a/server/orchestrator/__tests__/workspace.test.ts
+++ b/server/orchestrator/__tests__/workspace.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { Issue } from "../../trackers/types.ts";
-import { issueKey, issueNumber } from "../../types/brands.ts";
+import { issueKey, issueNumber, repoSlug } from "../../types/brands.ts";
 import {
 	ensureWorkspace,
 	realRunShell,
@@ -19,6 +19,7 @@ function createIssue(num: number): Issue {
 	return {
 		key: issueKey(`test-owner/test-repo#${num}`),
 		number: issueNumber(num),
+		repo: repoSlug("test-owner/test-repo"),
 		title: `Issue ${num}`,
 		description: "",
 		labels: [],

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -34,11 +34,17 @@ type Orchestrator = {
 };
 
 type TaggedIssue = { issue: Issue; repo: RepoSlug; workflow: RepoWorkflow };
+type RunningEntry = { runIds: RunId[]; repo: RepoSlug };
+type StillRunning = {
+	issues: readonly Issue[];
+	keys: ReadonlySet<IssueKey>;
+	reposReached: ReadonlySet<RepoSlug>;
+};
 type TickState = {
-	runningByIssue: Map<IssueKey, RunId[]>;
+	runningByIssue: Map<IssueKey, RunningEntry>;
 	runningCount: number;
 	pending: TaggedIssue[];
-	stillRunning: Map<RepoSlug, Set<IssueKey>>;
+	stillRunning: StillRunning;
 };
 
 export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
@@ -78,56 +84,55 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 	}
 
 	async function fetchTickState(): Promise<TickState> {
-		const entries = [...workflows.entries()];
-
 		const dbSnapshot = runRepo.getRunningSnapshot();
-		const runningByIssue = new Map<IssueKey, RunId[]>();
+		const runningByIssue = new Map<IssueKey, RunningEntry>();
 		for (const r of dbSnapshot) {
-			const ids = runningByIssue.get(r.issueKey) ?? [];
-			ids.push(r.id);
-			runningByIssue.set(r.issueKey, ids);
+			const entry = runningByIssue.get(r.issueKey) ?? {
+				runIds: [],
+				repo: r.repo,
+			};
+			entry.runIds.push(r.id);
+			runningByIssue.set(r.issueKey, entry);
 		}
 
-		const [pendingResults, runningResults] = await Promise.all([
-			Promise.allSettled(
-				entries.map(async ([repo, workflow]) => {
-					const issues = await tracker.fetchActiveIssues(repo, "pending");
-					return issues.map(
-						(issue): TaggedIssue => ({ issue, repo, workflow }),
-					);
-				}),
-			),
-			Promise.allSettled(
-				entries.map(async ([repo]) => {
-					const issues = await tracker.fetchActiveIssues(repo, "running");
-					return { repo, keys: new Set(issues.map((i) => i.key)) };
-				}),
-			),
+		const [pendingResult, runningResult] = await Promise.allSettled([
+			tracker.fetchActiveIssues("pending"),
+			tracker.fetchActiveIssues("running"),
 		]);
 
 		const pending: TaggedIssue[] = [];
-		for (const result of pendingResults) {
-			if (result.status === "fulfilled") {
-				pending.push(...result.value);
-			} else {
-				logger.warn(
-					{ err: result.reason },
-					"orchestrator.fetch_pending_failed",
-				);
+		if (pendingResult.status === "fulfilled") {
+			for (const issue of pendingResult.value.issues) {
+				const workflow = workflows.get(issue.repo);
+				if (!workflow) continue;
+				pending.push({ issue, repo: issue.repo, workflow });
 			}
+		} else {
+			logger.warn(
+				{ err: pendingResult.reason },
+				"orchestrator.fetch_pending_failed",
+			);
 		}
 		pending.sort((a, b) => a.issue.createdAt.localeCompare(b.issue.createdAt));
 
-		const stillRunning = new Map<RepoSlug, Set<IssueKey>>();
-		for (const result of runningResults) {
-			if (result.status === "fulfilled") {
-				stillRunning.set(result.value.repo, result.value.keys);
-			} else {
-				logger.warn(
-					{ err: result.reason },
-					"orchestrator.fetch_running_failed",
-				);
-			}
+		let stillRunning: StillRunning;
+		if (runningResult.status === "fulfilled") {
+			const issues = runningResult.value.issues;
+			stillRunning = {
+				issues,
+				keys: new Set(issues.map((i) => i.key)),
+				reposReached: runningResult.value.reposReached,
+			};
+		} else {
+			logger.warn(
+				{ err: runningResult.reason },
+				"orchestrator.fetch_running_failed",
+			);
+			stillRunning = {
+				issues: [],
+				keys: new Set(),
+				reposReached: new Set(),
+			};
 		}
 
 		return {
@@ -139,34 +144,34 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 	}
 
 	async function reconcileStaleRuns(state: TickState) {
-		for (const [key, runIds] of state.runningByIssue) {
-			const { repo } = unwrap(tracker.parseIssueKey(key));
-			const repoKeys = state.stillRunning.get(repo);
-			if (repoKeys && !repoKeys.has(key)) {
-				logger.info({ key }, "orchestrator.reconcile_terminal");
-				for (const id of runIds) {
-					const killed = runner.kill(id);
-					if (!killed) {
-						runRepo.failRun(id, {
-							error: "Stale run from previous session",
-							completedAt: new Date().toISOString(),
-						});
-					}
+		const { issues, keys, reposReached } = state.stillRunning;
+
+		for (const [key, { runIds, repo }] of state.runningByIssue) {
+			if (!reposReached.has(repo)) continue;
+			if (keys.has(key)) continue;
+			logger.info({ key }, "orchestrator.reconcile_terminal");
+			for (const id of runIds) {
+				const killed = runner.kill(id);
+				if (!killed) {
+					runRepo.failRun(id, {
+						error: "Stale run from previous session",
+						completedAt: new Date().toISOString(),
+					});
 				}
 			}
 		}
 
-		for (const [repo, keys] of state.stillRunning) {
-			for (const key of keys) {
-				if (state.runningByIssue.has(key)) continue;
-				const { number } = unwrap(tracker.parseIssueKey(key));
-				logger.info({ key }, "orchestrator.reconcile_orphan");
-				await tracker
-					.transitionState(repo, number, "running", "pending")
-					.catch((err) =>
-						logger.warn({ key, err }, "orchestrator.orphan_recovery_failed"),
-					);
-			}
+		for (const issue of issues) {
+			if (state.runningByIssue.has(issue.key)) continue;
+			logger.info({ key: issue.key }, "orchestrator.reconcile_orphan");
+			await tracker
+				.transitionState(issue.repo, issue.number, "running", "pending")
+				.catch((err) =>
+					logger.warn(
+						{ key: issue.key, err },
+						"orchestrator.orphan_recovery_failed",
+					),
+				);
 		}
 	}
 
@@ -201,7 +206,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 			}
 
 			runningCount++;
-			state.runningByIssue.set(issue.key, []);
+			state.runningByIssue.set(issue.key, { runIds: [], repo });
 			logger.info({ issue: issue.key }, "orchestrator.dispatched");
 		}
 	}
@@ -236,9 +241,10 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 			return { error: "Issue already has a running agent" };
 		}
 
-		const { repo, number: issueNumber } = unwrap(
+		const { number: issueNumber } = unwrap(
 			tracker.parseIssueKey(failedRun.issueKey),
 		);
+		const repo = failedRun.repo;
 		const workflow = workflows.get(repo);
 		if (!workflow) return { error: "No workflow for repo" };
 

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -75,6 +75,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 
 		return runner.enqueue({
 			name: `issue-${issue.number}`,
+			repo,
 			issueKey: issue.key,
 			issueTitle: issue.title,
 			attempt,

--- a/server/run-repository.ts
+++ b/server/run-repository.ts
@@ -10,7 +10,7 @@ import {
 	runStepOutputs,
 	runs,
 } from "./db/schema.ts";
-import type { IssueKey, RunId } from "./types/brands.ts";
+import type { IssueKey, RepoSlug, RunId } from "./types/brands.ts";
 import { assertNever } from "./types/exhaustive.ts";
 
 type RunRow = typeof runs.$inferSelect;
@@ -18,6 +18,7 @@ type RunRow = typeof runs.$inferSelect;
 type RunBase = {
 	id: RunId;
 	agentName: string;
+	repo: RepoSlug;
 	issueKey: IssueKey | null;
 	issueTitle: string | null;
 	startedAt: string;
@@ -48,6 +49,7 @@ function rowToRun(row: RunRow): Run {
 	const base: RunBase = {
 		id: row.id,
 		agentName: row.agentName,
+		repo: row.repo,
 		issueKey: row.issueKey,
 		issueTitle: row.issueTitle,
 		startedAt: row.startedAt,
@@ -95,6 +97,7 @@ export type RunRepository = {
 	insertRun(run: {
 		id: RunId;
 		agentName: string;
+		repo: RepoSlug;
 		issueKey: IssueKey;
 		issueTitle: string;
 		startedAt: string;
@@ -117,7 +120,7 @@ export type RunRepository = {
 		data: Record<string, unknown>;
 		createdAt: string;
 	}): void;
-	getRunningSnapshot(): { id: RunId; issueKey: IssueKey }[];
+	getRunningSnapshot(): { id: RunId; issueKey: IssueKey; repo: RepoSlug }[];
 	getRunById(id: RunId): Run | undefined;
 	getRuns(filters: {
 		agent?: string | undefined;
@@ -172,12 +175,12 @@ export function createRunRepository(db: Db): RunRepository {
 
 		getRunningSnapshot() {
 			return db
-				.select({ id: runs.id, issueKey: runs.issueKey })
+				.select({ id: runs.id, issueKey: runs.issueKey, repo: runs.repo })
 				.from(runs)
 				.where(and(eq(runs.status, "running"), isNotNull(runs.issueKey)))
 				.all()
 				.filter(
-					(row): row is { id: RunId; issueKey: IssueKey } =>
+					(row): row is { id: RunId; issueKey: IssueKey; repo: RepoSlug } =>
 						row.issueKey != null,
 				);
 		},

--- a/server/runner/__tests__/runner.integration.test.ts
+++ b/server/runner/__tests__/runner.integration.test.ts
@@ -9,7 +9,11 @@ import {
 	getEvents,
 	getRun,
 } from "../../testing/support/test-db.ts";
-import { issueKey as ik, runId as rid } from "../../types/brands.ts";
+import {
+	issueKey as ik,
+	runId as rid,
+	repoSlug as rs,
+} from "../../types/brands.ts";
 import { ABORT_ERROR, createRunner, type RunResult } from "../runner.ts";
 
 /** Helper: a handler that completes immediately. */
@@ -40,6 +44,7 @@ describe("Runner integration", () => {
 
 		const { runId } = runner.enqueue({
 			name: "test-job",
+			repo: rs("owner/repo"),
 			issueKey: ik("owner/repo#1"),
 			issueTitle: "Test issue",
 			handler: () =>
@@ -55,6 +60,7 @@ describe("Runner integration", () => {
 			agentName: "test-job",
 			status: "running",
 			error: null,
+			repo: "owner/repo",
 			issueKey: ik("owner/repo#1"),
 			issueTitle: "Test issue",
 			startedAt: expect.any(String),
@@ -77,6 +83,7 @@ describe("Runner integration", () => {
 		// Fill the single slot with a blocking job
 		runner.enqueue({
 			name: "blocker",
+			repo: rs("owner/repo"),
 			issueKey: ik("owner/repo#1"),
 			issueTitle: "Blocker",
 			handler: () =>
@@ -88,6 +95,7 @@ describe("Runner integration", () => {
 		// Second job sits in the pending queue — not yet executing
 		const { runId } = runner.enqueue({
 			name: "queued-job",
+			repo: rs("owner/repo"),
 			issueKey: ik("owner/repo#2"),
 			issueTitle: "Queued issue",
 			handler: async () => ({ status: "completed" as const, durationMs: 0 }),
@@ -102,6 +110,7 @@ describe("Runner integration", () => {
 			agentName: "queued-job",
 			status: "running",
 			error: null,
+			repo: "owner/repo",
 			issueKey: ik("owner/repo#2"),
 			issueTitle: "Queued issue",
 			startedAt: expect.any(String),
@@ -122,6 +131,7 @@ describe("Runner integration", () => {
 
 		const { runId, done } = runner.enqueue({
 			name: "fast-job",
+			repo: rs("owner/repo"),
 			issueKey: ik("owner/repo#2"),
 			issueTitle: "Fast issue",
 			handler: completedHandler,
@@ -139,6 +149,7 @@ describe("Runner integration", () => {
 			agentName: "fast-job",
 			status: "completed",
 			error: null,
+			repo: "owner/repo",
 			issueKey: ik("owner/repo#2"),
 			issueTitle: "Fast issue",
 			startedAt: expect.any(String),
@@ -156,6 +167,7 @@ describe("Runner integration", () => {
 
 		const { done } = runner.enqueue({
 			name: "crash-job",
+			repo: rs("owner/repo"),
 			issueKey: ik("owner/repo#99"),
 			issueTitle: "Crash issue",
 			handler: failedHandler("catastrophic failure"),
@@ -175,6 +187,7 @@ describe("Runner integration", () => {
 
 		const { runId } = runner.enqueue({
 			name: "lifecycle-job",
+			repo: rs("owner/repo"),
 			issueKey: ik("owner/repo#4"),
 			issueTitle: "Lifecycle issue",
 			handler: completedHandler,
@@ -206,6 +219,7 @@ describe("Runner integration", () => {
 
 		const { runId } = runner.enqueue({
 			name: "fail-event-job",
+			repo: rs("owner/repo"),
 			issueKey: ik("owner/repo#5"),
 			issueTitle: "Fail event issue",
 			handler: failedHandler("boom"),
@@ -237,6 +251,7 @@ describe("Runner integration", () => {
 
 		const { runId } = runner.enqueue({
 			name: "tool-job",
+			repo: rs("owner/repo"),
 			issueKey: ik("owner/repo#6"),
 			issueTitle: "Tool issue",
 			handler: async (ctx) => {
@@ -286,6 +301,7 @@ describe("Runner integration", () => {
 
 		const { runId, done } = runner.enqueue({
 			name: "killable-job",
+			repo: rs("owner/repo"),
 			issueKey: ik("owner/repo#7"),
 			issueTitle: "Killable issue",
 			handler: () => new Promise(() => {}), // never resolves naturally
@@ -307,6 +323,7 @@ describe("Runner integration", () => {
 			agentName: "killable-job",
 			status: "failed",
 			error: ABORT_ERROR,
+			repo: "owner/repo",
 			issueKey: ik("owner/repo#7"),
 			issueTitle: "Killable issue",
 			startedAt: expect.any(String),
@@ -330,6 +347,7 @@ describe("Runner integration", () => {
 
 		const { runId } = runner.enqueue({
 			name: "retry-job",
+			repo: rs("owner/repo"),
 			issueKey: ik("owner/repo#1"),
 			issueTitle: "Retry issue",
 			handler: completedHandler,
@@ -345,6 +363,7 @@ describe("Runner integration", () => {
 			agentName: "retry-job",
 			status: "completed",
 			error: null,
+			repo: "owner/repo",
 			issueKey: ik("owner/repo#1"),
 			issueTitle: "Retry issue",
 			startedAt: expect.any(String),
@@ -362,6 +381,7 @@ describe("Runner integration", () => {
 
 		const { runId } = runner.enqueue({
 			name: "multi-session-job",
+			repo: rs("owner/repo"),
 			issueKey: ik("owner/repo#8"),
 			issueTitle: "Multi session issue",
 			handler: async (ctx) => {
@@ -380,6 +400,7 @@ describe("Runner integration", () => {
 			agentName: "multi-session-job",
 			status: "completed",
 			error: null,
+			repo: "owner/repo",
 			issueKey: ik("owner/repo#8"),
 			issueTitle: "Multi session issue",
 			startedAt: expect.any(String),
@@ -397,6 +418,7 @@ describe("Runner integration", () => {
 
 		const { runId } = runner.enqueue({
 			name: "step-job",
+			repo: rs("owner/repo"),
 			issueKey: ik("owner/repo#9"),
 			issueTitle: "Step issue",
 			handler: async (ctx) => {
@@ -419,6 +441,7 @@ describe("Runner integration", () => {
 
 		const { runId, done } = runner.enqueue({
 			name: "default-concurrency-job",
+			repo: rs("owner/repo"),
 			issueKey: ik("owner/repo#10"),
 			issueTitle: "Default concurrency",
 			handler: completedHandler,
@@ -440,6 +463,7 @@ describe("Runner integration", () => {
 
 		const { runId } = runner.enqueue({
 			name: "session-job",
+			repo: rs("owner/repo"),
 			issueKey: ik("owner/repo#2"),
 			issueTitle: "Session issue",
 			handler: async (ctx) => {
@@ -456,6 +480,7 @@ describe("Runner integration", () => {
 			agentName: "session-job",
 			status: "completed",
 			error: null,
+			repo: "owner/repo",
 			issueKey: ik("owner/repo#2"),
 			issueTitle: "Session issue",
 			startedAt: expect.any(String),

--- a/server/runner/runner.ts
+++ b/server/runner/runner.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { eventBus, type RunEvent, type StepEvent } from "../event-bus.ts";
 import type { RunRepository } from "../run-repository.ts";
-import { type IssueKey, type RunId, runId } from "../types/brands.ts";
+import {
+	type IssueKey,
+	type RepoSlug,
+	type RunId,
+	runId,
+} from "../types/brands.ts";
 import { createJobQueue, type JobQueue } from "./queue.ts";
 
 export const ABORT_ERROR = "Run killed by user";
@@ -19,6 +24,7 @@ export type RunContext = {
 
 export type AgentJob = {
 	name: string;
+	repo: RepoSlug;
 	issueKey: IssueKey;
 	issueTitle: string;
 	handler: (ctx: RunContext) => Promise<RunResult>;
@@ -107,6 +113,7 @@ export function createRunner(config: RunnerConfig): Runner {
 		repo.insertRun({
 			id,
 			agentName: job.name,
+			repo: job.repo,
 			issueKey: job.issueKey,
 			issueTitle: job.issueTitle,
 			startedAt,

--- a/server/server.ts
+++ b/server/server.ts
@@ -32,7 +32,7 @@ migrate(db);
 const github = createGitHubClient(env.GITHUB_TOKEN ?? githubToken(""));
 let tracker: TrackerAdapter;
 if (config.tracker.kind === "github") {
-	tracker = githubTrackerAdapter(github);
+	tracker = githubTrackerAdapter(github, { repos: config.code_host.repos });
 } else {
 	const jiraRepo = config.code_host.repos[0];
 	if (!jiraRepo) {

--- a/server/testing/support/test-db.ts
+++ b/server/testing/support/test-db.ts
@@ -4,7 +4,7 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Db } from "../../db/db.ts";
 import { migrate } from "../../db/migrate.ts";
 import { runEvents, runs } from "../../db/schema.ts";
-import { issueKey, runId } from "../../types/brands.ts";
+import { issueKey, repoSlug, runId } from "../../types/brands.ts";
 
 export function createTestDb(): Db {
 	const sqlite = new Database(":memory:");
@@ -16,9 +16,10 @@ export function createTestDb(): Db {
 
 type LooseRunInsert = Omit<
 	Partial<typeof runs.$inferInsert>,
-	"id" | "issueKey" | "parentRunId"
+	"id" | "repo" | "issueKey" | "parentRunId"
 > & {
 	id: string;
+	repo?: string;
 	issueKey?: string | null;
 	parentRunId?: string | null;
 };
@@ -30,7 +31,7 @@ const variantDefaultsByStatus = {
 } as const;
 
 export function seedRun(db: Db, overrides: LooseRunInsert) {
-	const { id, issueKey: keyStr, parentRunId, ...rest } = overrides;
+	const { id, repo, issueKey: keyStr, parentRunId, ...rest } = overrides;
 	const status = rest.status ?? "completed";
 	const now = new Date().toISOString();
 	const completedAt = status === "running" ? null : now;
@@ -44,6 +45,7 @@ export function seedRun(db: Db, overrides: LooseRunInsert) {
 			...rest,
 			status,
 			id: runId(id),
+			repo: repoSlug(repo ?? "test-owner/test-repo"),
 			...(keyStr != null && { issueKey: issueKey(keyStr) }),
 			...(parentRunId != null && { parentRunId: runId(parentRunId) }),
 		})

--- a/server/testing/support/test-lifecycle.ts
+++ b/server/testing/support/test-lifecycle.ts
@@ -84,7 +84,10 @@ export function createInMemoryTracker(initial?: Issue): InMemoryTracker {
 			return issue;
 		},
 		async fetchActiveIssues() {
-			return issue ? [issue] : [];
+			return {
+				issues: issue ? [issue] : [],
+				reposReached: new Set([TEST_REPO]),
+			};
 		},
 		async transitionState(repo, number, from, to) {
 			const t: StateTransition = { repo, number, from, to };
@@ -95,7 +98,6 @@ export function createInMemoryTracker(initial?: Issue): InMemoryTracker {
 		parseIssueKey(key) {
 			const hashIndex = key.lastIndexOf("#");
 			return ok({
-				repo: repoSlug(key.slice(0, hashIndex)),
 				number: issueNumber(Number.parseInt(key.slice(hashIndex + 1), 10)),
 			});
 		},
@@ -131,6 +133,7 @@ export function createTestIssue(overrides: Partial<Issue> = {}): Issue {
 	return {
 		key: `${TEST_REPO}#1` as Issue["key"],
 		number: issueNumber(1),
+		repo: TEST_REPO,
 		title: "Fix login bug",
 		description: "Login throws on null email",
 		labels: ["bug"],

--- a/server/testing/support/test-orchestrator.ts
+++ b/server/testing/support/test-orchestrator.ts
@@ -45,7 +45,10 @@ export async function createTestOrchestrator(
 	});
 
 	const defaultCodeHost = githubCodeHostAdapter(github);
-	const defaultTracker = githubTrackerAdapter(github);
+	const trackerRepos = options.workflows
+		? [...options.workflows.keys()]
+		: [REPO];
+	const defaultTracker = githubTrackerAdapter(github, { repos: trackerRepos });
 
 	const agent = options.agent ?? adaptRunAgent(options.runAgent ?? noopAgent);
 

--- a/server/trackers/__tests__/decorator.test.ts
+++ b/server/trackers/__tests__/decorator.test.ts
@@ -16,10 +16,9 @@ function createFakeTracker(
 		fetchIssue: async () => {
 			throw new Error("not implemented");
 		},
-		fetchActiveIssues: async () => [],
+		fetchActiveIssues: async () => ({ issues: [], reposReached: new Set() }),
 		transitionState: async () => {},
-		parseIssueKey: () =>
-			ok({ repo: repoSlug("owner/repo"), number: issueNumber(1) }),
+		parseIssueKey: () => ok({ number: issueNumber(1) }),
 		...overrides,
 	};
 }
@@ -38,6 +37,22 @@ describe("decorateTracker", () => {
 			await expect(
 				decorated.fetchIssue(repoSlug("owner/repo"), issueNumber(42)),
 			).rejects.toThrow("not found");
+		});
+	});
+
+	describe("fetchActiveIssues", () => {
+		it("re-throws when inner fetchActiveIssues fails", async () => {
+			const decorated = decorateTracker(
+				createFakeTracker({
+					fetchActiveIssues: async () => {
+						throw new Error("upstream down");
+					},
+				}),
+			);
+
+			await expect(decorated.fetchActiveIssues("pending")).rejects.toThrow(
+				"upstream down",
+			);
 		});
 	});
 
@@ -98,15 +113,13 @@ describe("decorateTracker", () => {
 		it("delegates to inner tracker", () => {
 			const decorated = decorateTracker(
 				createFakeTracker({
-					parseIssueKey: () =>
-						ok({ repo: repoSlug("owner/repo"), number: issueNumber(42) }),
+					parseIssueKey: () => ok({ number: issueNumber(42) }),
 				}),
 			);
 
 			expect(decorated.parseIssueKey("owner/repo#42")).toEqual({
 				ok: true,
 				value: {
-					repo: "owner/repo",
 					number: 42,
 				},
 			});

--- a/server/trackers/__tests__/github.integration.test.ts
+++ b/server/trackers/__tests__/github.integration.test.ts
@@ -7,7 +7,7 @@ import {
 	REPO,
 } from "../../testing/support/fixtures.ts";
 import { server } from "../../testing/support/msw.ts";
-import { githubToken, issueNumber } from "../../types/brands.ts";
+import { githubToken, issueNumber, repoSlug } from "../../types/brands.ts";
 import { githubTrackerAdapter } from "../github.ts";
 
 describe("githubTrackerAdapter", () => {
@@ -29,13 +29,17 @@ describe("githubTrackerAdapter", () => {
 			);
 
 			const github = createGitHubClient(githubToken("test-token"));
-			const tracker = githubTrackerAdapter(github, ["open", "closed"]);
+			const tracker = githubTrackerAdapter(github, {
+				repos: [REPO],
+				activeStates: ["open", "closed"],
+			});
 
-			const issues = await tracker.fetchActiveIssues(REPO, "pending");
+			const { issues } = await tracker.fetchActiveIssues("pending");
 			expect(issues).toEqual([
 				{
 					key: `${REPO}#10`,
 					number: 10,
+					repo: REPO,
 					title: "Issue 10",
 					description: "Description for issue 10",
 					labels: ["agent"],
@@ -66,13 +70,17 @@ describe("githubTrackerAdapter", () => {
 			);
 
 			const github = createGitHubClient(githubToken("test-token"));
-			const tracker = githubTrackerAdapter(github, ["open", "closed"]);
+			const tracker = githubTrackerAdapter(github, {
+				repos: [REPO],
+				activeStates: ["open", "closed"],
+			});
 
-			const issues = await tracker.fetchActiveIssues(REPO, "pending");
+			const { issues } = await tracker.fetchActiveIssues("pending");
 			expect(issues).toEqual([
 				{
 					key: `${REPO}#1`,
 					number: 1,
+					repo: REPO,
 					title: "Issue 1",
 					description: "Description for issue 1",
 					labels: ["agent"],
@@ -82,12 +90,39 @@ describe("githubTrackerAdapter", () => {
 				{
 					key: `${REPO}#2`,
 					number: 2,
+					repo: REPO,
 					title: "Issue 2",
 					description: "Description for issue 2",
 					labels: ["agent"],
 					url: `https://github.com/${REPO}/issues/2`,
 					createdAt: "2025-01-02T00:00:00Z",
 				},
+			]);
+		});
+
+		it("fetches across each configured repo and stamps each issue with its source repo", async () => {
+			const repoA = repoSlug("acme/widgets");
+			const repoB = repoSlug("acme/services");
+
+			server.use(
+				http.get(`${GITHUB_API}/user`, () =>
+					HttpResponse.json({ login: "test-user" }),
+				),
+				http.get(`${GITHUB_API}/repos/${repoA}/issues`, () =>
+					HttpResponse.json([createGitHubIssue(1, ["agent"])]),
+				),
+				http.get(`${GITHUB_API}/repos/${repoB}/issues`, () =>
+					HttpResponse.json([createGitHubIssue(2, ["agent"])]),
+				),
+			);
+
+			const github = createGitHubClient(githubToken("test-token"));
+			const tracker = githubTrackerAdapter(github, { repos: [repoA, repoB] });
+
+			const { issues } = await tracker.fetchActiveIssues("pending");
+			expect(issues.map((i) => ({ key: i.key, repo: i.repo }))).toEqual([
+				{ key: `${repoA}#1`, repo: repoA },
+				{ key: `${repoB}#2`, repo: repoB },
 			]);
 		});
 
@@ -107,13 +142,14 @@ describe("githubTrackerAdapter", () => {
 			);
 
 			const github = createGitHubClient(githubToken("test-token"));
-			const tracker = githubTrackerAdapter(github);
+			const tracker = githubTrackerAdapter(github, { repos: [REPO] });
 
-			const issues = await tracker.fetchActiveIssues(REPO, "pending");
+			const { issues } = await tracker.fetchActiveIssues("pending");
 			expect(issues).toEqual([
 				{
 					key: `${REPO}#5`,
 					number: 5,
+					repo: REPO,
 					title: "Issue 5",
 					description: "",
 					labels: ["agent"],
@@ -159,7 +195,7 @@ describe("githubTrackerAdapter", () => {
 			);
 
 			const github = createGitHubClient(githubToken("test-token"));
-			const tracker = githubTrackerAdapter(github);
+			const tracker = githubTrackerAdapter(github, { repos: [REPO] });
 
 			await expect(
 				tracker.transitionState(
@@ -173,14 +209,13 @@ describe("githubTrackerAdapter", () => {
 	});
 
 	describe("parseIssueKey", () => {
-		it("parses GitHub issue keys", () => {
+		it("parses GitHub issue keys to an issue number", () => {
 			const github = createGitHubClient(githubToken("test-token"));
-			const tracker = githubTrackerAdapter(github);
+			const tracker = githubTrackerAdapter(github, { repos: [REPO] });
 
 			expect(tracker.parseIssueKey("owner/repo#42")).toEqual({
 				ok: true,
 				value: {
-					repo: "owner/repo",
 					number: 42,
 				},
 			});
@@ -188,7 +223,7 @@ describe("githubTrackerAdapter", () => {
 
 		it("returns Err for malformed GitHub issue keys", () => {
 			const github = createGitHubClient(githubToken("test-token"));
-			const tracker = githubTrackerAdapter(github);
+			const tracker = githubTrackerAdapter(github, { repos: [REPO] });
 
 			expect(tracker.parseIssueKey("owner/repo")).toEqual({
 				ok: false,

--- a/server/trackers/__tests__/jira.integration.test.ts
+++ b/server/trackers/__tests__/jira.integration.test.ts
@@ -56,6 +56,7 @@ describe("jiraTrackerAdapter", () => {
 			await expect(tracker.fetchIssue(REPO, issueNumber(42))).resolves.toEqual({
 				key: "PROJ-42",
 				number: 42,
+				repo: REPO,
 				title: "Issue PROJ-42",
 				description: "Description for PROJ-42",
 				labels: ["To Do"],
@@ -144,9 +145,10 @@ describe("jiraTrackerAdapter", () => {
 			);
 
 			const tracker = createTracker();
-			const issues = await tracker.fetchActiveIssues(REPO, "pending");
+			const { issues } = await tracker.fetchActiveIssues("pending");
 
 			expect(issues.map((issue) => issue.key)).toEqual(["PROJ-1"]);
+			expect(issues.map((issue) => issue.repo)).toEqual([REPO]);
 		});
 
 		it("adds a labels clause to the JQL when labels are configured", async () => {
@@ -181,9 +183,10 @@ describe("jiraTrackerAdapter", () => {
 				},
 			);
 
-			const issues = await tracker.fetchActiveIssues(REPO, "pending");
+			const { issues } = await tracker.fetchActiveIssues("pending");
 
 			expect(issues.map((issue) => issue.key)).toEqual(["PROJ-1"]);
+			expect(issues.map((issue) => issue.repo)).toEqual([REPO]);
 		});
 
 		it("escapes quotes and backslashes in custom status names", async () => {
@@ -218,9 +221,8 @@ describe("jiraTrackerAdapter", () => {
 				},
 			);
 
-			await expect(tracker.fetchActiveIssues(REPO, "pending")).resolves.toEqual(
-				[],
-			);
+			const { issues } = await tracker.fetchActiveIssues("pending");
+			expect(issues).toEqual([]);
 		});
 	});
 
@@ -290,13 +292,12 @@ describe("jiraTrackerAdapter", () => {
 	});
 
 	describe("parseIssueKey", () => {
-		it("parses native Jira issue keys to the configured code-host repo", () => {
+		it("parses native Jira issue keys to an issue number", () => {
 			const tracker = createTracker();
 
 			expect(tracker.parseIssueKey("PROJ-42")).toEqual({
 				ok: true,
 				value: {
-					repo: REPO,
 					number: 42,
 				},
 			});

--- a/server/trackers/decorator.ts
+++ b/server/trackers/decorator.ts
@@ -16,15 +16,15 @@ export function decorateTracker(inner: TrackerAdapter): TrackerAdapter {
 			}
 		},
 
-		async fetchActiveIssues(repo, state) {
+		async fetchActiveIssues(state) {
 			try {
-				const issues = await inner.fetchActiveIssues(repo, state);
+				const page = await inner.fetchActiveIssues(state);
 				canonicalLog.set({
-					tracker_active_issues_count: issues.length,
+					tracker_active_issues_count: page.issues.length,
 				});
-				return issues;
+				return page;
 			} catch (err) {
-				canonicalLog.append("warnings", `fetch_active_issues_failed: ${repo}`);
+				canonicalLog.append("warnings", `fetch_active_issues_failed: ${state}`);
 				throw err;
 			}
 		},

--- a/server/trackers/github.ts
+++ b/server/trackers/github.ts
@@ -1,15 +1,16 @@
+import * as canonicalLog from "../canonical-log.ts";
 import type { GitHubClient, GitHubIssue } from "../github-client.ts";
-import {
-	issueKey,
-	issueNumber,
-	type RepoSlug,
-	repoSlug,
-} from "../types/brands.ts";
+import { issueKey, issueNumber, type RepoSlug } from "../types/brands.ts";
 import { err, ok } from "../types/result.ts";
 import { decorateTracker } from "./decorator.ts";
 import type { Issue, TrackerAdapter, TrackerState } from "./types.ts";
 
 type IssueState = "open" | "closed" | "all";
+
+type GitHubTrackerOptions = {
+	repos: readonly RepoSlug[];
+	activeStates?: readonly IssueState[];
+};
 
 const LABELS: Record<TrackerState, string> = {
 	pending: "agent",
@@ -21,6 +22,7 @@ function mapGitHubIssue(repo: RepoSlug, i: GitHubIssue): Issue {
 	return {
 		key: issueKey(`${repo}#${i.number}`),
 		number: issueNumber(i.number),
+		repo,
 		title: i.title,
 		description: i.body ?? "",
 		labels: i.labels.map((l) => l.name),
@@ -31,12 +33,43 @@ function mapGitHubIssue(repo: RepoSlug, i: GitHubIssue): Issue {
 
 export function githubTrackerAdapter(
 	client: GitHubClient,
-	activeStates: IssueState[] = ["open"],
+	options: GitHubTrackerOptions,
 ): TrackerAdapter {
+	const { repos, activeStates = ["open"] as const } = options;
+
 	let usernamePromise: Promise<string> | undefined;
 	function getUsername(): Promise<string> {
 		usernamePromise ??= client.getAuthenticatedUser().then((u) => u.login);
 		return usernamePromise;
+	}
+
+	async function fetchForRepo(
+		repo: RepoSlug,
+		state: TrackerState,
+	): Promise<Issue[]> {
+		const username = await getUsername();
+		const label = LABELS[state];
+
+		const batches = await Promise.all(
+			activeStates.map((s) =>
+				client.listIssues(repo, {
+					labels: label,
+					state: s,
+					creator: username,
+					per_page: "100",
+				}),
+			),
+		);
+
+		const seen = new Set<number>();
+		return batches
+			.flat()
+			.filter((i) => {
+				if (seen.has(i.number)) return false;
+				seen.add(i.number);
+				return true;
+			})
+			.map((i) => mapGitHubIssue(repo, i));
 	}
 
 	return decorateTracker({
@@ -45,31 +78,27 @@ export function githubTrackerAdapter(
 			return mapGitHubIssue(repo, i);
 		},
 
-		async fetchActiveIssues(repo, state): Promise<Issue[]> {
-			const username = await getUsername();
-			const label = LABELS[state];
-
-			const batches = await Promise.all(
-				activeStates.map((state) =>
-					client.listIssues(repo, {
-						labels: label,
-						state,
-						creator: username,
-						per_page: "100",
-					}),
-				),
+		async fetchActiveIssues(state) {
+			const results = await Promise.allSettled(
+				repos.map(async (repo) => ({
+					repo,
+					issues: await fetchForRepo(repo, state),
+				})),
 			);
-
-			const seen = new Set<number>();
-
-			return batches
-				.flat()
-				.filter((i) => {
-					if (seen.has(i.number)) return false;
-					seen.add(i.number);
-					return true;
-				})
-				.map((i) => mapGitHubIssue(repo, i));
+			const issues: Issue[] = [];
+			const reposReached = new Set<RepoSlug>();
+			for (const [i, result] of results.entries()) {
+				if (result.status === "fulfilled") {
+					reposReached.add(result.value.repo);
+					issues.push(...result.value.issues);
+				} else {
+					canonicalLog.append(
+						"warnings",
+						`fetch_active_issues_failed: ${repos[i]}`,
+					);
+				}
+			}
+			return { issues, reposReached };
 		},
 
 		async transitionState(repo, issueNum, from, to): Promise<void> {
@@ -99,7 +128,6 @@ export function githubTrackerAdapter(
 			}
 
 			return ok({
-				repo: repoSlug(key.slice(0, hashIndex)),
 				number: issueNumber(Number.parseInt(rawNumber, 10)),
 			});
 		},

--- a/server/trackers/jira.ts
+++ b/server/trackers/jira.ts
@@ -48,40 +48,39 @@ function parseJiraKey(project: string, key: string): number | null {
 	return Number.parseInt(matchedNumber, 10);
 }
 
-function mapJiraIssue(
-	project: string,
-	baseUrl: string,
-	issue: JiraIssue,
-): Issue {
-	const num = parseJiraKey(project, issue.key);
-	/* v8 ignore next 3 -- defensive check; Jira API returns keys matching its own search filter */
-	if (num == null) {
-		throw new Error(`Invalid Jira issue key from API: ${issue.key}`);
-	}
-	return {
-		key: issueKey(issue.key),
-		number: issueNumber(num),
-		title: issue.fields.summary,
-		description: extractText(issue.fields.description),
-		labels: [issue.fields.status.name],
-		url: `${trimTrailingSlash(baseUrl)}/browse/${issue.key}`,
-		createdAt: issue.fields.created,
-	};
-}
-
 export function jiraTrackerAdapter(
 	client: JiraClient,
 	options: JiraTrackerOptions,
 ): TrackerAdapter {
+	const baseUrl = trimTrailingSlash(options.baseUrl);
+
+	function mapIssue(issue: JiraIssue): Issue {
+		const num = parseJiraKey(options.project, issue.key);
+		/* v8 ignore next 3 -- defensive check; Jira API returns keys matching its own search filter */
+		if (num == null) {
+			throw new Error(`Invalid Jira issue key from API: ${issue.key}`);
+		}
+		return {
+			key: issueKey(issue.key),
+			number: issueNumber(num),
+			repo: options.repo,
+			title: issue.fields.summary,
+			description: extractText(issue.fields.description),
+			labels: [issue.fields.status.name],
+			url: `${baseUrl}/browse/${issue.key}`,
+			createdAt: issue.fields.created,
+		};
+	}
+
 	return decorateTracker({
 		async fetchIssue(_repo, issueNum): Promise<Issue> {
 			const issue = await client.getIssue(
 				jiraIssueKey(options.project, issueNum),
 			);
-			return mapJiraIssue(options.project, options.baseUrl, issue);
+			return mapIssue(issue);
 		},
 
-		async fetchActiveIssues(_repo, state): Promise<Issue[]> {
+		async fetchActiveIssues(state) {
 			const clauses = [
 				`project = ${quoteJqlString(options.project)}`,
 				`status = ${quoteJqlString(options.statuses[state])}`,
@@ -91,10 +90,11 @@ export function jiraTrackerAdapter(
 				clauses.push(`labels in (${quoted})`);
 			}
 			const jql = `${clauses.join(" AND ")} ORDER BY created ASC`;
-			const issues = await client.searchIssues({ jql, maxResults: 100 });
-			return issues.map((issue) =>
-				mapJiraIssue(options.project, options.baseUrl, issue),
-			);
+			const raw = await client.searchIssues({ jql, maxResults: 100 });
+			return {
+				issues: raw.map(mapIssue),
+				reposReached: new Set([options.repo]),
+			};
 		},
 
 		async transitionState(_repo, issueNum, _from, to): Promise<void> {
@@ -120,7 +120,6 @@ export function jiraTrackerAdapter(
 				});
 			}
 			return ok({
-				repo: options.repo,
 				number: issueNumber(num),
 			});
 		},

--- a/server/trackers/types.ts
+++ b/server/trackers/types.ts
@@ -4,6 +4,7 @@ import type { Result } from "../types/result.ts";
 export type Issue = {
 	key: IssueKey;
 	number: IssueNumber;
+	repo: RepoSlug;
 	title: string;
 	description: string;
 	labels: string[];
@@ -19,9 +20,14 @@ export type ParseIssueKeyError = {
 	message: string;
 };
 
+export type ActiveIssuesPage = {
+	issues: Issue[];
+	reposReached: ReadonlySet<RepoSlug>;
+};
+
 export type TrackerAdapter = {
 	fetchIssue(repo: RepoSlug, issueNumber: IssueNumber): Promise<Issue>;
-	fetchActiveIssues(repo: RepoSlug, state: TrackerState): Promise<Issue[]>;
+	fetchActiveIssues(state: TrackerState): Promise<ActiveIssuesPage>;
 	transitionState(
 		repo: RepoSlug,
 		issueNumber: IssueNumber,
@@ -30,5 +36,5 @@ export type TrackerAdapter = {
 	): Promise<void>;
 	parseIssueKey(
 		key: string,
-	): Result<{ repo: RepoSlug; number: IssueNumber }, ParseIssueKeyError>;
+	): Result<{ number: IssueNumber }, ParseIssueKeyError>;
 };

--- a/server/workflow/__tests__/prompt-preprocessor.test.ts
+++ b/server/workflow/__tests__/prompt-preprocessor.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { createTestWorkspaceRoot } from "../../testing/support/test-workspace.ts";
 import type { Issue } from "../../trackers/types.ts";
-import { issueKey, issueNumber } from "../../types/brands.ts";
+import { issueKey, issueNumber, repoSlug } from "../../types/brands.ts";
 import {
 	expandMarkedShellBlocks,
 	markTrustedShellBlocks,
@@ -14,6 +14,7 @@ import { renderPrompt } from "../workflow.ts";
 const baseIssue: Issue = {
 	key: issueKey("owner/repo#1"),
 	number: issueNumber(1),
+	repo: repoSlug("owner/repo"),
 	title: "Fix the thing",
 	description: "Detailed description",
 	labels: ["bug", "urgent"],

--- a/server/workflow/__tests__/workflow.test.ts
+++ b/server/workflow/__tests__/workflow.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { Issue } from "../../trackers/types.ts";
-import { issueKey, issueNumber } from "../../types/brands.ts";
+import { issueKey, issueNumber, repoSlug } from "../../types/brands.ts";
 import { parseRepoWorkflow, renderPrompt } from "../workflow.ts";
 
 const baseIssue: Issue = {
 	key: issueKey("owner/repo#1"),
 	number: issueNumber(1),
+	repo: repoSlug("owner/repo"),
 	title: "Fix the thing",
 	description: "Detailed description",
 	labels: ["bug", "urgent"],


### PR DESCRIPTION
## Summary

Slice 2 of [docs/repo-scoping-plan.md](docs/repo-scoping-plan.md). Pure structural refactor — no user-visible behaviour change.

- `Issue` carries `repo: RepoSlug`; `runs.repo` column added and persisted on dispatch.
- `TrackerAdapter.fetchActiveIssues` takes only `(state)` — adapters are now responsible for finding all in-scope issues. GitHub loops its configured repos internally and merges; Jira still stamps its single configured repo (label-driven resolution lands in slice 3).
- Orchestrator no longer fans out per-repo for issue fetching, no longer derives repo from `parseIssueKey` in reconcile / retry — reads it from `Issue.repo` and the run record instead.
- `StillRunning` collapsed to `{ issues, keys, reposReached }`. Orphan recovery iterates the flat issue list using `issue.repo`/`issue.number` directly, eliminating the `parseIssueKey` round-trip.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 319 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)