### PR TITLE
feat: repo-scoping slice 4 — trigger label, lifecycle separation, reporter parity

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,7 @@ tracker:
   kind: jira
   base_url: todo
   project: AIENG
+  trigger_label: local-agents
   statuses:
     pending: "To Do"
     running: "In Progress"

--- a/docs/repo-scoping-plan.md
+++ b/docs/repo-scoping-plan.md
@@ -169,7 +169,9 @@ Slices 4 → 5 are also sequential. Slice 4's new pending filter (`trigger_label
 
 ## Slice 4 — Trigger Label, Lifecycle Separation, and Reporter Parity
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Verification:** `pnpm lint`, `pnpm typecheck`, `pnpm test` (330 tests).
 
 **Purpose:** Establish a clean, symmetric model for issue eligibility and lifecycle state across both trackers. The trigger label is a pure marker that humans apply and remove; the orchestrator never mutates it. Lifecycle state lives in a separate mechanism per tracker (state labels on GitHub, status transitions on Jira). Bring Jira to parity with GitHub on creator/reporter filtering.
 

--- a/server/__tests__/config.test.ts
+++ b/server/__tests__/config.test.ts
@@ -34,6 +34,7 @@ describe("loadConfig", () => {
 		using configFile = writeConfig(`
 tracker:
   kind: github
+  trigger_label: agent
 code_host:
   kind: github
   scopes:
@@ -50,6 +51,7 @@ ${fullDefaults}`);
 		using configFile = writeConfig(`
 tracker:
   kind: github
+  trigger_label: agent
 code_host:
   kind: gitlab
   base_url: https://gitlab.example.test
@@ -70,6 +72,7 @@ ${fullDefaults}`);
 		using configFile = writeConfig(`
 tracker:
   kind: github
+  trigger_label: agent
 code_host:
   kind: gitlab
   scopes:
@@ -85,6 +88,7 @@ tracker:
   kind: jira
   base_url: https://jira.example.test
   project: PROJ
+  trigger_label: agent
 code_host:
   kind: gitlab
   base_url: https://gitlab.example.test
@@ -101,6 +105,7 @@ tracker:
   kind: jira
   base_url: https://jira.example.test
   project: PROJ
+  trigger_label: agent
   statuses:
     pending: Backlog
     running: Doing
@@ -117,6 +122,7 @@ ${fullDefaults}`);
 			kind: "jira",
 			base_url: "https://jira.example.test",
 			project: "PROJ",
+			trigger_label: "agent",
 			statuses: {
 				pending: "Backlog",
 				running: "Doing",
@@ -131,6 +137,7 @@ tracker:
   kind: jira
   base_url: https://jira.example.test
   project: PROJ
+  trigger_label: agent
   statuses:
     pending: To Do
     running: In Progress
@@ -149,6 +156,7 @@ tracker:
   kind: jira
   base_url: https://jira.example.test
   project: PROJ
+  trigger_label: agent
   statuses:
     pending: To Do
     running: In Progress
@@ -169,6 +177,7 @@ ${fullDefaults}`);
 		using configFile = writeConfig(`
 tracker:
   kind: github
+  trigger_label: agent
 code_host:
   kind: github
 ${fullDefaults}`);
@@ -180,6 +189,7 @@ ${fullDefaults}`);
 		using configFile = writeConfig(`
 tracker:
   kind: github
+  trigger_label: agent
 code_host:
   kind: github
   scopes:
@@ -193,6 +203,7 @@ code_host:
 		using configFile = writeConfig(`
 tracker:
   kind: github
+  trigger_label: agent
 code_host:
   kind: github
   scopes:
@@ -208,6 +219,7 @@ ${fullDefaults}`);
 		using configFile = writeConfig(`
 tracker:
   kind: github
+  trigger_label: agent
 code_host:
   kind: github
   repos:
@@ -215,5 +227,56 @@ code_host:
 ${fullDefaults}`);
 
 		expect(() => loadConfig(configFile.path)).toThrow();
+	});
+
+	it("rejects github tracker without trigger_label", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: github
+code_host:
+  kind: github
+  scopes:
+    - owner/repo
+${fullDefaults}`);
+
+		expect(() => loadConfig(configFile.path)).toThrow();
+	});
+
+	it("rejects jira tracker without trigger_label", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: jira
+  base_url: https://jira.example.test
+  project: PROJ
+  statuses:
+    pending: To Do
+    running: In Progress
+    awaiting_review: In Review
+code_host:
+  kind: github
+  scopes:
+    - owner/repo
+${fullDefaults}`);
+
+		expect(() => loadConfig(configFile.path)).toThrow();
+	});
+
+	it("exposes trigger_label on the github tracker variant", () => {
+		using configFile = writeConfig(`
+tracker:
+  kind: github
+  trigger_label: local-agents
+code_host:
+  kind: github
+  scopes:
+    - owner/repo
+${fullDefaults}`);
+
+		const config = loadConfig(configFile.path);
+
+		expect(config.tracker).toEqual({
+			kind: "github",
+			trigger_label: "local-agents",
+		});
 	});
 });

--- a/server/__tests__/env.test.ts
+++ b/server/__tests__/env.test.ts
@@ -7,7 +7,7 @@ const originalEnv = process.env;
 
 function gitlabConfig(): Pick<Config, "tracker" | "code_host"> {
 	return {
-		tracker: { kind: "github" },
+		tracker: { kind: "github", trigger_label: "agent" },
 		code_host: {
 			kind: "gitlab",
 			scopes: [repoSlug("group/project")],
@@ -22,6 +22,7 @@ function jiraConfig(): Pick<Config, "tracker" | "code_host"> {
 			kind: "jira",
 			base_url: "https://jira.example.test",
 			project: "PROJ",
+			trigger_label: "agent",
 			statuses: {
 				pending: "To Do",
 				running: "In Progress",

--- a/server/__tests__/github-client.integration.test.ts
+++ b/server/__tests__/github-client.integration.test.ts
@@ -99,6 +99,45 @@ describe("GitHub client retry", () => {
 		);
 	});
 
+	it("searchIssues GETs /search/issues with the q param and returns items[]", async () => {
+		server.use(
+			http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
+				const url = new URL(request.url);
+				if (url.searchParams.get("q") !== "repo:owner/repo label:agent") {
+					return new HttpResponse(null, { status: 400 });
+				}
+				return HttpResponse.json({
+					items: [
+						{
+							number: 7,
+							title: "Issue 7",
+							body: null,
+							labels: [{ name: "agent" }],
+							html_url: "https://github.com/owner/repo/issues/7",
+							created_at: "2025-02-01T00:00:00Z",
+						},
+					],
+				});
+			}),
+		);
+
+		const client = createGitHubClient(githubToken("test-token"), {
+			baseDelayMs: 1,
+		});
+		const issues = await client.searchIssues("repo:owner/repo label:agent");
+
+		expect(issues).toEqual([
+			{
+				number: 7,
+				title: "Issue 7",
+				body: null,
+				labels: [{ name: "agent" }],
+				html_url: "https://github.com/owner/repo/issues/7",
+				created_at: "2025-02-01T00:00:00Z",
+			},
+		]);
+	});
+
 	it("retries on network errors", async () => {
 		server.use(
 			http.get(`${GITHUB_API}/user`, function* () {

--- a/server/config.ts
+++ b/server/config.ts
@@ -7,11 +7,13 @@ export type Config = {
 	tracker:
 		| {
 				kind: "github";
+				trigger_label: string;
 		  }
 		| {
 				kind: "jira";
 				base_url: string;
 				project: string;
+				trigger_label: string;
 				statuses: {
 					pending: string;
 					running: string;
@@ -45,6 +47,7 @@ const configSchema = z
 			z
 				.object({
 					kind: z.literal("github"),
+					trigger_label: z.string().min(1),
 				})
 				.strict(),
 			z
@@ -52,6 +55,7 @@ const configSchema = z
 					kind: z.literal("jira"),
 					base_url: z.url(),
 					project: z.string().min(1),
+					trigger_label: z.string().min(1),
 					statuses: z
 						.object({
 							pending: z.string().min(1),

--- a/server/github-client.ts
+++ b/server/github-client.ts
@@ -59,6 +59,7 @@ export type GitHubClient = {
 			per_page: string;
 		},
 	): Promise<GitHubIssue[]>;
+	searchIssues(query: string): Promise<GitHubIssue[]>;
 	removeIssueLabel(
 		repo: RepoSlug,
 		issueNumber: IssueNumber,
@@ -125,6 +126,14 @@ export function createGitHubClient(
 			return request(`/repos/${repo}/issues?${query}`, {
 				schema: z.array(githubIssueSchema),
 			});
+		},
+
+		async searchIssues(query) {
+			const params = new URLSearchParams({ q: query });
+			const result = await request(`/search/issues?${params}`, {
+				schema: z.object({ items: z.array(githubIssueSchema) }),
+			});
+			return result.items;
 		},
 
 		removeIssueLabel(repo, issueNumber, label) {

--- a/server/orchestrator/__tests__/orchestrator.dispatch-multi-repo.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.dispatch-multi-repo.integration.test.ts
@@ -47,17 +47,21 @@ describe("Orchestrator multi-repo scheduling", () => {
 			http.get(`${GITHUB_API}/user`, () =>
 				HttpResponse.json({ login: "test-user" }),
 			),
-			http.get(`${GITHUB_API}/repos/${REPO}/issues`, () => {
-				return new HttpResponse(null, { status: 500 });
-			}),
-			http.get(`${GITHUB_API}/repos/${REPO2}/issues`, ({ request }) => {
-				const url = new URL(request.url);
-				const label = url.searchParams.get("labels");
-				if (label === "agent") {
-					return HttpResponse.json([createGitHubIssue(10, ["agent"])]);
+			http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
+				const q = new URL(request.url).searchParams.get("q") ?? "";
+				if (q.includes(`repo:${REPO} `)) {
+					return new HttpResponse(null, { status: 500 });
 				}
-				return HttpResponse.json([]);
+				if (q.includes(`repo:${REPO2} `)) {
+					return HttpResponse.json({
+						items: [createGitHubIssue(10, ["agent"])],
+					});
+				}
+				return HttpResponse.json({ items: [] });
 			}),
+			http.get(`${GITHUB_API}/repos/:owner/:repo/issues`, () =>
+				HttpResponse.json([]),
+			),
 			http.delete(
 				`${GITHUB_API}/repos/${REPO2}/issues/:number/labels/:label`,
 				() => new HttpResponse(null, { status: 204 }),
@@ -99,26 +103,23 @@ describe("Orchestrator multi-repo scheduling", () => {
 			http.get(`${GITHUB_API}/user`, () =>
 				HttpResponse.json({ login: "test-user" }),
 			),
-			http.get(`${GITHUB_API}/repos/${REPO}/issues`, ({ request }) => {
-				const url = new URL(request.url);
-				const label = url.searchParams.get("labels");
-				if (label === "agent") {
-					return HttpResponse.json([
-						createGitHubIssue(1, ["agent"], "2025-01-01T00:00:00Z"),
-					]);
+			http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
+				const q = new URL(request.url).searchParams.get("q") ?? "";
+				if (q.includes(`repo:${REPO} `)) {
+					return HttpResponse.json({
+						items: [createGitHubIssue(1, ["agent"], "2025-01-01T00:00:00Z")],
+					});
 				}
-				return HttpResponse.json([]);
-			}),
-			http.get(`${GITHUB_API}/repos/${REPO2}/issues`, ({ request }) => {
-				const url = new URL(request.url);
-				const label = url.searchParams.get("labels");
-				if (label === "agent") {
-					return HttpResponse.json([
-						createGitHubIssue(2, ["agent"], "2025-01-02T00:00:00Z"),
-					]);
+				if (q.includes(`repo:${REPO2} `)) {
+					return HttpResponse.json({
+						items: [createGitHubIssue(2, ["agent"], "2025-01-02T00:00:00Z")],
+					});
 				}
-				return HttpResponse.json([]);
+				return HttpResponse.json({ items: [] });
 			}),
+			http.get(`${GITHUB_API}/repos/:owner/:repo/issues`, () =>
+				HttpResponse.json([]),
+			),
 			http.delete(
 				`${GITHUB_API}/repos/:owner/:repo/issues/:number/labels/:label`,
 				() => new HttpResponse(null, { status: 204 }),

--- a/server/orchestrator/__tests__/orchestrator.jira.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.jira.integration.test.ts
@@ -80,7 +80,13 @@ describe("Orchestrator Jira dispatch", () => {
 				apiToken: jiraApiToken("jira-token"),
 				maxAttempts: 1,
 			}),
-			{ project: "PROJ", scopes: [REPO], baseUrl: JIRA_BASE_URL, statuses },
+			{
+				project: "PROJ",
+				scopes: [REPO],
+				baseUrl: JIRA_BASE_URL,
+				statuses,
+				triggerLabel: "agent",
+			},
 		);
 
 		// Strict codeHost stub: returns success only when called against the

--- a/server/orchestrator/__tests__/orchestrator.reconcile.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.reconcile.integration.test.ts
@@ -138,20 +138,20 @@ describe("Orchestrator reconciliation", () => {
 	});
 
 	it("fetches running issues even with no running DB records to detect orphans", async () => {
-		let fetchCallCount = 0;
+		let pendingFetches = 0;
+		let runningFetches = 0;
 
 		server.use(
 			http.get(`${GITHUB_API}/user`, () =>
 				HttpResponse.json({ login: "test-user" }),
 			),
+			http.get(`${GITHUB_API}/search/issues`, () => {
+				pendingFetches++;
+				return HttpResponse.json({ items: [] });
+			}),
 			http.get(`${GITHUB_API}/repos/${REPO}/issues`, ({ request }) => {
-				const url = new URL(request.url);
-				const label = url.searchParams.get("labels");
-				fetchCallCount++;
-				if (label === "agent") return HttpResponse.json([]);
-				// If this is called with agent:running and there are no running agents,
-				// that means we made an unnecessary fetch
-				if (label === "agent:running") return HttpResponse.json([]);
+				const labels = new URL(request.url).searchParams.get("labels") ?? "";
+				if (labels.includes("agent:running")) runningFetches++;
 				return HttpResponse.json([]);
 			}),
 		);
@@ -161,11 +161,10 @@ describe("Orchestrator reconciliation", () => {
 		});
 		const { orchestrator } = ctx;
 
-		// No running agents — tick should still fetch running issues to detect orphans
 		await orchestrator.tick();
 
-		// Should have fetched both pending and running issues
-		expect(fetchCallCount).toBe(2);
+		expect(pendingFetches).toBe(1);
+		expect(runningFetches).toBe(1);
 	});
 
 	it("handles fetch failure gracefully during reconciliation", async () => {
@@ -176,11 +175,12 @@ describe("Orchestrator reconciliation", () => {
 			http.get(`${GITHUB_API}/user`, () =>
 				HttpResponse.json({ login: "test-user" }),
 			),
+			http.get(`${GITHUB_API}/search/issues`, () =>
+				HttpResponse.json({ items: pendingIssues }),
+			),
 			http.get(`${GITHUB_API}/repos/${REPO}/issues`, ({ request }) => {
-				const url = new URL(request.url);
-				const label = url.searchParams.get("labels");
-				if (label === "agent") return HttpResponse.json(pendingIssues);
-				if (label === "agent:running") {
+				const labels = new URL(request.url).searchParams.get("labels") ?? "";
+				if (labels.includes("agent:running")) {
 					if (failRunningFetch) {
 						return new HttpResponse(null, { status: 500 });
 					}
@@ -393,27 +393,23 @@ describe("Orchestrator reconciliation", () => {
 		expect(runsAfterSecondTick).toEqual(allRuns);
 	});
 
-	it("rolls back orphan label when GitHub still says agent:running but DB has no running run", async () => {
+	it("rolls back the running state label when GitHub still says agent:running but DB has no running run, leaving the trigger label intact", async () => {
 		const recoveryDelete = http.delete(
 			`${GITHUB_API}/repos/${REPO}/issues/:number/labels/agent:running`,
 			() => new HttpResponse(null, { status: 204 }),
 			{ once: true },
 		);
-		const recoveryPost = http.post(
+		const triggerLabelMutation = http.post(
 			`${GITHUB_API}/repos/${REPO}/issues/:number/labels`,
-			async ({ request }) => {
-				const body = (await request.json()) as { labels: string[] };
-				if (body.labels[0] !== "agent") {
-					return new HttpResponse(null, { status: 400 });
-				}
-				return HttpResponse.json([]);
-			},
-			{ once: true },
+			() =>
+				new HttpResponse("trigger label must not be mutated", {
+					status: 500,
+				}),
 		);
 
 		server.use(
 			recoveryDelete,
-			recoveryPost,
+			triggerLabelMutation,
 			...githubHandlers({
 				resolveIssues: (label) => {
 					if (label === "agent:running")
@@ -446,6 +442,6 @@ describe("Orchestrator reconciliation", () => {
 		await orchestrator.settled();
 
 		expect(recoveryDelete.isUsed).toBe(true);
-		expect(recoveryPost.isUsed).toBe(true);
+		expect(triggerLabelMutation.isUsed).toBe(false);
 	});
 });

--- a/server/orchestrator/__tests__/orchestrator.scheduling.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.scheduling.integration.test.ts
@@ -188,8 +188,8 @@ describe("Orchestrator scheduling", () => {
 			}),
 		);
 		server.use(
-			http.delete(
-				`${GITHUB_API}/repos/${REPO}/issues/:number/labels/:label`,
+			http.post(
+				`${GITHUB_API}/repos/${REPO}/issues/:number/labels`,
 				() => new HttpResponse(null, { status: 500 }),
 			),
 		);

--- a/server/server.ts
+++ b/server/server.ts
@@ -32,7 +32,10 @@ migrate(db);
 const github = createGitHubClient(env.GITHUB_TOKEN ?? githubToken(""));
 let tracker: TrackerAdapter;
 if (config.tracker.kind === "github") {
-	tracker = githubTrackerAdapter(github, { repos: config.code_host.scopes });
+	tracker = githubTrackerAdapter(github, {
+		repos: config.code_host.scopes,
+		triggerLabel: config.tracker.trigger_label,
+	});
 } else {
 	if (!env.JIRA_EMAIL || !env.JIRA_API_TOKEN) {
 		throw new Error("JIRA_EMAIL and JIRA_API_TOKEN are required for Jira");
@@ -47,6 +50,7 @@ if (config.tracker.kind === "github") {
 		scopes: config.code_host.scopes,
 		baseUrl: config.tracker.base_url,
 		statuses: config.tracker.statuses,
+		triggerLabel: config.tracker.trigger_label,
 	});
 }
 let codeHost: CodeHostAdapter;

--- a/server/testing/support/msw.ts
+++ b/server/testing/support/msw.ts
@@ -35,8 +35,21 @@ export function githubHandlers({
 		}),
 		http.get(`${GITHUB_API}/repos/${REPO}/issues`, ({ request }) => {
 			const url = new URL(request.url);
-			const label = url.searchParams.get("labels");
-			return HttpResponse.json(label ? resolve(label) : []);
+			const labels = (url.searchParams.get("labels") ?? "")
+				.split(",")
+				.filter(Boolean);
+			const stateLabel = labels.find((l) => l !== "agent");
+			if (stateLabel) {
+				return HttpResponse.json(resolve(stateLabel));
+			}
+			return HttpResponse.json(
+				labels.includes("agent") ? resolve("agent") : [],
+			);
+		}),
+		http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
+			const q = new URL(request.url).searchParams.get("q") ?? "";
+			if (!q.includes("label:agent")) return HttpResponse.json({ items: [] });
+			return HttpResponse.json({ items: resolve("agent") });
 		}),
 		http.delete<{ label: string }>(
 			`${GITHUB_API}/repos/${REPO}/issues/:number/labels/:label`,

--- a/server/testing/support/test-config.ts
+++ b/server/testing/support/test-config.ts
@@ -5,7 +5,7 @@ export function createTestConfig(
 	overrides: Partial<Config["defaults"]> = {},
 ): Config {
 	return {
-		tracker: { kind: "github" },
+		tracker: { kind: "github", trigger_label: "agent" },
 		code_host: {
 			kind: "github",
 			scopes: [repoSlug("test-owner/test-repo")],

--- a/server/testing/support/test-orchestrator.ts
+++ b/server/testing/support/test-orchestrator.ts
@@ -47,7 +47,10 @@ export async function createTestOrchestrator(
 
 	const defaultCodeHost = githubCodeHostAdapter(github);
 	const trackerRepos = options.trackerRepos ?? [REPO];
-	const defaultTracker = githubTrackerAdapter(github, { repos: trackerRepos });
+	const defaultTracker = githubTrackerAdapter(github, {
+		repos: trackerRepos,
+		triggerLabel: "agent",
+	});
 
 	const agent = options.agent ?? adaptRunAgent(options.runAgent ?? noopAgent);
 

--- a/server/trackers/__tests__/github.integration.test.ts
+++ b/server/trackers/__tests__/github.integration.test.ts
@@ -10,31 +10,36 @@ import { server } from "../../testing/support/msw.ts";
 import { githubToken, issueNumber, repoSlug } from "../../types/brands.ts";
 import { githubTrackerAdapter } from "../github.ts";
 
+const TRIGGER = "agent";
+
 describe("githubTrackerAdapter", () => {
 	describe("fetchActiveIssues", () => {
-		it("deduplicates issues that appear in multiple state queries", async () => {
-			const issue = createGitHubIssue(10, ["agent"]);
-
+		it("pending uses the search API with the trigger label and negated state labels", async () => {
+			const captured: string[] = [];
 			server.use(
 				http.get(`${GITHUB_API}/user`, () =>
 					HttpResponse.json({ login: "test-user" }),
 				),
-				http.get(`${GITHUB_API}/repos/${REPO}/issues`, ({ request }) => {
+				http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
 					const url = new URL(request.url);
-					const state = url.searchParams.get("state");
-					if (state === "open" || state === "closed")
-						return HttpResponse.json([issue]);
-					return HttpResponse.json([]);
+					captured.push(url.searchParams.get("q") ?? "");
+					return HttpResponse.json({
+						items: [createGitHubIssue(10, ["agent"])],
+					});
 				}),
 			);
 
 			const github = createGitHubClient(githubToken("test-token"));
 			const tracker = githubTrackerAdapter(github, {
 				repos: [REPO],
-				activeStates: ["open", "closed"],
+				triggerLabel: TRIGGER,
 			});
 
 			const { issues } = await tracker.fetchActiveIssues("pending");
+
+			expect(captured).toEqual([
+				`repo:${REPO} type:issue author:test-user state:open label:agent -label:agent:running -label:agent:awaiting-review`,
+			]);
 			expect(issues).toEqual([
 				{
 					key: `${REPO}#10`,
@@ -49,22 +54,79 @@ describe("githubTrackerAdapter", () => {
 			]);
 		});
 
