### PR TITLE
feat: repo-scoping slice 5 — github org-level issue scanning

### DIFF
--- a/docs/repo-scoping-plan.md
+++ b/docs/repo-scoping-plan.md
@@ -221,7 +221,9 @@ After this slice, an issue is eligible only when (a) it carries the configured t
 
 ## Slice 5 — GitHub Tracker: Org-Level Issue Scanning
 
-**Status:** Not started
+**Status:** Ready for review
+
+**Verification:** `pnpm lint`, `pnpm typecheck`, `pnpm test` (334 tests).
 
 **Purpose:** Make group-prefix scopes meaningful for the GitHub tracker. Today the GitHub adapter calls `listIssues` once per configured repo; this is incompatible with a scope like `acme` that should match any repo in the org. Switch to an org-level or search-based fetch that works across the full scope.
 

--- a/server/__tests__/github-client.integration.test.ts
+++ b/server/__tests__/github-client.integration.test.ts
@@ -99,14 +99,18 @@ describe("GitHub client retry", () => {
 		);
 	});
 
-	it("searchIssues GETs /search/issues with the q param and returns items[]", async () => {
+	it("searchIssues GETs /search/issues with the q param and per_page=100 and returns items[]", async () => {
 		server.use(
 			http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
 				const url = new URL(request.url);
-				if (url.searchParams.get("q") !== "repo:owner/repo label:agent") {
+				if (
+					url.searchParams.get("q") !== "repo:owner/repo label:agent" ||
+					url.searchParams.get("per_page") !== "100"
+				) {
 					return new HttpResponse(null, { status: 400 });
 				}
 				return HttpResponse.json({
+					total_count: 1,
 					items: [
 						{
 							number: 7,
@@ -115,6 +119,7 @@ describe("GitHub client retry", () => {
 							labels: [{ name: "agent" }],
 							html_url: "https://github.com/owner/repo/issues/7",
 							created_at: "2025-02-01T00:00:00Z",
+							repository_url: "https://api.github.com/repos/owner/repo",
 						},
 					],
 				});
@@ -134,8 +139,36 @@ describe("GitHub client retry", () => {
 				labels: [{ name: "agent" }],
 				html_url: "https://github.com/owner/repo/issues/7",
 				created_at: "2025-02-01T00:00:00Z",
+				repository_url: "https://api.github.com/repos/owner/repo",
 			},
 		]);
+	});
+
+	it("searchIssues throws when total_count exceeds the page size (truncation)", async () => {
+		server.use(
+			http.get(`${GITHUB_API}/search/issues`, () =>
+				HttpResponse.json({
+					total_count: 250,
+					items: Array.from({ length: 100 }, (_, n) => ({
+						number: n + 1,
+						title: `Issue ${n + 1}`,
+						body: null,
+						labels: [{ name: "agent" }],
+						html_url: `https://github.com/owner/repo/issues/${n + 1}`,
+						created_at: "2025-02-01T00:00:00Z",
+						repository_url: "https://api.github.com/repos/owner/repo",
+					})),
+				}),
+			),
+		);
+
+		const client = createGitHubClient(githubToken("test-token"), {
+			baseDelayMs: 1,
+		});
+
+		await expect(client.searchIssues("org:acme label:agent")).rejects.toThrow(
+			/250 results.*cap.*100/i,
+		);
 	});
 
 	it("retries on network errors", async () => {

--- a/server/github-client.ts
+++ b/server/github-client.ts
@@ -25,6 +25,7 @@ const githubIssueSchema = z.object({
 	labels: z.array(z.object({ name: z.string() })),
 	html_url: z.string(),
 	created_at: z.string(),
+	repository_url: z.string().optional(),
 });
 
 export type GitHubIssue = z.infer<typeof githubIssueSchema>;
@@ -50,15 +51,6 @@ export type GitHubClient = {
 		},
 	): Promise<{ number: number; html_url: string }>;
 	getIssue(repo: RepoSlug, issueNumber: IssueNumber): Promise<GitHubIssue>;
-	listIssues(
-		repo: RepoSlug,
-		params: {
-			labels: string;
-			state: string;
-			creator: string;
-			per_page: string;
-		},
-	): Promise<GitHubIssue[]>;
 	searchIssues(query: string): Promise<GitHubIssue[]>;
 	removeIssueLabel(
 		repo: RepoSlug,
@@ -121,18 +113,23 @@ export function createGitHubClient(
 			});
 		},
 
-		listIssues(repo, params) {
-			const query = new URLSearchParams(params);
-			return request(`/repos/${repo}/issues?${query}`, {
-				schema: z.array(githubIssueSchema),
-			});
-		},
-
 		async searchIssues(query) {
-			const params = new URLSearchParams({ q: query });
-			const result = await request(`/search/issues?${params}`, {
-				schema: z.object({ items: z.array(githubIssueSchema) }),
+			const perPage = 100;
+			const params = new URLSearchParams({
+				q: query,
+				per_page: String(perPage),
 			});
+			const result = await request(`/search/issues?${params}`, {
+				schema: z.object({
+					total_count: z.number(),
+					items: z.array(githubIssueSchema),
+				}),
+			});
+			if (result.total_count > perPage) {
+				throw new Error(
+					`GitHub search returned ${result.total_count} results; per-page cap is ${perPage}. Query: ${query}`,
+				);
+			}
 			return result.items;
 		},
 

--- a/server/orchestrator/__tests__/orchestrator.dispatch-multi-repo.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.dispatch-multi-repo.integration.test.ts
@@ -40,8 +40,8 @@ describe("Orchestrator multi-repo scheduling", () => {
 		expect(issuesFetchCount).toBe(1);
 	});
 
-	it("fetch failure for one repo does not block other repos", async () => {
-		const REPO2 = repoSlug("test-owner/second-repo");
+	it("fetch failure for one org does not block other orgs", async () => {
+		const REPO2 = repoSlug("other-org/second-repo");
 
 		server.use(
 			http.get(`${GITHUB_API}/user`, () =>
@@ -49,19 +49,17 @@ describe("Orchestrator multi-repo scheduling", () => {
 			),
 			http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
 				const q = new URL(request.url).searchParams.get("q") ?? "";
-				if (q.includes(`repo:${REPO} `)) {
+				if (q.startsWith(`org:test-owner `)) {
 					return new HttpResponse(null, { status: 500 });
 				}
-				if (q.includes(`repo:${REPO2} `)) {
+				if (q.startsWith(`org:other-org `)) {
 					return HttpResponse.json({
-						items: [createGitHubIssue(10, ["agent"])],
+						total_count: 1,
+						items: [createGitHubIssue(10, ["agent"], undefined, REPO2)],
 					});
 				}
-				return HttpResponse.json({ items: [] });
+				return HttpResponse.json({ total_count: 0, items: [] });
 			}),
-			http.get(`${GITHUB_API}/repos/:owner/:repo/issues`, () =>
-				HttpResponse.json([]),
-			),
 			http.delete(
 				`${GITHUB_API}/repos/${REPO2}/issues/:number/labels/:label`,
 				() => new HttpResponse(null, { status: 204 }),
@@ -79,7 +77,7 @@ describe("Orchestrator multi-repo scheduling", () => {
 
 		await using ctx = await createTestOrchestrator({
 			maxConcurrency: 5,
-			trackerRepos: [REPO, REPO2],
+			trackerScopes: [REPO, REPO2],
 		});
 		const { orchestrator, db, runner, workspace } = ctx;
 		await workspace.preCreateWorkspace(`${REPO2}#10`);
@@ -97,7 +95,7 @@ describe("Orchestrator multi-repo scheduling", () => {
 	});
 
 	it("dispatches issues across multiple repos in oldest-first order", async () => {
-		const REPO2 = repoSlug("test-owner/second-repo");
+		const REPO2 = repoSlug("other-org/second-repo");
 
 		server.use(
 			http.get(`${GITHUB_API}/user`, () =>
@@ -105,21 +103,22 @@ describe("Orchestrator multi-repo scheduling", () => {
 			),
 			http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
 				const q = new URL(request.url).searchParams.get("q") ?? "";
-				if (q.includes(`repo:${REPO} `)) {
+				if (q.startsWith(`org:test-owner `)) {
 					return HttpResponse.json({
+						total_count: 1,
 						items: [createGitHubIssue(1, ["agent"], "2025-01-01T00:00:00Z")],
 					});
 				}
-				if (q.includes(`repo:${REPO2} `)) {
+				if (q.startsWith(`org:other-org `)) {
 					return HttpResponse.json({
-						items: [createGitHubIssue(2, ["agent"], "2025-01-02T00:00:00Z")],
+						total_count: 1,
+						items: [
+							createGitHubIssue(2, ["agent"], "2025-01-02T00:00:00Z", REPO2),
+						],
 					});
 				}
-				return HttpResponse.json({ items: [] });
+				return HttpResponse.json({ total_count: 0, items: [] });
 			}),
-			http.get(`${GITHUB_API}/repos/:owner/:repo/issues`, () =>
-				HttpResponse.json([]),
-			),
 			http.delete(
 				`${GITHUB_API}/repos/:owner/:repo/issues/:number/labels/:label`,
 				() => new HttpResponse(null, { status: 204 }),
@@ -138,7 +137,7 @@ describe("Orchestrator multi-repo scheduling", () => {
 		await using ctx = await createTestOrchestrator({
 			maxConcurrency: 5,
 			configOverrides: { max_concurrent: 5 },
-			trackerRepos: [REPO, REPO2],
+			trackerScopes: [REPO, REPO2],
 		});
 		const { orchestrator, db, runner, workspace } = ctx;
 		await workspace.preCreateWorkspace(`${REPO}#1`);

--- a/server/orchestrator/__tests__/orchestrator.reconcile.integration.test.ts
+++ b/server/orchestrator/__tests__/orchestrator.reconcile.integration.test.ts
@@ -145,14 +145,15 @@ describe("Orchestrator reconciliation", () => {
 			http.get(`${GITHUB_API}/user`, () =>
 				HttpResponse.json({ login: "test-user" }),
 			),
-			http.get(`${GITHUB_API}/search/issues`, () => {
-				pendingFetches++;
-				return HttpResponse.json({ items: [] });
-			}),
-			http.get(`${GITHUB_API}/repos/${REPO}/issues`, ({ request }) => {
-				const labels = new URL(request.url).searchParams.get("labels") ?? "";
-				if (labels.includes("agent:running")) runningFetches++;
-				return HttpResponse.json([]);
+			http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
+				const q = new URL(request.url).searchParams.get("q") ?? "";
+				const positive = q.split(/\s+/).filter((t) => t.startsWith("label:"));
+				if (positive.includes("label:agent:running")) {
+					runningFetches++;
+				} else {
+					pendingFetches++;
+				}
+				return HttpResponse.json({ total_count: 0, items: [] });
 			}),
 		);
 
@@ -175,18 +176,22 @@ describe("Orchestrator reconciliation", () => {
 			http.get(`${GITHUB_API}/user`, () =>
 				HttpResponse.json({ login: "test-user" }),
 			),
-			http.get(`${GITHUB_API}/search/issues`, () =>
-				HttpResponse.json({ items: pendingIssues }),
-			),
-			http.get(`${GITHUB_API}/repos/${REPO}/issues`, ({ request }) => {
-				const labels = new URL(request.url).searchParams.get("labels") ?? "";
-				if (labels.includes("agent:running")) {
+			http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
+				const q = new URL(request.url).searchParams.get("q") ?? "";
+				const positive = q.split(/\s+/).filter((t) => t.startsWith("label:"));
+				if (positive.includes("label:agent:running")) {
 					if (failRunningFetch) {
 						return new HttpResponse(null, { status: 500 });
 					}
-					return HttpResponse.json([createGitHubIssue(1, ["agent:running"])]);
+					return HttpResponse.json({
+						total_count: 1,
+						items: [createGitHubIssue(1, ["agent", "agent:running"])],
+					});
 				}
-				return HttpResponse.json([]);
+				return HttpResponse.json({
+					total_count: pendingIssues.length,
+					items: pendingIssues,
+				});
 			}),
 			http.delete(
 				`${GITHUB_API}/repos/${REPO}/issues/:number/labels/:label`,

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -3,6 +3,7 @@ import type { Config } from "../config.ts";
 import { logger } from "../logger.ts";
 import type { RunRepository } from "../run-repository.ts";
 import type { Runner } from "../runner/runner.ts";
+import { resolveRepo } from "../scope-resolver.ts";
 import type { Issue, TrackerAdapter } from "../trackers/types.ts";
 import type { IssueKey, RepoSlug, RunId } from "../types/brands.ts";
 import { unwrap } from "../types/result.ts";
@@ -37,7 +38,7 @@ type RunningEntry = { runIds: RunId[]; repo: RepoSlug };
 type StillRunning = {
 	issues: readonly Issue[];
 	keys: ReadonlySet<IssueKey>;
-	reposReached: ReadonlySet<RepoSlug>;
+	scopesReached: ReadonlySet<RepoSlug>;
 };
 type TickState = {
 	runningByIssue: Map<IssueKey, RunningEntry>;
@@ -117,7 +118,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 			stillRunning = {
 				issues,
 				keys: new Set(issues.map((i) => i.key)),
-				reposReached: runningResult.value.reposReached,
+				scopesReached: runningResult.value.scopesReached,
 			};
 		} else {
 			logger.warn(
@@ -127,7 +128,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 			stillRunning = {
 				issues: [],
 				keys: new Set(),
-				reposReached: new Set(),
+				scopesReached: new Set(),
 			};
 		}
 
@@ -140,10 +141,11 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 	}
 
 	async function reconcileStaleRuns(state: TickState) {
-		const { issues, keys, reposReached } = state.stillRunning;
+		const { issues, keys, scopesReached } = state.stillRunning;
+		const reachableScopes = [...scopesReached];
 
 		for (const [key, { runIds, repo }] of state.runningByIssue) {
-			if (!reposReached.has(repo)) continue;
+			if (!resolveRepo(repo, reachableScopes)) continue;
 			if (keys.has(key)) continue;
 			logger.info({ key }, "orchestrator.reconcile_terminal");
 			for (const id of runIds) {

--- a/server/server.ts
+++ b/server/server.ts
@@ -33,7 +33,7 @@ const github = createGitHubClient(env.GITHUB_TOKEN ?? githubToken(""));
 let tracker: TrackerAdapter;
 if (config.tracker.kind === "github") {
 	tracker = githubTrackerAdapter(github, {
-		repos: config.code_host.scopes,
+		scopes: config.code_host.scopes,
 		triggerLabel: config.tracker.trigger_label,
 	});
 } else {

--- a/server/testing/support/fixtures.ts
+++ b/server/testing/support/fixtures.ts
@@ -41,14 +41,16 @@ export function createGitHubIssue(
 	number: number,
 	labels: string[],
 	createdAt = "2025-01-01T00:00:00Z",
+	repo = REPO,
 ) {
 	return {
 		number,
 		title: `Issue ${number}`,
 		body: `Description for issue ${number}`,
 		labels: labels.map((name) => ({ name })),
-		html_url: `https://github.com/${REPO}/issues/${number}`,
+		html_url: `https://github.com/${repo}/issues/${number}`,
 		created_at: createdAt,
+		repository_url: `${GITHUB_API}/repos/${repo}`,
 	};
 }
 

--- a/server/testing/support/msw.ts
+++ b/server/testing/support/msw.ts
@@ -33,23 +33,23 @@ export function githubHandlers({
 			if (!issue) return new HttpResponse(null, { status: 404 });
 			return HttpResponse.json(issue);
 		}),
-		http.get(`${GITHUB_API}/repos/${REPO}/issues`, ({ request }) => {
-			const url = new URL(request.url);
-			const labels = (url.searchParams.get("labels") ?? "")
-				.split(",")
-				.filter(Boolean);
-			const stateLabel = labels.find((l) => l !== "agent");
-			if (stateLabel) {
-				return HttpResponse.json(resolve(stateLabel));
-			}
-			return HttpResponse.json(
-				labels.includes("agent") ? resolve("agent") : [],
-			);
-		}),
 		http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
 			const q = new URL(request.url).searchParams.get("q") ?? "";
-			if (!q.includes("label:agent")) return HttpResponse.json({ items: [] });
-			return HttpResponse.json({ items: resolve("agent") });
+			const positive = new Set(
+				q.split(/\s+/).filter((t) => t.startsWith("label:")),
+			);
+			if (!positive.has("label:agent")) {
+				return HttpResponse.json({ total_count: 0, items: [] });
+			}
+			let items: GitHubIssue[];
+			if (positive.has("label:agent:running")) {
+				items = resolve("agent:running");
+			} else if (positive.has("label:agent:awaiting-review")) {
+				items = resolve("agent:awaiting-review");
+			} else {
+				items = resolve("agent");
+			}
+			return HttpResponse.json({ total_count: items.length, items });
 		}),
 		http.delete<{ label: string }>(
 			`${GITHUB_API}/repos/${REPO}/issues/:number/labels/:label`,

--- a/server/testing/support/test-lifecycle.ts
+++ b/server/testing/support/test-lifecycle.ts
@@ -86,7 +86,7 @@ export function createInMemoryTracker(initial?: Issue): InMemoryTracker {
 		async fetchActiveIssues() {
 			return {
 				issues: issue ? [issue] : [],
-				reposReached: new Set([TEST_REPO]),
+				scopesReached: new Set([TEST_REPO]),
 			};
 		},
 		async transitionState(repo, number, from, to) {

--- a/server/testing/support/test-orchestrator.ts
+++ b/server/testing/support/test-orchestrator.ts
@@ -25,7 +25,7 @@ type CreateTestOrchestratorOptions = {
 	agent?: AgentInvoker;
 	configOverrides?: Parameters<typeof createTestConfig>[0];
 	workflow?: RepoWorkflow;
-	trackerRepos?: readonly RepoSlug[];
+	trackerScopes?: readonly RepoSlug[];
 	maxConcurrency?: number;
 	codeHost?: (defaults: CodeHostAdapter) => CodeHostAdapter;
 	tracker?: (defaults: TrackerAdapter) => TrackerAdapter;
@@ -46,9 +46,9 @@ export async function createTestOrchestrator(
 	});
 
 	const defaultCodeHost = githubCodeHostAdapter(github);
-	const trackerRepos = options.trackerRepos ?? [REPO];
+	const trackerScopes = options.trackerScopes ?? [REPO];
 	const defaultTracker = githubTrackerAdapter(github, {
-		repos: trackerRepos,
+		scopes: trackerScopes,
 		triggerLabel: "agent",
 	});
 

--- a/server/trackers/__tests__/decorator.test.ts
+++ b/server/trackers/__tests__/decorator.test.ts
@@ -16,7 +16,7 @@ function createFakeTracker(
 		fetchIssue: async () => {
 			throw new Error("not implemented");
 		},
-		fetchActiveIssues: async () => ({ issues: [], reposReached: new Set() }),
+		fetchActiveIssues: async () => ({ issues: [], scopesReached: new Set() }),
 		transitionState: async () => {},
 		parseIssueKey: () => ok({ number: issueNumber(1) }),
 		...overrides,

--- a/server/trackers/__tests__/github.integration.test.ts
+++ b/server/trackers/__tests__/github.integration.test.ts
@@ -279,6 +279,68 @@ describe("githubTrackerAdapter", () => {
 			]);
 		});
 
+		it("drops issues whose repository_url is missing or unparseable", async () => {
+			server.use(
+				http.get(`${GITHUB_API}/user`, () =>
+					HttpResponse.json({ login: "test-user" }),
+				),
+				http.get(`${GITHUB_API}/search/issues`, () =>
+					HttpResponse.json({
+						total_count: 3,
+						items: [
+							{
+								...createGitHubIssue(40, ["agent"]),
+								repository_url: undefined,
+							},
+							{
+								...createGitHubIssue(41, ["agent"]),
+								repository_url: "https://api.github.com/some-other-shape",
+							},
+							createGitHubIssue(42, ["agent"]),
+						],
+					}),
+				),
+			);
+
+			const github = createGitHubClient(githubToken("test-token"));
+			const tracker = githubTrackerAdapter(github, {
+				scopes: [REPO],
+				triggerLabel: TRIGGER,
+			});
+
+			const { issues } = await tracker.fetchActiveIssues("pending");
+
+			expect(issues.map((i) => i.key)).toEqual([`${REPO}#42`]);
+		});
+
+		it("dedupes issues that appear in more than one activeStates batch", async () => {
+			const captured: string[] = [];
+			server.use(
+				http.get(`${GITHUB_API}/user`, () =>
+					HttpResponse.json({ login: "test-user" }),
+				),
+				http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
+					captured.push(new URL(request.url).searchParams.get("q") ?? "");
+					return HttpResponse.json({
+						total_count: 1,
+						items: [createGitHubIssue(50, ["agent"])],
+					});
+				}),
+			);
+
+			const github = createGitHubClient(githubToken("test-token"));
+			const tracker = githubTrackerAdapter(github, {
+				scopes: [REPO],
+				triggerLabel: TRIGGER,
+				activeStates: ["open", "closed"],
+			});
+
+			const { issues } = await tracker.fetchActiveIssues("pending");
+
+			expect(captured).toHaveLength(2);
+			expect(issues.map((i) => i.key)).toEqual([`${REPO}#50`]);
+		});
+
 		it("maps null body to empty string", async () => {
 			server.use(
 				http.get(`${GITHUB_API}/user`, () =>

--- a/server/trackers/__tests__/github.integration.test.ts
+++ b/server/trackers/__tests__/github.integration.test.ts
@@ -14,7 +14,7 @@ const TRIGGER = "agent";
 
 describe("githubTrackerAdapter", () => {
 	describe("fetchActiveIssues", () => {
-		it("pending uses the search API with the trigger label and negated state labels", async () => {
+		it("pending issues one search per distinct org and stamps repo from repository_url", async () => {
 			const captured: string[] = [];
 			server.use(
 				http.get(`${GITHUB_API}/user`, () =>
@@ -24,21 +24,27 @@ describe("githubTrackerAdapter", () => {
 					const url = new URL(request.url);
 					captured.push(url.searchParams.get("q") ?? "");
 					return HttpResponse.json({
-						items: [createGitHubIssue(10, ["agent"])],
+						total_count: 1,
+						items: [
+							{
+								...createGitHubIssue(10, ["agent"]),
+								repository_url: `${GITHUB_API}/repos/${REPO}`,
+							},
+						],
 					});
 				}),
 			);
 
 			const github = createGitHubClient(githubToken("test-token"));
 			const tracker = githubTrackerAdapter(github, {
-				repos: [REPO],
+				scopes: [REPO],
 				triggerLabel: TRIGGER,
 			});
 
 			const { issues } = await tracker.fetchActiveIssues("pending");
 
 			expect(captured).toEqual([
-				`repo:${REPO} type:issue author:test-user state:open label:agent -label:agent:running -label:agent:awaiting-review`,
+				`org:test-owner type:issue author:test-user state:open label:agent -label:agent:running -label:agent:awaiting-review`,
 			]);
 			expect(issues).toEqual([
 				{
@@ -54,101 +60,95 @@ describe("githubTrackerAdapter", () => {
 			]);
 		});
 
-		it("running uses listIssues filtered by trigger AND state label", async () => {
+		it("running issues a scope-wide search with the running state label", async () => {
 			const captured: string[] = [];
-			server.use(
-				http.get(`${GITHUB_API}/user`, () =>
-					HttpResponse.json({ login: "test-user" }),
-				),
-				http.get(`${GITHUB_API}/repos/${REPO}/issues`, ({ request }) => {
-					const url = new URL(request.url);
-					captured.push(url.searchParams.get("labels") ?? "");
-					return HttpResponse.json([
-						createGitHubIssue(11, ["agent", "agent:running"]),
-					]);
-				}),
-			);
-
-			const github = createGitHubClient(githubToken("test-token"));
-			const tracker = githubTrackerAdapter(github, {
-				repos: [REPO],
-				triggerLabel: TRIGGER,
-			});
-
-			const { issues } = await tracker.fetchActiveIssues("running");
-
-			expect(captured).toEqual(["agent,agent:running"]);
-			expect(issues.map((i) => i.key)).toEqual([`${REPO}#11`]);
-		});
-
-		it("awaiting_review uses listIssues filtered by trigger AND awaiting-review state label", async () => {
-			const captured: string[] = [];
-			server.use(
-				http.get(`${GITHUB_API}/user`, () =>
-					HttpResponse.json({ login: "test-user" }),
-				),
-				http.get(`${GITHUB_API}/repos/${REPO}/issues`, ({ request }) => {
-					const url = new URL(request.url);
-					captured.push(url.searchParams.get("labels") ?? "");
-					return HttpResponse.json([
-						createGitHubIssue(12, ["agent", "agent:awaiting-review"]),
-					]);
-				}),
-			);
-
-			const github = createGitHubClient(githubToken("test-token"));
-			const tracker = githubTrackerAdapter(github, {
-				repos: [REPO],
-				triggerLabel: TRIGGER,
-			});
-
-			const { issues } = await tracker.fetchActiveIssues("awaiting_review");
-
-			expect(captured).toEqual(["agent,agent:awaiting-review"]);
-			expect(issues.map((i) => i.key)).toEqual([`${REPO}#12`]);
-		});
-
-		it("derives state labels from a custom trigger label", async () => {
-			const captured: { search: string[]; list: string[] } = {
-				search: [],
-				list: [],
-			};
 			server.use(
 				http.get(`${GITHUB_API}/user`, () =>
 					HttpResponse.json({ login: "test-user" }),
 				),
 				http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
-					captured.search.push(
-						new URL(request.url).searchParams.get("q") ?? "",
-					);
-					return HttpResponse.json({ items: [] });
-				}),
-				http.get(`${GITHUB_API}/repos/${REPO}/issues`, ({ request }) => {
-					captured.list.push(
-						new URL(request.url).searchParams.get("labels") ?? "",
-					);
-					return HttpResponse.json([]);
+					captured.push(new URL(request.url).searchParams.get("q") ?? "");
+					return HttpResponse.json({
+						total_count: 1,
+						items: [createGitHubIssue(11, ["agent", "agent:running"])],
+					});
 				}),
 			);
 
 			const github = createGitHubClient(githubToken("test-token"));
 			const tracker = githubTrackerAdapter(github, {
-				repos: [REPO],
+				scopes: [REPO],
+				triggerLabel: TRIGGER,
+			});
+
+			const { issues } = await tracker.fetchActiveIssues("running");
+
+			expect(captured).toEqual([
+				`org:test-owner type:issue author:test-user state:open label:agent label:agent:running`,
+			]);
+			expect(issues.map((i) => i.key)).toEqual([`${REPO}#11`]);
+		});
+
+		it("awaiting_review issues a scope-wide search with the awaiting-review state label", async () => {
+			const captured: string[] = [];
+			server.use(
+				http.get(`${GITHUB_API}/user`, () =>
+					HttpResponse.json({ login: "test-user" }),
+				),
+				http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
+					captured.push(new URL(request.url).searchParams.get("q") ?? "");
+					return HttpResponse.json({
+						total_count: 1,
+						items: [createGitHubIssue(12, ["agent", "agent:awaiting-review"])],
+					});
+				}),
+			);
+
+			const github = createGitHubClient(githubToken("test-token"));
+			const tracker = githubTrackerAdapter(github, {
+				scopes: [REPO],
+				triggerLabel: TRIGGER,
+			});
+
+			const { issues } = await tracker.fetchActiveIssues("awaiting_review");
+
+			expect(captured).toEqual([
+				`org:test-owner type:issue author:test-user state:open label:agent label:agent:awaiting-review`,
+			]);
+			expect(issues.map((i) => i.key)).toEqual([`${REPO}#12`]);
+		});
+
+		it("derives state labels from a custom trigger label across pending and running queries", async () => {
+			const captured: string[] = [];
+			server.use(
+				http.get(`${GITHUB_API}/user`, () =>
+					HttpResponse.json({ login: "test-user" }),
+				),
+				http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
+					captured.push(new URL(request.url).searchParams.get("q") ?? "");
+					return HttpResponse.json({ total_count: 0, items: [] });
+				}),
+			);
+
+			const github = createGitHubClient(githubToken("test-token"));
+			const tracker = githubTrackerAdapter(github, {
+				scopes: [REPO],
 				triggerLabel: "local-agents",
 			});
 
 			await tracker.fetchActiveIssues("pending");
 			await tracker.fetchActiveIssues("running");
 
-			expect(captured.search).toEqual([
-				`repo:${REPO} type:issue author:test-user state:open label:local-agents -label:local-agents:running -label:local-agents:awaiting-review`,
+			expect(captured).toEqual([
+				`org:test-owner type:issue author:test-user state:open label:local-agents -label:local-agents:running -label:local-agents:awaiting-review`,
+				`org:test-owner type:issue author:test-user state:open label:local-agents label:local-agents:running`,
 			]);
-			expect(captured.list).toEqual(["local-agents,local-agents:running"]);
 		});
 
-		it("fetches across each configured repo and stamps each issue with its source repo", async () => {
+		it("issues one search per distinct org and dedupes across orgs", async () => {
 			const repoA = repoSlug("acme/widgets");
-			const repoB = repoSlug("acme/services");
+			const repoB = repoSlug("other-org/services");
+			const captured: string[] = [];
 
 			server.use(
 				http.get(`${GITHUB_API}/user`, () =>
@@ -156,30 +156,126 @@ describe("githubTrackerAdapter", () => {
 				),
 				http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
 					const q = new URL(request.url).searchParams.get("q") ?? "";
-					if (q.includes(`repo:${repoA}`)) {
+					captured.push(q);
+					if (q.startsWith("org:acme ")) {
 						return HttpResponse.json({
-							items: [createGitHubIssue(1, ["agent"])],
+							total_count: 1,
+							items: [createGitHubIssue(1, ["agent"], undefined, repoA)],
 						});
 					}
-					if (q.includes(`repo:${repoB}`)) {
+					if (q.startsWith("org:other-org ")) {
 						return HttpResponse.json({
-							items: [createGitHubIssue(2, ["agent"])],
+							total_count: 1,
+							items: [createGitHubIssue(2, ["agent"], undefined, repoB)],
 						});
 					}
-					return HttpResponse.json({ items: [] });
+					return HttpResponse.json({ total_count: 0, items: [] });
 				}),
 			);
 
 			const github = createGitHubClient(githubToken("test-token"));
 			const tracker = githubTrackerAdapter(github, {
-				repos: [repoA, repoB],
+				scopes: [repoA, repoB],
 				triggerLabel: TRIGGER,
 			});
 
 			const { issues } = await tracker.fetchActiveIssues("pending");
+
+			expect(captured.map((q) => q.split(" ")[0])).toEqual([
+				"org:acme",
+				"org:other-org",
+			]);
 			expect(issues.map((i) => ({ key: i.key, repo: i.repo }))).toEqual([
 				{ key: `${repoA}#1`, repo: repoA },
 				{ key: `${repoB}#2`, repo: repoB },
+			]);
+		});
+
+		it("scopesReached returns the configured scopes whose org searches succeeded", async () => {
+			const acmeRepo = repoSlug("acme/widgets");
+			const otherRepo = repoSlug("other-org/services");
+
+			server.use(
+				http.get(`${GITHUB_API}/user`, () =>
+					HttpResponse.json({ login: "test-user" }),
+				),
+				http.get(`${GITHUB_API}/search/issues`, ({ request }) => {
+					const q = new URL(request.url).searchParams.get("q") ?? "";
+					if (q.startsWith("org:other-org ")) {
+						return new HttpResponse(null, { status: 500 });
+					}
+					return HttpResponse.json({ total_count: 0, items: [] });
+				}),
+			);
+
+			const github = createGitHubClient(githubToken("test-token"), {
+				maxAttempts: 1,
+			});
+			const tracker = githubTrackerAdapter(github, {
+				scopes: [acmeRepo, otherRepo],
+				triggerLabel: TRIGGER,
+			});
+
+			const { scopesReached } = await tracker.fetchActiveIssues("pending");
+
+			expect([...scopesReached]).toEqual([acmeRepo]);
+		});
+
+		it("admits descendants of a group-prefix scope", async () => {
+			const widgetsApp = repoSlug("acme/widgets-app");
+			server.use(
+				http.get(`${GITHUB_API}/user`, () =>
+					HttpResponse.json({ login: "test-user" }),
+				),
+				http.get(`${GITHUB_API}/search/issues`, () =>
+					HttpResponse.json({
+						total_count: 1,
+						items: [createGitHubIssue(20, ["agent"], undefined, widgetsApp)],
+					}),
+				),
+			);
+
+			const github = createGitHubClient(githubToken("test-token"));
+			const tracker = githubTrackerAdapter(github, {
+				scopes: [repoSlug("acme")],
+				triggerLabel: TRIGGER,
+			});
+
+			const { issues } = await tracker.fetchActiveIssues("pending");
+
+			expect(issues.map((i) => ({ key: i.key, repo: i.repo }))).toEqual([
+				{ key: `${widgetsApp}#20`, repo: widgetsApp },
+			]);
+		});
+
+		it("drops issues whose repo does not resolve against any specific-repo scope", async () => {
+			const widgets = repoSlug("acme/widgets");
+			const sibling = repoSlug("acme/widgets-other");
+			server.use(
+				http.get(`${GITHUB_API}/user`, () =>
+					HttpResponse.json({ login: "test-user" }),
+				),
+				http.get(`${GITHUB_API}/search/issues`, () =>
+					HttpResponse.json({
+						total_count: 2,
+						items: [
+							createGitHubIssue(30, ["agent"], undefined, widgets),
+							createGitHubIssue(31, ["agent"], undefined, sibling),
+						],
+					}),
+				),
+			);
+
+			const github = createGitHubClient(githubToken("test-token"));
+			const tracker = githubTrackerAdapter(github, {
+				scopes: [widgets],
+				triggerLabel: TRIGGER,
+			});
+
+			const { issues } = await tracker.fetchActiveIssues("pending");
+
+			expect(issues.map((i) => ({ key: i.key, repo: i.repo }))).toEqual([
+				{ key: `${widgets}#30`, repo: widgets },
 			]);
 		});
 
@@ -190,6 +286,7 @@ describe("githubTrackerAdapter", () => {
 				),
 				http.get(`${GITHUB_API}/search/issues`, () =>
 					HttpResponse.json({
+						total_count: 1,
 						items: [
 							{
 								...createGitHubIssue(5, ["agent"]),
@@ -202,7 +299,7 @@ describe("githubTrackerAdapter", () => {
 
 			const github = createGitHubClient(githubToken("test-token"));
 			const tracker = githubTrackerAdapter(github, {
-				repos: [REPO],
+				scopes: [REPO],
 				triggerLabel: TRIGGER,
 			});
 
@@ -251,7 +348,7 @@ describe("githubTrackerAdapter", () => {
 
 			const github = createGitHubClient(githubToken("test-token"));
 			const tracker = githubTrackerAdapter(github, {
-				repos: [REPO],
+				scopes: [REPO],
 				triggerLabel: TRIGGER,
 			});
 
@@ -293,7 +390,7 @@ describe("githubTrackerAdapter", () => {
 
 			const github = createGitHubClient(githubToken("test-token"));
 			const tracker = githubTrackerAdapter(github, {
-				repos: [REPO],
+				scopes: [REPO],
 				triggerLabel: TRIGGER,
 			});
 
@@ -338,7 +435,7 @@ describe("githubTrackerAdapter", () => {
 
 			const github = createGitHubClient(githubToken("test-token"));
 			const tracker = githubTrackerAdapter(github, {
-				repos: [REPO],
+				scopes: [REPO],
 				triggerLabel: TRIGGER,
 			});
 
@@ -357,7 +454,7 @@ describe("githubTrackerAdapter", () => {
 		it("parses GitHub issue keys to an issue number", () => {
 			const github = createGitHubClient(githubToken("test-token"));
 			const tracker = githubTrackerAdapter(github, {
-				repos: [REPO],
+				scopes: [REPO],
 				triggerLabel: TRIGGER,
 			});
 
@@ -372,7 +469,7 @@ describe("githubTrackerAdapter", () => {
 		it("returns Err for malformed GitHub issue keys", () => {
 			const github = createGitHubClient(githubToken("test-token"));
 			const tracker = githubTrackerAdapter(github, {
-				repos: [REPO],
+				scopes: [REPO],
 				triggerLabel: TRIGGER,
 			});
 

--- a/server/trackers/github.ts
+++ b/server/trackers/github.ts
@@ -1,6 +1,12 @@
 import * as canonicalLog from "../canonical-log.ts";
 import type { GitHubClient, GitHubIssue } from "../github-client.ts";
-import { issueKey, issueNumber, type RepoSlug } from "../types/brands.ts";
+import { resolveRepo } from "../scope-resolver.ts";
+import {
+	issueKey,
+	issueNumber,
+	type RepoSlug,
+	repoSlug,
+} from "../types/brands.ts";
 import { err, ok } from "../types/result.ts";
 import { decorateTracker } from "./decorator.ts";
 import type { Issue, TrackerAdapter, TrackerState } from "./types.ts";
@@ -8,10 +14,27 @@ import type { Issue, TrackerAdapter, TrackerState } from "./types.ts";
 type IssueState = "open" | "closed" | "all";
 
 type GitHubTrackerOptions = {
-	repos: readonly RepoSlug[];
+	scopes: readonly RepoSlug[];
 	triggerLabel: string;
 	activeStates?: readonly IssueState[];
 };
+
+const REPOSITORY_URL_PATTERN = /\/repos\/([^/]+\/[^/]+)$/;
+
+function parseRepoFromUrl(url: string | undefined): RepoSlug | null {
+	if (!url) return null;
+	const match = REPOSITORY_URL_PATTERN.exec(url);
+	return match?.[1] ? repoSlug(match[1]) : null;
+}
+
+function orgOf(scope: RepoSlug): string {
+	const slash = scope.indexOf("/");
+	return slash === -1 ? scope : scope.slice(0, slash);
+}
+
+function distinctOrgs(scopes: readonly RepoSlug[]): string[] {
+	return [...new Set(scopes.map(orgOf))];
+}
 
 function mapGitHubIssue(repo: RepoSlug, i: GitHubIssue): Issue {
 	return {
@@ -30,11 +53,12 @@ export function githubTrackerAdapter(
 	client: GitHubClient,
 	options: GitHubTrackerOptions,
 ): TrackerAdapter {
-	const { repos, triggerLabel, activeStates = ["open"] as const } = options;
+	const { scopes, triggerLabel, activeStates = ["open"] as const } = options;
 	const stateLabels: Record<Exclude<TrackerState, "pending">, string> = {
 		running: `${triggerLabel}:running`,
 		awaiting_review: `${triggerLabel}:awaiting-review`,
 	};
+	const orgs = distinctOrgs(scopes);
 
 	let usernamePromise: Promise<string> | undefined;
 	function getUsername(): Promise<string> {
@@ -42,51 +66,67 @@ export function githubTrackerAdapter(
 		return usernamePromise;
 	}
 
-	async function fetchPending(repo: RepoSlug): Promise<Issue[]> {
+	type OrgSearchResult = {
+		org: string;
+		items: readonly GitHubIssue[] | null;
+	};
+
+	async function searchAcrossOrgs(suffix: string): Promise<OrgSearchResult[]> {
 		const username = await getUsername();
-		const batches = await Promise.all(
-			activeStates.map((s) =>
-				client.searchIssues(
-					`repo:${repo} type:issue author:${username} state:${s} label:${triggerLabel} -label:${stateLabels.running} -label:${stateLabels.awaiting_review}`,
-				),
-			),
+		return Promise.all(
+			orgs.map(async (org) => {
+				const batches = await Promise.all(
+					activeStates.map((s) =>
+						client
+							.searchIssues(
+								`org:${org} type:issue author:${username} state:${s} ${suffix}`,
+							)
+							.catch((err: unknown) => {
+								canonicalLog.append(
+									"warnings",
+									`fetch_active_issues_failed: org=${org} ${canonicalLog.errorMessage(err)}`,
+								);
+								return null;
+							}),
+					),
+				);
+				const failed = batches.some((b) => b === null);
+				const items = failed ? null : dedupe(batches.flatMap((b) => b ?? []));
+				return { org, items };
+			}),
 		);
-		return dedupe(batches.flat()).map((i) => mapGitHubIssue(repo, i));
 	}
 
-	async function fetchByStateLabel(
-		repo: RepoSlug,
-		stateLabel: string,
-	): Promise<Issue[]> {
-		const username = await getUsername();
-		const batches = await Promise.all(
-			activeStates.map((s) =>
-				client.listIssues(repo, {
-					labels: `${triggerLabel},${stateLabel}`,
-					state: s,
-					creator: username,
-					per_page: "100",
-				}),
-			),
-		);
-		return dedupe(batches.flat()).map((i) => mapGitHubIssue(repo, i));
+	function scopesForOrgs(reachedOrgs: ReadonlySet<string>): RepoSlug[] {
+		return scopes.filter((s) => reachedOrgs.has(orgOf(s)));
 	}
 
 	function dedupe(issues: GitHubIssue[]): GitHubIssue[] {
-		const seen = new Set<number>();
+		const seen = new Set<string>();
 		return issues.filter((i) => {
-			if (seen.has(i.number)) return false;
-			seen.add(i.number);
+			if (seen.has(i.html_url)) return false;
+			seen.add(i.html_url);
 			return true;
 		});
 	}
 
-	async function fetchForRepo(
-		repo: RepoSlug,
-		state: TrackerState,
-	): Promise<Issue[]> {
-		if (state === "pending") return fetchPending(repo);
-		return fetchByStateLabel(repo, stateLabels[state]);
+	function resolveAndMap(items: readonly GitHubIssue[]): Issue[] {
+		const issues: Issue[] = [];
+		for (const item of items) {
+			const repoFromUrl = parseRepoFromUrl(item.repository_url);
+			if (!repoFromUrl) continue;
+			const resolved = resolveRepo(repoFromUrl, scopes);
+			if (!resolved) continue;
+			issues.push(mapGitHubIssue(resolved, item));
+		}
+		return issues;
+	}
+
+	function suffixForState(state: TrackerState): string {
+		if (state === "pending") {
+			return `label:${triggerLabel} -label:${stateLabels.running} -label:${stateLabels.awaiting_review}`;
+		}
+		return `label:${triggerLabel} label:${stateLabels[state]}`;
 	}
 
 	return decorateTracker({
@@ -96,26 +136,15 @@ export function githubTrackerAdapter(
 		},
 
 		async fetchActiveIssues(state) {
-			const results = await Promise.allSettled(
-				repos.map(async (repo) => ({
-					repo,
-					issues: await fetchForRepo(repo, state),
-				})),
+			const results = await searchAcrossOrgs(suffixForState(state));
+			const reachedOrgs = new Set(
+				results.filter((r) => r.items !== null).map((r) => r.org),
 			);
-			const issues: Issue[] = [];
-			const reposReached = new Set<RepoSlug>();
-			for (const [i, result] of results.entries()) {
-				if (result.status === "fulfilled") {
-					reposReached.add(result.value.repo);
-					issues.push(...result.value.issues);
-				} else {
-					canonicalLog.append(
-						"warnings",
-						`fetch_active_issues_failed: ${repos[i]}`,
-					);
-				}
-			}
-			return { issues, reposReached };
+			const items = results.flatMap((r) => r.items ?? []);
+			return {
+				issues: resolveAndMap(items),
+				scopesReached: new Set(scopesForOrgs(reachedOrgs)),
+			};
 		},
 
 		async transitionState(repo, issueNum, from, to): Promise<void> {

--- a/server/trackers/jira.ts
+++ b/server/trackers/jira.ts
@@ -129,15 +129,11 @@ export function jiraTrackerAdapter(
 			const jql = `${clauses.join(" AND ")} ORDER BY created ASC`;
 			const raw = await client.searchIssues({ jql, maxResults: 100 });
 			const issues: Issue[] = [];
-			const reposReached = new Set<RepoSlug>(options.scopes);
 			for (const r of raw) {
 				const mapped = resolveScopedIssue(r);
-				if (mapped) {
-					issues.push(mapped);
-					reposReached.add(mapped.repo);
-				}
+				if (mapped) issues.push(mapped);
 			}
-			return { issues, reposReached };
+			return { issues, scopesReached: new Set<RepoSlug>(options.scopes) };
 		},
 
 		async transitionState(_repo, issueNum, _from, to): Promise<void> {

--- a/server/trackers/types.ts
+++ b/server/trackers/types.ts
@@ -22,7 +22,7 @@ export type ParseIssueKeyError = {
 
 export type ActiveIssuesPage = {
 	issues: Issue[];
-	reposReached: ReadonlySet<RepoSlug>;
+	scopesReached: ReadonlySet<RepoSlug>;
 };
 
 export type TrackerAdapter = {


### PR DESCRIPTION
## Summary

- Replaces per-repo `client.listIssues` iteration in the GitHub tracker with scope-wide `client.searchIssues` calls keyed by org. One search per distinct org per state, with results filtered client-side via `resolveRepo` against the configured scopes — so group-prefix scopes like `acme` admit any descendant repo, and specific-repo scopes still resolve trivially.
- `searchIssues` now sets `per_page=100` and throws if `total_count` exceeds the cap, surfacing search-result truncation explicitly rather than silently dropping issues. The unused `client.listIssues` is removed.
- `Issue.repo` is derived from each search result's `repository_url`; `reposReached` becomes `scopesReached`, and the orchestrator uses `resolveRepo` against it for stale-run reconciliation.

Closes the GitHub-side of the repo-scoping plan in `docs/repo-scoping-plan.md`.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (336 tests)
- [x] `pnpm test:coverage` — branch coverage 97.67% (above 97.5% threshold)
- [ ] Smoke test against a live GitHub org with a mix of group-prefix and specific-repo scopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)