### PR TITLE
feat: repo-scoping slice 3 — scope-based config and Jira label resolution

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,8 +6,6 @@ tracker:
     pending: "To Do"
     running: "In Progress"
     awaiting_review: "In Review"
-  labels:
-    - software-factory-poc
 
 code_host:
   kind: gitlab

--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ tracker:
 code_host:
   kind: gitlab
   base_url: https://gitlab.com
-  repos:
+  scopes:
     - todo
 
 defaults:

--- a/docs/repo-scoping-plan.md
+++ b/docs/repo-scoping-plan.md
@@ -124,7 +124,9 @@ Slices 4 → 5 are also sequential. Slice 4's new pending filter (`trigger_label
 
 ## Slice 3 — Scope-Based Config and Jira Label Resolution
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Verification:** `pnpm lint`, `pnpm typecheck`, `pnpm test` (323 tests).
 
 **Purpose:** Make the user-visible feature land. Replace `code_host.repos[]` with `code_host.scopes[]`, drop the 1-repo-per-Jira-project constraint, and have the Jira tracker resolve each issue's target repo from a `repo:<path>` label. Out-of-scope labels are silently ignored.
 

--- a/server/__tests__/config.test.ts
+++ b/server/__tests__/config.test.ts
@@ -125,52 +125,6 @@ ${fullDefaults}`);
 		});
 	});
 
-	it("accepts jira tracker with optional labels", () => {
-		using configFile = writeConfig(`
-tracker:
-  kind: jira
-  base_url: https://jira.example.test
-  project: PROJ
-  statuses:
-    pending: To Do
-    running: In Progress
-    awaiting_review: In Review
-  labels:
-    - software-factory-poc
-code_host:
-  kind: github
-  scopes:
-    - owner/repo
-${fullDefaults}`);
-
-		const config = loadConfig(configFile.path);
-
-		expect(config.tracker).toMatchObject({
-			kind: "jira",
-			labels: ["software-factory-poc"],
-		});
-	});
-
-	it("rejects jira tracker with an empty labels list", () => {
-		using configFile = writeConfig(`
-tracker:
-  kind: jira
-  base_url: https://jira.example.test
-  project: PROJ
-  statuses:
-    pending: To Do
-    running: In Progress
-    awaiting_review: In Review
-  labels: []
-code_host:
-  kind: github
-  scopes:
-    - owner/repo
-${fullDefaults}`);
-
-		expect(() => loadConfig(configFile.path)).toThrow();
-	});
-
 	it("rejects jira tracker with zero code host scopes", () => {
 		using configFile = writeConfig(`
 tracker:

--- a/server/__tests__/config.test.ts
+++ b/server/__tests__/config.test.ts
@@ -30,19 +30,19 @@ const fullDefaults = `defaults:
 `;
 
 describe("loadConfig", () => {
-	it("accepts repos under code_host", () => {
+	it("accepts scopes under code_host", () => {
 		using configFile = writeConfig(`
 tracker:
   kind: github
 code_host:
   kind: github
-  repos:
+  scopes:
     - owner/repo
 ${fullDefaults}`);
 
 		const config = loadConfig(configFile.path);
 
-		expect(config.code_host.repos).toEqual(["owner/repo"]);
+		expect(config.code_host.scopes).toEqual(["owner/repo"]);
 		expect(config.defaults.workspace_root).toBe("/tmp/workspaces");
 	});
 
@@ -53,7 +53,7 @@ tracker:
 code_host:
   kind: gitlab
   base_url: https://gitlab.example.test
-  repos:
+  scopes:
     - platform/team/project
 ${fullDefaults}`);
 
@@ -61,7 +61,7 @@ ${fullDefaults}`);
 
 		expect(config.code_host).toEqual({
 			kind: "gitlab",
-			repos: ["platform/team/project"],
+			scopes: ["platform/team/project"],
 			base_url: "https://gitlab.example.test",
 		});
 	});
@@ -72,7 +72,7 @@ tracker:
   kind: github
 code_host:
   kind: gitlab
-  repos:
+  scopes:
     - group/project
 ${fullDefaults}`);
 
@@ -88,7 +88,7 @@ tracker:
 code_host:
   kind: gitlab
   base_url: https://gitlab.example.test
-  repos:
+  scopes:
     - group/project
 ${fullDefaults}`);
 
@@ -107,7 +107,7 @@ tracker:
     awaiting_review: Code Review
 code_host:
   kind: github
-  repos:
+  scopes:
     - owner/repo
 ${fullDefaults}`);
 
@@ -139,7 +139,7 @@ tracker:
     - software-factory-poc
 code_host:
   kind: github
-  repos:
+  scopes:
     - owner/repo
 ${fullDefaults}`);
 
@@ -164,14 +164,14 @@ tracker:
   labels: []
 code_host:
   kind: github
-  repos:
+  scopes:
     - owner/repo
 ${fullDefaults}`);
 
 		expect(() => loadConfig(configFile.path)).toThrow();
 	});
 
-	it("rejects jira tracker with zero code host repos", () => {
+	it("rejects jira tracker with zero code host scopes", () => {
 		using configFile = writeConfig(`
 tracker:
   kind: jira