-		it("returns issues from multiple states when they differ", async () => {
+		it("running uses listIssues filtered by trigger AND state label", async () => {
+			const captured: string[] = [];
 			server.use(
 				http.get(`${GITHUB_API}/user`, () =>
 					HttpResponse.json({ login: "test-user" }),
 				),
 				http.get(`${GITHUB_API}/repos/${REPO}/issues`, ({ request }) => {
 					const url = new URL(request.url);
-					const state = url.searchParams.get("state");
-					if (state === "open")
-						return HttpResponse.json([
-							createGitHubIssue(1, ["agent"], "2025-01-01T00:00:00Z"),
-						]);
-					if (state === "closed")
-						return HttpResponse.json([
-							createGitHubIssue(2, ["agent"], "2025-01-02T00:00:00Z"),
-						]);
+					captured.push(url.searchParams.get("labels") ?? "");
+					return HttpResponse.json([
+						createGitHubIssue(11, ["agent", "agent:running"]),
+					]);
+				}),
+			);
+
+			const github = createGitHubClient(githubToken("test-token"));
+			const tracker = githubTrackerAdapter(github, {
+				repos: [REPO],
+				triggerLabel: TRIGGER,
+			});
+
+			const { issues } = await tracker.fetchActiveIssues("running");
+
+			expect(captured).toEqual(["agent,agent:running"]);
+			expect(issues.map((i) => i.key)).toEqual([`${REPO}#11`]);
+		});
+
+		it("awaiting_review uses listIssues filtered by trigger AND awaiting-review state label", async () => {
+			const captured: string[] = [];
+			server.use(
+				http.get(`${GITHUB_API}/user`, () =>
+					HttpResponse.json({ login: "test-user" }),
+				),
+				http.get(`${GITHUB_API}/repos/${REPO}/issues`, ({ request }) => {
+					const url = new URL(request.url);
+					captured.push(url.searchParams.get("labels") ?? "");
+					return HttpResponse.json([
+						createGitHubIssue(12, ["agent", "agent:awaiting-review"]),
+					]);
+				}),
+			);
+
+			const github = createGitHubClient(githubToken("test-token"));
+			const tracker = githubTrackerAdapter(github, {
+				repos: [REPO],
+				triggerLabel: TRIGGER,
+			});
+
+			const { issues } = await tracker.fetchActiveIssues("awaiting_review");
+
+			expect(captured).toEqual(["agent,agent:awaiting-review"]);
+			expect(issues.map((i) => i.key)).toEqual([`${REPO}#12`]);
+		});
+
+		it("derives state labels from a custom trigger label", async () => {
+			const captured: { search: string[]; list: string[] } = {
+				search: [],
+				list: [],
+			};
+			server.use(
+				http.get(`${GITHUB_API}/user`, () =>
+					HttpResponse.json({ login: "test-user" }),
+				),
+				http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
+					captured.search.push(
+						new URL(request.url).searchParams.get("q") ?? "",
+					);
+					return HttpResponse.json({ items: [] });
+				}),
+				http.get(`${GITHUB_API}/repos/${REPO}/issues`, ({ request }) => {
+					captured.list.push(
+						new URL(request.url).searchParams.get("labels") ?? "",
+					);
 					return HttpResponse.json([]);
 				}),
 			);
@@ -72,32 +134,16 @@ describe("githubTrackerAdapter", () => {
 			const github = createGitHubClient(githubToken("test-token"));
 			const tracker = githubTrackerAdapter(github, {
 				repos: [REPO],
-				activeStates: ["open", "closed"],
+				triggerLabel: "local-agents",
 			});
 
-			const { issues } = await tracker.fetchActiveIssues("pending");
-			expect(issues).toEqual([
-				{
-					key: `${REPO}#1`,
-					number: 1,
-					repo: REPO,
-					title: "Issue 1",
-					description: "Description for issue 1",
-					labels: ["agent"],
-					url: `https://github.com/${REPO}/issues/1`,
-					createdAt: "2025-01-01T00:00:00Z",
-				},
-				{
-					key: `${REPO}#2`,
-					number: 2,
-					repo: REPO,
-					title: "Issue 2",
-					description: "Description for issue 2",
-					labels: ["agent"],
-					url: `https://github.com/${REPO}/issues/2`,
-					createdAt: "2025-01-02T00:00:00Z",
-				},
+			await tracker.fetchActiveIssues("pending");
+			await tracker.fetchActiveIssues("running");
+
+			expect(captured.search).toEqual([
+				`repo:${REPO} type:issue author:test-user state:open label:local-agents -label:local-agents:running -label:local-agents:awaiting-review`,
 			]);
+			expect(captured.list).toEqual(["local-agents,local-agents:running"]);
 		});
 
 		it("fetches across each configured repo and stamps each issue with its source repo", async () => {
@@ -108,16 +154,27 @@ describe("githubTrackerAdapter", () => {
 				http.get(`${GITHUB_API}/user`, () =>
 					HttpResponse.json({ login: "test-user" }),
 				),
-				http.get(`${GITHUB_API}/repos/${repoA}/issues`, () =>
-					HttpResponse.json([createGitHubIssue(1, ["agent"])]),
-				),
-				http.get(`${GITHUB_API}/repos/${repoB}/issues`, () =>
-					HttpResponse.json([createGitHubIssue(2, ["agent"])]),
-				),
+				http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
+					const q = new URL(request.url).searchParams.get("q") ?? "";
+					if (q.includes(`repo:${repoA}`)) {
+						return HttpResponse.json({
+							items: [createGitHubIssue(1, ["agent"])],
+						});
+					}
+					if (q.includes(`repo:${repoB}`)) {
+						return HttpResponse.json({
+							items: [createGitHubIssue(2, ["agent"])],
+						});
+					}
+					return HttpResponse.json({ items: [] });
+				}),
 			);
 
 			const github = createGitHubClient(githubToken("test-token"));
-			const tracker = githubTrackerAdapter(github, { repos: [repoA, repoB] });
+			const tracker = githubTrackerAdapter(github, {
+				repos: [repoA, repoB],
+				triggerLabel: TRIGGER,
+			});
 
 			const { issues } = await tracker.fetchActiveIssues("pending");
 			expect(issues.map((i) => ({ key: i.key, repo: i.repo }))).toEqual([
@@ -131,18 +188,23 @@ describe("githubTrackerAdapter", () => {
 				http.get(`${GITHUB_API}/user`, () =>
 					HttpResponse.json({ login: "test-user" }),
 				),
-				http.get(`${GITHUB_API}/repos/${REPO}/issues`, () =>
-					HttpResponse.json([
-						{
-							...createGitHubIssue(5, ["agent"]),
-							body: null,
-						},
-					]),
+				http.get(`${GITHUB_API}/search/issues`, () =>
+					HttpResponse.json({
+						items: [
+							{
+								...createGitHubIssue(5, ["agent"]),
+								body: null,
+							},
+						],
+					}),
 				),
 			);
 
 			const github = createGitHubClient(githubToken("test-token"));
-			const tracker = githubTrackerAdapter(github, { repos: [REPO] });
+			const tracker = githubTrackerAdapter(github, {
+				repos: [REPO],
+				triggerLabel: TRIGGER,
+			});
 
 			const { issues } = await tracker.fetchActiveIssues("pending");
 			expect(issues).toEqual([
@@ -161,33 +223,26 @@ describe("githubTrackerAdapter", () => {
 	});
 
 	describe("transitionState", () => {
-		it("maps logical states to GitHub labels", async () => {
+		it("pending → running adds the running state label and never touches the trigger label", async () => {
+			const calls: { method: string; label: string }[] = [];
+
 			server.use(
-				http.get(`${GITHUB_API}/user`, () =>
-					HttpResponse.json({ login: "test-user" }),
-				),
 				http.delete(
 					`${GITHUB_API}/repos/${REPO}/issues/:number/labels/:label`,
 					({ params }) => {
-						if (
-							params["number"] !== "42" ||
-							params["label"] !== "agent:running"
-						) {
-							return new HttpResponse(null, { status: 400 });
-						}
+						calls.push({
+							method: "DELETE",
+							label: decodeURIComponent(String(params["label"])),
+						});
 						return new HttpResponse(null, { status: 204 });
 					},
 				),
 				http.post(
 					`${GITHUB_API}/repos/${REPO}/issues/:number/labels`,
-					async ({ params, request }) => {
+					async ({ request }) => {
 						const body = (await request.json()) as { labels: string[] };
-						if (
-							params["number"] !== "42" ||
-							JSON.stringify(body.labels) !==
-								JSON.stringify(["agent:awaiting-review"])
-						) {
-							return new HttpResponse(null, { status: 400 });
+						for (const label of body.labels) {
+							calls.push({ method: "POST", label });
 						}
 						return HttpResponse.json([]);
 					},
@@ -195,23 +250,116 @@ describe("githubTrackerAdapter", () => {
 			);
 
 			const github = createGitHubClient(githubToken("test-token"));
-			const tracker = githubTrackerAdapter(github, { repos: [REPO] });
+			const tracker = githubTrackerAdapter(github, {
+				repos: [REPO],
+				triggerLabel: TRIGGER,
+			});
 
-			await expect(
-				tracker.transitionState(
-					REPO,
-					issueNumber(42),
-					"running",
-					"awaiting_review",
+			await tracker.transitionState(
+				REPO,
+				issueNumber(42),
+				"pending",
+				"running",
+			);
+
+			expect(calls).toEqual([{ method: "POST", label: "agent:running" }]);
+		});
+
+		it("running → awaiting_review swaps state labels and never touches the trigger label", async () => {
+			const calls: { method: string; label: string }[] = [];
+
+			server.use(
+				http.delete(
+					`${GITHUB_API}/repos/${REPO}/issues/:number/labels/:label`,
+					({ params }) => {
+						calls.push({
+							method: "DELETE",
+							label: decodeURIComponent(String(params["label"])),
+						});
+						return new HttpResponse(null, { status: 204 });
+					},
 				),
-			).resolves.toBeUndefined();
+				http.post(
+					`${GITHUB_API}/repos/${REPO}/issues/:number/labels`,
+					async ({ request }) => {
+						const body = (await request.json()) as { labels: string[] };
+						for (const label of body.labels) {
+							calls.push({ method: "POST", label });
+						}
+						return HttpResponse.json([]);
+					},
+				),
+			);
+
+			const github = createGitHubClient(githubToken("test-token"));
+			const tracker = githubTrackerAdapter(github, {
+				repos: [REPO],
+				triggerLabel: TRIGGER,
+			});
+
+			await tracker.transitionState(
+				REPO,
+				issueNumber(42),
+				"running",
+				"awaiting_review",
+			);
+
+			expect(calls).toEqual([
+				{ method: "DELETE", label: "agent:running" },
+				{ method: "POST", label: "agent:awaiting-review" },
+			]);
+		});
+
+		it("running → pending removes the running state label and never re-adds the trigger label", async () => {
+			const calls: { method: string; label: string }[] = [];
+
+			server.use(
+				http.delete(
+					`${GITHUB_API}/repos/${REPO}/issues/:number/labels/:label`,
+					({ params }) => {
+						calls.push({
+							method: "DELETE",
+							label: decodeURIComponent(String(params["label"])),
+						});
+						return new HttpResponse(null, { status: 204 });
+					},
+				),
+				http.post(
+					`${GITHUB_API}/repos/${REPO}/issues/:number/labels`,
+					async ({ request }) => {
+						const body = (await request.json()) as { labels: string[] };
+						for (const label of body.labels) {
+							calls.push({ method: "POST", label });
+						}
+						return HttpResponse.json([]);
+					},
+				),
+			);
+
+			const github = createGitHubClient(githubToken("test-token"));
+			const tracker = githubTrackerAdapter(github, {
+				repos: [REPO],
+				triggerLabel: TRIGGER,
+			});
+
+			await tracker.transitionState(
+				REPO,
+				issueNumber(42),
+				"running",
+				"pending",
+			);
+
+			expect(calls).toEqual([{ method: "DELETE", label: "agent:running" }]);
 		});
 	});
 
 	describe("parseIssueKey", () => {
 		it("parses GitHub issue keys to an issue number", () => {
 			const github = createGitHubClient(githubToken("test-token"));
-			const tracker = githubTrackerAdapter(github, { repos: [REPO] });
+			const tracker = githubTrackerAdapter(github, {
+				repos: [REPO],
+				triggerLabel: TRIGGER,
+			});
 
 			expect(tracker.parseIssueKey("owner/repo#42")).toEqual({
 				ok: true,
@@ -223,7 +371,10 @@ describe("githubTrackerAdapter", () => {
 
 		it("returns Err for malformed GitHub issue keys", () => {
 			const github = createGitHubClient(githubToken("test-token"));
-			const tracker = githubTrackerAdapter(github, { repos: [REPO] });
+			const tracker = githubTrackerAdapter(github, {
+				repos: [REPO],
+				triggerLabel: TRIGGER,
+			});
 
 			expect(tracker.parseIssueKey("owner/repo")).toEqual({
 				ok: false,

--- a/server/trackers/__tests__/jira.integration.test.ts
+++ b/server/trackers/__tests__/jira.integration.test.ts
@@ -36,6 +36,7 @@ function createTracker(scopes: readonly RepoSlug[] = [REPO]) {
 			scopes,
 			baseUrl: JIRA_BASE_URL,
 			statuses,
+			triggerLabel: "agent",
 		},
 	);
 }
@@ -130,7 +131,7 @@ describe("jiraTrackerAdapter", () => {
 	});
 
 	describe("fetchActiveIssues", () => {
-		it("builds safe JQL for the configured project and logical status", async () => {
+		it("builds JQL constrained by project, status, trigger label, and the authenticated reporter", async () => {
 			const expectedFields = [
 				"summary",
 				"description",
@@ -144,7 +145,7 @@ describe("jiraTrackerAdapter", () => {
 					const body = (await request.json()) as Record<string, unknown>;
 					if (
 						body["jql"] !==
-							'project = "PROJ" AND status = "To Do" ORDER BY created ASC' ||
+							'project = "PROJ" AND status = "To Do" AND labels = "agent" AND reporter = currentUser() ORDER BY created ASC' ||
 						body["maxResults"] !== 100 ||
 						JSON.stringify(body["fields"]) !== JSON.stringify(expectedFields)
 					) {
@@ -163,6 +164,38 @@ describe("jiraTrackerAdapter", () => {
 
 			expect(issues.map((issue) => issue.key)).toEqual(["PROJ-1"]);
 			expect(issues.map((issue) => issue.repo)).toEqual([REPO]);
+		});
+
+		it("interpolates a custom trigger label into the JQL labels clause", async () => {
+			let capturedJql = "";
+			server.use(
+				http.post(`${JIRA_API}/search/jql`, async ({ request }) => {
+					const body = (await request.json()) as Record<string, unknown>;
+					capturedJql = String(body["jql"]);
+					return HttpResponse.json({ issues: [] });
+				}),
+			);
+
+			const tracker = jiraTrackerAdapter(
+				createJiraClient({
+					baseUrl: JIRA_BASE_URL,
+					email: jiraEmail("agent@example.test"),
+					apiToken: jiraApiToken("jira-token"),
+					maxAttempts: 1,
+				}),
+				{
+					project: "PROJ",
+					scopes: [REPO],
+					baseUrl: JIRA_BASE_URL,
+					statuses,
+					triggerLabel: "local-agents",
+				},
+			);
+			await tracker.fetchActiveIssues("pending");
+
+			expect(capturedJql).toBe(
+				'project = "PROJ" AND status = "To Do" AND labels = "local-agents" AND reporter = currentUser() ORDER BY created ASC',
+			);
 		});
 
 		it("maps Issue.labels from fields.labels, not the status name", async () => {
@@ -285,7 +318,7 @@ describe("jiraTrackerAdapter", () => {
 					const body = (await request.json()) as { jql?: string };
 					if (
 						body.jql !==
-						'project = "PROJ" AND status = "Ready \\"Now\\" \\\\ Backlog" ORDER BY created ASC'
+						'project = "PROJ" AND status = "Ready \\"Now\\" \\\\ Backlog" AND labels = "agent" AND reporter = currentUser() ORDER BY created ASC'
 					) {
 						return new HttpResponse(null, { status: 400 });
 					}
@@ -308,6 +341,7 @@ describe("jiraTrackerAdapter", () => {
 						...statuses,
 						pending: 'Ready "Now" \\ Backlog',
 					},
+					triggerLabel: "agent",
 				},
 			);
 

--- a/server/trackers/github.ts
+++ b/server/trackers/github.ts
@@ -9,13 +9,8 @@ type IssueState = "open" | "closed" | "all";
 
 type GitHubTrackerOptions = {
 	repos: readonly RepoSlug[];
+	triggerLabel: string;
 	activeStates?: readonly IssueState[];
-};
-
-const LABELS: Record<TrackerState, string> = {
-	pending: "agent",
-	running: "agent:running",
-	awaiting_review: "agent:awaiting-review",
 };
 
 function mapGitHubIssue(repo: RepoSlug, i: GitHubIssue): Issue {
@@ -35,7 +30,11 @@ export function githubTrackerAdapter(
 	client: GitHubClient,
 	options: GitHubTrackerOptions,
 ): TrackerAdapter {
-	const { repos, activeStates = ["open"] as const } = options;
+	const { repos, triggerLabel, activeStates = ["open"] as const } = options;
+	const stateLabels: Record<Exclude<TrackerState, "pending">, string> = {
+		running: `${triggerLabel}:running`,
+		awaiting_review: `${triggerLabel}:awaiting-review`,
+	};
 
 	let usernamePromise: Promise<string> | undefined;
 	function getUsername(): Promise<string> {
@@ -43,33 +42,51 @@ export function githubTrackerAdapter(
 		return usernamePromise;
 	}
 
-	async function fetchForRepo(
+	async function fetchPending(repo: RepoSlug): Promise<Issue[]> {
+		const username = await getUsername();
+		const batches = await Promise.all(
+			activeStates.map((s) =>
+				client.searchIssues(
+					`repo:${repo} type:issue author:${username} state:${s} label:${triggerLabel} -label:${stateLabels.running} -label:${stateLabels.awaiting_review}`,
+				),
+			),
+		);
+		return dedupe(batches.flat()).map((i) => mapGitHubIssue(repo, i));
+	}
+
+	async function fetchByStateLabel(
 		repo: RepoSlug,
-		state: TrackerState,
+		stateLabel: string,
 	): Promise<Issue[]> {
 		const username = await getUsername();
-		const label = LABELS[state];
-
 		const batches = await Promise.all(
 			activeStates.map((s) =>
 				client.listIssues(repo, {
-					labels: label,
+					labels: `${triggerLabel},${stateLabel}`,
 					state: s,
 					creator: username,
 					per_page: "100",
 				}),
 			),
 		);
+		return dedupe(batches.flat()).map((i) => mapGitHubIssue(repo, i));
+	}
 
+	function dedupe(issues: GitHubIssue[]): GitHubIssue[] {
 		const seen = new Set<number>();
-		return batches
-			.flat()
-			.filter((i) => {
-				if (seen.has(i.number)) return false;
-				seen.add(i.number);
-				return true;
-			})
-			.map((i) => mapGitHubIssue(repo, i));
+		return issues.filter((i) => {
+			if (seen.has(i.number)) return false;
+			seen.add(i.number);
+			return true;
+		});
+	}
+
+	async function fetchForRepo(
+		repo: RepoSlug,
+		state: TrackerState,
+	): Promise<Issue[]> {
+		if (state === "pending") return fetchPending(repo);
+		return fetchByStateLabel(repo, stateLabels[state]);
 	}
 
 	return decorateTracker({
@@ -103,8 +120,12 @@ export function githubTrackerAdapter(
 
 		async transitionState(repo, issueNum, from, to): Promise<void> {
 			await Promise.all([
-				client.removeIssueLabel(repo, issueNum, LABELS[from]),
-				client.addIssueLabels(repo, issueNum, [LABELS[to]]),
+				from === "pending"
+					? Promise.resolve()
+					: client.removeIssueLabel(repo, issueNum, stateLabels[from]),
+				to === "pending"
+					? Promise.resolve()
+					: client.addIssueLabels(repo, issueNum, [stateLabels[to]]),
 			]);
 		},
 

--- a/server/trackers/jira.ts
+++ b/server/trackers/jira.ts
@@ -13,6 +13,7 @@ type JiraTrackerOptions = {
 	scopes: readonly RepoSlug[];
 	baseUrl: string;
 	statuses: JiraStatuses;
+	triggerLabel: string;
 };
 
 const REPO_LABEL_PREFIX = "repo:";
@@ -122,6 +123,8 @@ export function jiraTrackerAdapter(
 			const clauses = [
 				`project = ${quoteJqlString(options.project)}`,
 				`status = ${quoteJqlString(options.statuses[state])}`,
+				`labels = ${quoteJqlString(options.triggerLabel)}`,
+				"reporter = currentUser()",
 			];
 			const jql = `${clauses.join(" AND ")} ORDER BY created ASC`;
 			const raw = await client.searchIssues({ jql, maxResults: 100 });


### PR DESCRIPTION
## Summary
- Adds `tracker.trigger_label` (required, both tracker variants); humans own the label, the orchestrator never mutates it.
- GitHub tracker derives state labels from the trigger label, uses `searchIssues` (with `-label:` negation) for pending and `listIssues` for running/awaiting-review, and only swaps state labels on transitions (pending has no state label).
- Jira tracker requires `triggerLabel`, adds `labels = "<trigger>"` and `reporter = currentUser()` to JQL — bringing it to parity with GitHub on creator/reporter filtering.
- Adds `searchIssues(query)` on `server/github-client.ts`.

Implements slice 4 of `docs/repo-scoping-plan.md`.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (330 tests passing)
- [x] New unit tests cover: pending uses search API with negated state labels, running/awaiting-review use list API with `trigger,state` filter, transitions never mutate the trigger label, JQL contains `reporter = currentUser()` and a single-label equality clause, custom trigger labels propagate to both query shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)