@@ -183,13 +183,13 @@ tracker:
     awaiting_review: In Review
 code_host:
   kind: github
-  repos: []
+  scopes: []
 ${fullDefaults}`);
 
 		expect(() => loadConfig(configFile.path)).toThrow();
 	});
 
-	it("rejects jira tracker with multiple code host repos", () => {
+	it("accepts jira tracker with multiple code host scopes", () => {
 		using configFile = writeConfig(`
 tracker:
   kind: jira
@@ -201,17 +201,17 @@ tracker:
     awaiting_review: In Review
 code_host:
   kind: github
-  repos:
+  scopes:
     - owner/repo-a
     - owner/repo-b
 ${fullDefaults}`);
 
-		expect(() => loadConfig(configFile.path)).toThrow(
-			"Jira tracker requires exactly one code_host.repos entry",
-		);
+		const config = loadConfig(configFile.path);
+
+		expect(config.code_host.scopes).toEqual(["owner/repo-a", "owner/repo-b"]);
 	});
 
-	it("rejects config without code_host repos", () => {
+	it("rejects config without code_host scopes", () => {
 		using configFile = writeConfig(`
 tracker:
   kind: github
@@ -228,7 +228,7 @@ tracker:
   kind: github
 code_host:
   kind: github
-  repos:
+  scopes:
     - owner/repo
 `);
 
@@ -241,10 +241,23 @@ tracker:
   kind: github
 code_host:
   kind: github
-  repos:
+  scopes:
     - owner/repo
 repos:
   - old-owner/old-repo
+${fullDefaults}`);
+
+		expect(() => loadConfig(configFile.path)).toThrow();
+	});
+
+	it("rejects code_host.repos under the new schema", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: github
+code_host:
+  kind: github
+  repos:
+    - owner/repo
 ${fullDefaults}`);
 
 		expect(() => loadConfig(configFile.path)).toThrow();

--- a/server/__tests__/env.test.ts
+++ b/server/__tests__/env.test.ts
@@ -10,7 +10,7 @@ function gitlabConfig(): Pick<Config, "tracker" | "code_host"> {
 		tracker: { kind: "github" },
 		code_host: {
 			kind: "gitlab",
-			repos: [repoSlug("group/project")],
+			scopes: [repoSlug("group/project")],
 			base_url: "https://gitlab.com",
 		},
 	};
@@ -30,7 +30,7 @@ function jiraConfig(): Pick<Config, "tracker" | "code_host"> {
 		},
 		code_host: {
 			kind: "gitlab",
-			repos: [repoSlug("group/project")],
+			scopes: [repoSlug("group/project")],
 			base_url: "https://gitlab.com",
 		},
 	};

--- a/server/__tests__/jira-client.integration.test.ts
+++ b/server/__tests__/jira-client.integration.test.ts
@@ -18,7 +18,13 @@ describe("Jira client", () => {
 					body["jql"] !== 'project = "PROJ"' ||
 					body["maxResults"] !== 100 ||
 					JSON.stringify(body["fields"]) !==
-						JSON.stringify(["summary", "description", "status", "created"])
+						JSON.stringify([
+							"summary",
+							"description",
+							"status",
+							"created",
+							"labels",
+						])
 				) {
 					return new HttpResponse(null, { status: 400 });
 				}

--- a/server/config.ts
+++ b/server/config.ts
@@ -22,11 +22,11 @@ export type Config = {
 	code_host:
 		| {
 				kind: "github";
-				repos: RepoSlug[];
+				scopes: RepoSlug[];
 		  }
 		| {
 				kind: "gitlab";
-				repos: RepoSlug[];
+				scopes: RepoSlug[];
 				base_url: string;
 		  };
 	defaults: {
@@ -68,13 +68,13 @@ const configSchema = z
 			z
 				.object({
 					kind: z.literal("github"),
-					repos: z.array(repoSlugSchema).min(1),
+					scopes: z.array(repoSlugSchema).min(1),
 				})
 				.strict(),
 			z
 				.object({
 					kind: z.literal("gitlab"),
-					repos: z.array(repoSlugSchema).min(1),
+					scopes: z.array(repoSlugSchema).min(1),
 					base_url: z.url(),
 				})
 				.strict(),
@@ -89,16 +89,7 @@ const configSchema = z
 			})
 			.strict(),
 	})
-	.strict()
-	.superRefine((config, ctx) => {
-		if (config.tracker.kind === "jira" && config.code_host.repos.length !== 1) {
-			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
-				path: ["code_host", "repos"],
-				message: "Jira tracker requires exactly one code_host.repos entry",
-			});
-		}
-	});
+	.strict();
 
 export function loadConfig(filePath: string): Config {
 	const raw = readFileSync(filePath, "utf-8");

--- a/server/config.ts
+++ b/server/config.ts
@@ -17,7 +17,6 @@ export type Config = {
 					running: string;
 					awaiting_review: string;
 				};
-				labels?: string[] | undefined;
 		  };
 	code_host:
 		| {
@@ -60,7 +59,6 @@ const configSchema = z
 							awaiting_review: z.string().min(1),
 						})
 						.strict(),
-					labels: z.array(z.string().min(1)).min(1).optional(),
 				})
 				.strict(),
 		]),

--- a/server/jira-client.ts
+++ b/server/jira-client.ts
@@ -2,7 +2,13 @@ import { z } from "zod";
 import { createJsonRequester, type HttpClientOptions } from "./http-client.ts";
 import type { JiraApiToken, JiraEmail } from "./types/brands.ts";
 
-const ISSUE_FIELDS = ["summary", "description", "status", "created"] as const;
+const ISSUE_FIELDS = [
+	"summary",
+	"description",
+	"status",
+	"created",
+	"labels",
+] as const;
 const DEFAULT_SEARCH_MAX_RESULTS = 100;
 
 const jiraIssueSchema = z.object({
@@ -11,6 +17,7 @@ const jiraIssueSchema = z.object({
 		summary: z.string(),
 		description: z.unknown().nullable().optional(),
 		created: z.string(),
+		labels: z.array(z.string()),
 		status: z.object({
 			name: z.string(),
 		}),

--- a/server/orchestrator/__tests__/orchestrator.dispatch-multi-repo.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.dispatch-multi-repo.integration.test.ts
@@ -3,15 +3,13 @@ import { describe, expect, it } from "vitest";
 import { runs } from "../../db/schema.ts";
 import {
 	createGitHubIssue,
-	createTestWorkflow,
 	GITHUB_API,
 	hangingAgent,
 	REPO,
 } from "../../testing/support/fixtures.ts";
 import { githubHandlers, server } from "../../testing/support/msw.ts";
 import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
-import { type RepoSlug, repoSlug } from "../../types/brands.ts";
-import type { RepoWorkflow } from "../../workflow/workflow.ts";
+import { repoSlug } from "../../types/brands.ts";
 
 describe("Orchestrator multi-repo scheduling", () => {
 	it("ticking guard prevents concurrent ticks", async () => {
@@ -77,10 +75,7 @@ describe("Orchestrator multi-repo scheduling", () => {
 
 		await using ctx = await createTestOrchestrator({
 			maxConcurrency: 5,
-			workflows: new Map<RepoSlug, RepoWorkflow>([
-				[REPO, createTestWorkflow()],
-				[REPO2, createTestWorkflow()],
-			]),
+			trackerRepos: [REPO, REPO2],
 		});
 		const { orchestrator, db, runner, workspace } = ctx;
 		await workspace.preCreateWorkspace(`${REPO2}#10`);
@@ -142,10 +137,7 @@ describe("Orchestrator multi-repo scheduling", () => {
 		await using ctx = await createTestOrchestrator({
 			maxConcurrency: 5,
 			configOverrides: { max_concurrent: 5 },
-			workflows: new Map<RepoSlug, RepoWorkflow>([
-				[REPO, createTestWorkflow()],
-				[REPO2, createTestWorkflow()],
-			]),
+			trackerRepos: [REPO, REPO2],
 		});
 		const { orchestrator, db, runner, workspace } = ctx;
 		await workspace.preCreateWorkspace(`${REPO}#1`);

--- a/server/orchestrator/__tests__/orchestrator.jira.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.jira.integration.test.ts
@@ -54,7 +54,9 @@ describe("Orchestrator Jira dispatch", () => {
 				const jql = body.jql ?? "";
 				if (jql.includes('status = "To Do"')) {
 					return HttpResponse.json({
-						issues: [createJiraIssue("PROJ-42", "To Do")],
+						issues: [
+							createJiraIssue("PROJ-42", "To Do", undefined, [`repo:${REPO}`]),
+						],
 					});
 				}
 				return HttpResponse.json({ issues: [] });
@@ -78,7 +80,7 @@ describe("Orchestrator Jira dispatch", () => {
 				apiToken: jiraApiToken("jira-token"),
 				maxAttempts: 1,
 			}),
-			{ project: "PROJ", repo: REPO, baseUrl: JIRA_BASE_URL, statuses },
+			{ project: "PROJ", scopes: [REPO], baseUrl: JIRA_BASE_URL, statuses },
 		);
 
 		// Strict codeHost stub: returns success only when called against the
@@ -96,7 +98,7 @@ describe("Orchestrator Jira dispatch", () => {
 					return { number: 1, url: "https://example.test/change/1" };
 				},
 			}),
-			workflows: new Map([[REPO, createTestWorkflow()]]),
+			workflow: createTestWorkflow(),
 		});
 		const { orchestrator, runner, workspace } = ctx;
 		await workspace.preCreateWorkspace("PROJ-42");

--- a/server/orchestrator/__tests__/orchestrator.scheduling.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.scheduling.integration.test.ts
@@ -10,8 +10,7 @@ import {
 import { githubHandlers, server } from "../../testing/support/msw.ts";
 import { seedRun } from "../../testing/support/test-db.ts";
 import { createTestOrchestrator } from "../../testing/support/test-orchestrator.ts";
-import { type RepoSlug, runId as rid } from "../../types/brands.ts";
-import type { RepoWorkflow } from "../../workflow/workflow.ts";
+import { runId as rid } from "../../types/brands.ts";
 
 describe("Orchestrator scheduling", () => {
 	it("transitions pending → running on dispatch", async () => {
@@ -260,16 +259,6 @@ describe("Orchestrator retryRun eligibility", () => {
 		seedRun(ctx.db, { ...failedRunDefaults, id: "maxed", attempt: 4 });
 		const result = await ctx.orchestrator.retryRun(rid("maxed"));
 		expect(result).toEqual({ error: "Max retries exceeded" });
-	});
-
-	it("rejects when no workflow exists for the repo", async () => {
-		server.use(...githubHandlers());
-		await using ctx = await createTestOrchestrator({
-			workflows: new Map<RepoSlug, RepoWorkflow>(),
-		});
-		seedRun(ctx.db, { ...failedRunDefaults, id: "no-wf" });
-		const result = await ctx.orchestrator.retryRun(rid("no-wf"));
-		expect(result).toEqual({ error: "No workflow for repo" });
 	});
 
 	it("rejects when issue already has a running agent", async () => {

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -17,7 +17,7 @@ type OrchestratorConfig = {
 	tracker: TrackerAdapter;
 	codeHost: CodeHostAdapter;
 	config: Config;
-	workflows: Map<RepoSlug, RepoWorkflow>;
+	workflow: RepoWorkflow;
 	runner: Runner;
 	agent?: AgentInvoker;
 	clock?: Clock;
@@ -33,7 +33,6 @@ type Orchestrator = {
 	stop(): void;
 };
 
-type TaggedIssue = { issue: Issue; repo: RepoSlug; workflow: RepoWorkflow };
 type RunningEntry = { runIds: RunId[]; repo: RepoSlug };
 type StillRunning = {
 	issues: readonly Issue[];
@@ -43,7 +42,7 @@ type StillRunning = {
 type TickState = {
 	runningByIssue: Map<IssueKey, RunningEntry>;
 	runningCount: number;
-	pending: TaggedIssue[];
+	pending: Issue[];
 	stillRunning: StillRunning;
 };
 
@@ -57,7 +56,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		tracker,
 		codeHost,
 		config,
-		workflows,
+		workflow,
 		runner,
 		agent = claudeSdkAgentInvoker(),
 		clock = systemClock(),
@@ -100,20 +99,17 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 			tracker.fetchActiveIssues("running"),
 		]);
 
-		const pending: TaggedIssue[] = [];
-		if (pendingResult.status === "fulfilled") {
-			for (const issue of pendingResult.value.issues) {
-				const workflow = workflows.get(issue.repo);
-				if (!workflow) continue;
-				pending.push({ issue, repo: issue.repo, workflow });
-			}
-		} else {
+		const pending: Issue[] =
+			pendingResult.status === "fulfilled"
+				? [...pendingResult.value.issues]
+				: [];
+		if (pendingResult.status === "rejected") {
 			logger.warn(
 				{ err: pendingResult.reason },
 				"orchestrator.fetch_pending_failed",
 			);
 		}
-		pending.sort((a, b) => a.issue.createdAt.localeCompare(b.issue.createdAt));
+		pending.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
 
 		let stillRunning: StillRunning;
 		if (runningResult.status === "fulfilled") {
@@ -178,10 +174,11 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 	async function dispatchPendingIssues(state: TickState) {
 		let { runningCount } = state;
 
-		for (const { issue, repo, workflow } of state.pending) {
+		for (const issue of state.pending) {
 			if (state.runningByIssue.has(issue.key)) continue;
 			if (runningCount >= defaults.max_concurrent) break;
 
+			const { repo } = issue;
 			await tracker.transitionState(repo, issue.number, "pending", "running");
 
 			try {
@@ -245,8 +242,6 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 			tracker.parseIssueKey(failedRun.issueKey),
 		);
 		const repo = failedRun.repo;
-		const workflow = workflows.get(repo);
-		if (!workflow) return { error: "No workflow for repo" };
 
 		const issue = await tracker.fetchIssue(repo, issueNumber);
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -18,7 +18,7 @@ import { githubTrackerAdapter } from "./trackers/github.ts";
 import { jiraTrackerAdapter } from "./trackers/jira.ts";
 import type { TrackerAdapter } from "./trackers/types.ts";
 import { githubToken } from "./types/brands.ts";
-import { createWorkflowMap, loadWorkflow } from "./workflow/workflow-loader.ts";
+import { loadWorkflow } from "./workflow/workflow-loader.ts";
 
 const baseEnv = loadEnv();
 const config = loadConfig(baseEnv.CONFIG_PATH);
@@ -32,12 +32,8 @@ migrate(db);
 const github = createGitHubClient(env.GITHUB_TOKEN ?? githubToken(""));
 let tracker: TrackerAdapter;
 if (config.tracker.kind === "github") {
-	tracker = githubTrackerAdapter(github, { repos: config.code_host.repos });
+	tracker = githubTrackerAdapter(github, { repos: config.code_host.scopes });
 } else {
-	const jiraRepo = config.code_host.repos[0];
-	if (!jiraRepo) {
-		throw new Error("Jira tracker requires exactly one code_host.repos entry");
-	}
 	if (!env.JIRA_EMAIL || !env.JIRA_API_TOKEN) {
 		throw new Error("JIRA_EMAIL and JIRA_API_TOKEN are required for Jira");
 	}
@@ -48,7 +44,7 @@ if (config.tracker.kind === "github") {
 	});
 	tracker = jiraTrackerAdapter(jira, {
 		project: config.tracker.project,
-		repo: jiraRepo,
+		scopes: config.code_host.scopes,
 		baseUrl: config.tracker.base_url,
 		statuses: config.tracker.statuses,
 		...(config.tracker.labels && { labels: config.tracker.labels }),
@@ -77,16 +73,14 @@ const runner = createRunner({
 	maxConcurrency: config.defaults.max_concurrent,
 });
 
-// Load the global workflow once at startup.
 const workflow = loadWorkflow();
-const workflows = createWorkflowMap(config.code_host.repos, workflow);
 
 const orchestrator = createOrchestrator({
 	runRepo: repo,
 	tracker,
 	codeHost,
 	config,
-	workflows,
+	workflow,
 	runner,
 });
 
@@ -125,8 +119,7 @@ const httpServer = serve({ fetch: app.fetch, port: env.PORT }, (info) => {
 		{
 			port: info.port,
 			codeHost: config.code_host.kind,
-			repos: config.code_host.repos,
-			activeRepos: [...workflows.keys()],
+			scopes: config.code_host.scopes,
 			interval: config.defaults.polling_interval_ms,
 		},
 		"orchestrator.started",

--- a/server/server.ts
+++ b/server/server.ts
@@ -47,7 +47,6 @@ if (config.tracker.kind === "github") {
 		scopes: config.code_host.scopes,
 		baseUrl: config.tracker.base_url,
 		statuses: config.tracker.statuses,
-		...(config.tracker.labels && { labels: config.tracker.labels }),
 	});
 }
 let codeHost: CodeHostAdapter;

--- a/server/testing/support/fixtures.ts
+++ b/server/testing/support/fixtures.ts
@@ -56,6 +56,7 @@ export function createJiraIssue(
 	key: string,
 	status = "To Do",
 	created = "2025-01-01T00:00:00.000+0000",
+	labels: string[] = [],
 ) {
 	return {
 		key,
@@ -72,6 +73,7 @@ export function createJiraIssue(
 				],
 			},
 			created,
+			labels,
 			status: { name: status },
 		},
 	};

--- a/server/testing/support/test-config.ts
+++ b/server/testing/support/test-config.ts
@@ -8,7 +8,7 @@ export function createTestConfig(
 		tracker: { kind: "github" },
 		code_host: {
 			kind: "github",
-			repos: [repoSlug("test-owner/test-repo")],
+			scopes: [repoSlug("test-owner/test-repo")],
 		},
 		defaults: {
 			polling_interval_ms: 100,

--- a/server/testing/support/test-orchestrator.ts
+++ b/server/testing/support/test-orchestrator.ts
@@ -24,7 +24,8 @@ type CreateTestOrchestratorOptions = {
 	runAgent?: LegacyRunAgent;
 	agent?: AgentInvoker;
 	configOverrides?: Parameters<typeof createTestConfig>[0];
-	workflows?: Map<RepoSlug, RepoWorkflow>;
+	workflow?: RepoWorkflow;
+	trackerRepos?: readonly RepoSlug[];
 	maxConcurrency?: number;
 	codeHost?: (defaults: CodeHostAdapter) => CodeHostAdapter;
 	tracker?: (defaults: TrackerAdapter) => TrackerAdapter;
@@ -45,9 +46,7 @@ export async function createTestOrchestrator(
 	});
 
 	const defaultCodeHost = githubCodeHostAdapter(github);
-	const trackerRepos = options.workflows
-		? [...options.workflows.keys()]
-		: [REPO];
+	const trackerRepos = options.trackerRepos ?? [REPO];
 	const defaultTracker = githubTrackerAdapter(github, { repos: trackerRepos });
 
 	const agent = options.agent ?? adaptRunAgent(options.runAgent ?? noopAgent);
@@ -62,9 +61,7 @@ export async function createTestOrchestrator(
 			workspace_root: workspace.root,
 			...options.configOverrides,
 		}),
-		workflows:
-			options.workflows ??
-			new Map<RepoSlug, RepoWorkflow>([[REPO, createTestWorkflow()]]),
+		workflow: options.workflow ?? createTestWorkflow(),
 		runner,
 		agent,
 	});

--- a/server/trackers/__tests__/jira.integration.test.ts
+++ b/server/trackers/__tests__/jira.integration.test.ts
@@ -8,7 +8,13 @@ import {
 	REPO,
 } from "../../testing/support/fixtures.ts";
 import { server } from "../../testing/support/msw.ts";
-import { issueNumber, jiraApiToken, jiraEmail } from "../../types/brands.ts";
+import {
+	issueNumber,
+	jiraApiToken,
+	jiraEmail,
+	type RepoSlug,
+	repoSlug,
+} from "../../types/brands.ts";
 import { jiraTrackerAdapter } from "../jira.ts";
 
 const statuses = {
@@ -17,7 +23,7 @@ const statuses = {
 	awaiting_review: "In Review",
 } as const;
 
-function createTracker() {
+function createTracker(scopes: readonly RepoSlug[] = [REPO]) {
 	return jiraTrackerAdapter(
 		createJiraClient({
 			baseUrl: JIRA_BASE_URL,
@@ -27,7 +33,7 @@ function createTracker() {
 		}),
 		{
 			project: "PROJ",
-			repo: REPO,
+			scopes,
 			baseUrl: JIRA_BASE_URL,
 			statuses,
 		},
@@ -59,7 +65,7 @@ describe("jiraTrackerAdapter", () => {
 				repo: REPO,
 				title: "Issue PROJ-42",
 				description: "Description for PROJ-42",
-				labels: ["To Do"],
+				labels: [],
 				url: `${JIRA_BASE_URL}/browse/PROJ-42`,
 				createdAt: "2025-01-01T00:00:00.000+0000",
 			});
@@ -125,7 +131,13 @@ describe("jiraTrackerAdapter", () => {
 
 	describe("fetchActiveIssues", () => {
 		it("builds safe JQL for the configured project and logical status", async () => {
-			const expectedFields = ["summary", "description", "status", "created"];
+			const expectedFields = [
+				"summary",
+				"description",
+				"status",
+				"created",
+				"labels",
+			];
 
 			server.use(
 				http.post(`${JIRA_API}/search/jql`, async ({ request }) => {
@@ -139,7 +151,9 @@ describe("jiraTrackerAdapter", () => {
 						return new HttpResponse(null, { status: 400 });
 					}
 					return HttpResponse.json({
-						issues: [createJiraIssue("PROJ-1", "To Do")],
+						issues: [
+							createJiraIssue("PROJ-1", "To Do", undefined, [`repo:${REPO}`]),
+						],
 					});
 				}),
 			);
@@ -151,42 +165,118 @@ describe("jiraTrackerAdapter", () => {
 			expect(issues.map((issue) => issue.repo)).toEqual([REPO]);
 		});
 
-		it("adds a labels clause to the JQL when labels are configured", async () => {
+		it("maps Issue.labels from fields.labels, not the status name", async () => {
 			server.use(
-				http.post(`${JIRA_API}/search/jql`, async ({ request }) => {
-					const body = (await request.json()) as { jql?: string };
-					if (
-						body.jql !==
-						'project = "PROJ" AND status = "To Do" AND labels in ("software-factory-poc", "needs-triage") ORDER BY created ASC'
-					) {
-						return new HttpResponse(null, { status: 400 });
-					}
-					return HttpResponse.json({
-						issues: [createJiraIssue("PROJ-1", "To Do")],
-					});
-				}),
+				http.post(`${JIRA_API}/search/jql`, () =>
+					HttpResponse.json({
+						issues: [
+							createJiraIssue("PROJ-2", "To Do", undefined, [
+								`repo:${REPO}`,
+								"needs-triage",
+							]),
+						],
+					}),
+				),
 			);
 
-			const tracker = jiraTrackerAdapter(
-				createJiraClient({
-					baseUrl: JIRA_BASE_URL,
-					email: jiraEmail("agent@example.test"),
-					apiToken: jiraApiToken("jira-token"),
-					maxAttempts: 1,
-				}),
-				{
-					project: "PROJ",
-					repo: REPO,
-					baseUrl: JIRA_BASE_URL,
-					statuses,
-					labels: ["software-factory-poc", "needs-triage"],
-				},
-			);
-
+			const tracker = createTracker();
 			const { issues } = await tracker.fetchActiveIssues("pending");
 
-			expect(issues.map((issue) => issue.key)).toEqual(["PROJ-1"]);
-			expect(issues.map((issue) => issue.repo)).toEqual([REPO]);
+			expect(issues).toHaveLength(1);
+			expect(issues[0]?.labels).toEqual([`repo:${REPO}`, "needs-triage"]);
+		});
+
+		it("dispatches when an issue has a single matching repo: label", async () => {
+			server.use(
+				http.post(`${JIRA_API}/search/jql`, () =>
+					HttpResponse.json({
+						issues: [
+							createJiraIssue("PROJ-3", "To Do", undefined, [`repo:${REPO}`]),
+						],
+					}),
+				),
+			);
+
+			const tracker = createTracker();
+			const { issues } = await tracker.fetchActiveIssues("pending");
+
+			expect(issues.map((i) => i.key)).toEqual(["PROJ-3"]);
+			expect(issues.map((i) => i.repo)).toEqual([REPO]);
+		});
+
+		it("drops issues with no repo: label", async () => {
+			server.use(
+				http.post(`${JIRA_API}/search/jql`, () =>
+					HttpResponse.json({
+						issues: [createJiraIssue("PROJ-4", "To Do", undefined, [])],
+					}),
+				),
+			);
+
+			const tracker = createTracker();
+			const { issues } = await tracker.fetchActiveIssues("pending");
+
+			expect(issues).toEqual([]);
+		});
+
+		it("drops issues whose repo: label does not resolve against any scope", async () => {
+			server.use(
+				http.post(`${JIRA_API}/search/jql`, () =>
+					HttpResponse.json({
+						issues: [
+							createJiraIssue("PROJ-5", "To Do", undefined, [
+								"repo:other-org/somewhere-else",
+							]),
+						],
+					}),
+				),
+			);
+
+			const tracker = createTracker();
+			const { issues } = await tracker.fetchActiveIssues("pending");
+
+			expect(issues).toEqual([]);
+		});
+
+		it("drops issues with multiple repo: labels", async () => {
+			const REPO_B = repoSlug("test-owner/repo-b");
+			server.use(
+				http.post(`${JIRA_API}/search/jql`, () =>
+					HttpResponse.json({
+						issues: [
+							createJiraIssue("PROJ-6", "To Do", undefined, [
+								`repo:${REPO}`,
+								`repo:${REPO_B}`,
+							]),
+						],
+					}),
+				),
+			);
+
+			const tracker = createTracker([REPO, REPO_B]);
+			const { issues } = await tracker.fetchActiveIssues("pending");
+
+			expect(issues).toEqual([]);
+		});
+
+		it("resolves a repo: label that descends from a group-prefix scope to its full path", async () => {
+			const childRepo = repoSlug("test-owner/playground/child");
+			server.use(
+				http.post(`${JIRA_API}/search/jql`, () =>
+					HttpResponse.json({
+						issues: [
+							createJiraIssue("PROJ-7", "To Do", undefined, [
+								`repo:${childRepo}`,
+							]),
+						],
+					}),
+				),
+			);
+
+			const tracker = createTracker([repoSlug("test-owner")]);
+			const { issues } = await tracker.fetchActiveIssues("pending");
+
+			expect(issues.map((i) => i.repo)).toEqual([childRepo]);
 		});
 
 		it("escapes quotes and backslashes in custom status names", async () => {
@@ -212,7 +302,7 @@ describe("jiraTrackerAdapter", () => {
 				}),
 				{
 					project: "PROJ",
-					repo: REPO,
+					scopes: [REPO],
 					baseUrl: JIRA_BASE_URL,
 					statuses: {
 						...statuses,

--- a/server/trackers/jira.ts
+++ b/server/trackers/jira.ts
@@ -13,7 +13,6 @@ type JiraTrackerOptions = {
 	scopes: readonly RepoSlug[];
 	baseUrl: string;
 	statuses: JiraStatuses;
-	labels?: readonly string[];
 };
 
 const REPO_LABEL_PREFIX = "repo:";
@@ -124,10 +123,6 @@ export function jiraTrackerAdapter(
 				`project = ${quoteJqlString(options.project)}`,
 				`status = ${quoteJqlString(options.statuses[state])}`,
 			];
-			if (options.labels && options.labels.length > 0) {
-				const quoted = options.labels.map(quoteJqlString).join(", ");
-				clauses.push(`labels in (${quoted})`);
-			}
 			const jql = `${clauses.join(" AND ")} ORDER BY created ASC`;
 			const raw = await client.searchIssues({ jql, maxResults: 100 });
 			const issues: Issue[] = [];

--- a/server/trackers/jira.ts
+++ b/server/trackers/jira.ts
@@ -1,4 +1,6 @@
+import * as canonicalLog from "../canonical-log.ts";
 import type { JiraClient, JiraIssue } from "../jira-client.ts";
+import { resolveRepo } from "../scope-resolver.ts";
 import { issueKey, issueNumber, type RepoSlug } from "../types/brands.ts";
 import { err, ok } from "../types/result.ts";
 import { decorateTracker } from "./decorator.ts";
@@ -8,11 +10,18 @@ type JiraStatuses = Record<TrackerState, string>;
 
 type JiraTrackerOptions = {
 	project: string;
-	repo: RepoSlug;
+	scopes: readonly RepoSlug[];
 	baseUrl: string;
 	statuses: JiraStatuses;
 	labels?: readonly string[];
 };
+
+const REPO_LABEL_PREFIX = "repo:";
+
+type DropReason =
+	| "no_repo_label"
+	| "multiple_repo_labels"
+	| "unresolved_repo_label";
 
 function jiraIssueKey(project: string, num: number): string {
 	return `${project}-${num}`;
@@ -54,7 +63,15 @@ export function jiraTrackerAdapter(
 ): TrackerAdapter {
 	const baseUrl = trimTrailingSlash(options.baseUrl);
 
-	function mapIssue(issue: JiraIssue): Issue {
+	function logDrop(issueKeyValue: string, reason: DropReason): void {
+		canonicalLog.append("dropped_issues", {
+			event: "issue_dropped",
+			reason,
+			issueKey: issueKeyValue,
+		});
+	}
+
+	function buildIssue(issue: JiraIssue, repo: RepoSlug): Issue {
 		const num = parseJiraKey(options.project, issue.key);
 		/* v8 ignore next 3 -- defensive check; Jira API returns keys matching its own search filter */
 		if (num == null) {
@@ -63,21 +80,43 @@ export function jiraTrackerAdapter(
 		return {
 			key: issueKey(issue.key),
 			number: issueNumber(num),
-			repo: options.repo,
+			repo,
 			title: issue.fields.summary,
 			description: extractText(issue.fields.description),
-			labels: [issue.fields.status.name],
+			labels: issue.fields.labels,
 			url: `${baseUrl}/browse/${issue.key}`,
 			createdAt: issue.fields.created,
 		};
 	}
 
+	function resolveScopedIssue(issue: JiraIssue): Issue | null {
+		const repoLabels = issue.fields.labels.filter((l) =>
+			l.startsWith(REPO_LABEL_PREFIX),
+		);
+		const [first, second] = repoLabels;
+		if (!first) {
+			logDrop(issue.key, "no_repo_label");
+			return null;
+		}
+		if (second) {
+			logDrop(issue.key, "multiple_repo_labels");
+			return null;
+		}
+		const path = first.slice(REPO_LABEL_PREFIX.length);
+		const resolved = resolveRepo(path, options.scopes);
+		if (!resolved) {
+			logDrop(issue.key, "unresolved_repo_label");
+			return null;
+		}
+		return buildIssue(issue, resolved);
+	}
+
 	return decorateTracker({
-		async fetchIssue(_repo, issueNum): Promise<Issue> {
+		async fetchIssue(repo, issueNum): Promise<Issue> {
 			const issue = await client.getIssue(
 				jiraIssueKey(options.project, issueNum),
 			);
-			return mapIssue(issue);
+			return buildIssue(issue, repo);
 		},
 
 		async fetchActiveIssues(state) {
@@ -91,10 +130,16 @@ export function jiraTrackerAdapter(
 			}
 			const jql = `${clauses.join(" AND ")} ORDER BY created ASC`;
 			const raw = await client.searchIssues({ jql, maxResults: 100 });
-			return {
-				issues: raw.map(mapIssue),
-				reposReached: new Set([options.repo]),
-			};
+			const issues: Issue[] = [];
+			const reposReached = new Set<RepoSlug>(options.scopes);
+			for (const r of raw) {
+				const mapped = resolveScopedIssue(r);
+				if (mapped) {
+					issues.push(mapped);
+					reposReached.add(mapped.repo);
+				}
+			}
+			return { issues, reposReached };
 		},
 
 		async transitionState(_repo, issueNum, _from, to): Promise<void> {

--- a/server/workflow/__tests__/workflow-loader.test.ts
+++ b/server/workflow/__tests__/workflow-loader.test.ts
@@ -2,8 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { repoSlug } from "../../types/brands.ts";
-import { createWorkflowMap, loadWorkflow } from "../workflow-loader.ts";
+import { loadWorkflow } from "../workflow-loader.ts";
 
 const validWorkflowYaml = `
 branch: "agent/issue-{{ issue.number }}"
@@ -103,24 +102,5 @@ change_request:
 `);
 
 		expect(() => loadWorkflow(workflowFile.path)).not.toThrow();
-	});
-});
-
-describe("createWorkflowMap", () => {
-	it("applies the same loaded workflow to every configured repo", () => {
-		using workflowFile = writeWorkflow(validWorkflowYaml);
-		const workflow = loadWorkflow(workflowFile.path);
-
-		const workflows = createWorkflowMap(
-			[repoSlug("test-owner/first-repo"), repoSlug("test-owner/second-repo")],
-			workflow,
-		);
-
-		expect(workflows).toEqual(
-			new Map([
-				["test-owner/first-repo", workflow],
-				["test-owner/second-repo", workflow],
-			]),
-		);
 	});
 });

--- a/server/workflow/workflow-loader.ts
+++ b/server/workflow/workflow-loader.ts
@@ -1,5 +1,4 @@
 import { readFileSync } from "node:fs";
-import type { RepoSlug } from "../types/brands.ts";
 import type { RepoWorkflow } from "./workflow.ts";
 import { parseRepoWorkflow } from "./workflow.ts";
 import { validateOutputReferences } from "./workflow-validator.ts";
@@ -11,11 +10,4 @@ export function loadWorkflow(path = WORKFLOW_PATH): RepoWorkflow {
 	const workflow = parseRepoWorkflow(content);
 	validateOutputReferences(workflow, path);
 	return workflow;
-}
-
-export function createWorkflowMap(
-	repos: RepoSlug[],
-	workflow: RepoWorkflow,
-): Map<RepoSlug, RepoWorkflow> {
-	return new Map(repos.map((repo) => [repo, workflow]));
 }


### PR DESCRIPTION
## Summary

- Replaces `code_host.repos[]` with `code_host.scopes[]`; drops the 1-repo-per-Jira-project constraint. A single Jira project can now drive runs across many repos.
- Jira issues identify their target repo via a `repo:<full-path>` label, resolved against the configured scopes (slice 1's `resolveRepo`). Out-of-scope, missing, or multiple `repo:` labels are dropped with a structured `canonicalLog` entry.
- `Issue.labels` on the Jira side now maps from `fields.labels` rather than the status name; `JiraIssue` schema gains a `labels` field.
- Per-repo workflow map collapses to a single global `workflow: RepoWorkflow` on the orchestrator — group-prefix scopes have no enumerable repo set up-front, and the today-true invariant is one workflow for all repos.
- Removes the now-dead optional `tracker.labels` allowlist (slice 4 will reintroduce a labels clause built from `trigger_label`).

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test:coverage` (321 tests pass; coverage 99.03% statements / 97.78% branch)
- [ ] Manual: confirm a Jira config with multiple scopes loads cleanly and that an issue carrying `repo:<scope>` dispatches to the resolved repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)