### PR TITLE
refactor: hoist public types above private helpers in server/

### DIFF
--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -37,3 +37,7 @@ Goal: make invalid states unrepresentable; let the compiler verify assumptions.
 ### Decision rule
 
 For any invariant: who enforces it? If the answer is "the developer, by remembering," move it into the type system.
+
+### Module layout
+
+Order top-to-bottom: imports → public types (including the module's main interface) → main implementation → private helpers and helper types. A reader skimming a file should see its public shape before its internals. Don't bury the interface below helper functions.

--- a/server/env.ts
+++ b/server/env.ts
@@ -10,20 +10,6 @@ import {
 	jiraEmail,
 } from "./types/brands.ts";
 
-function parseEnv<T extends z.ZodTypeAny>(schema: T): z.infer<T> {
-	const result = schema.safeParse(process.env);
-
-	if (!result.success) {
-		const issues = result.error.issues
-			.map((i) => `  ${i.path.join(".")}: ${i.message}`)
-			.join("\n");
-		console.error(`Invalid environment variables:\n${issues}`);
-		process.exit(1);
-	}
-
-	return result.data;
-}
-
 const envSchema = z.object({
 	CONFIG_PATH: z.string().min(1),
 	PORT: z.coerce.number().default(3000),
@@ -40,6 +26,35 @@ type Env = Omit<RawEnv, "GITLAB_TOKEN" | "JIRA_EMAIL" | "JIRA_API_TOKEN"> & {
 	JIRA_EMAIL?: JiraEmail;
 	JIRA_API_TOKEN?: JiraApiToken;
 };
+
+export function loadEnv(config?: Pick<Config, "tracker" | "code_host">): Env {
+	const env = parseEnv(envSchema);
+
+	if (config?.code_host.kind === "gitlab") {
+		requireToken(env, "GITLAB_TOKEN");
+	}
+
+	if (config?.tracker.kind === "jira") {
+		requireToken(env, "JIRA_EMAIL");
+		requireToken(env, "JIRA_API_TOKEN");
+	}
+
+	return brandEnv(env);
+}
+
+function parseEnv<T extends z.ZodTypeAny>(schema: T): z.infer<T> {
+	const result = schema.safeParse(process.env);
+
+	if (!result.success) {
+		const issues = result.error.issues
+			.map((i) => `  ${i.path.join(".")}: ${i.message}`)
+			.join("\n");
+		console.error(`Invalid environment variables:\n${issues}`);
+		process.exit(1);
+	}
+
+	return result.data;
+}
 
 function requireToken(env: RawEnv, name: keyof RawEnv) {
 	if (typeof env[name] !== "string" || env[name].length === 0) {
@@ -60,19 +75,4 @@ function brandEnv(env: RawEnv): Env {
 			JIRA_API_TOKEN: jiraApiToken(JIRA_API_TOKEN),
 		}),
 	};
-}
-
-export function loadEnv(config?: Pick<Config, "tracker" | "code_host">): Env {
-	const env = parseEnv(envSchema);
-
-	if (config?.code_host.kind === "gitlab") {
-		requireToken(env, "GITLAB_TOKEN");
-	}
-
-	if (config?.tracker.kind === "jira") {
-		requireToken(env, "JIRA_EMAIL");
-		requireToken(env, "JIRA_API_TOKEN");
-	}
-
-	return brandEnv(env);
 }

--- a/server/gitlab-client.ts
+++ b/server/gitlab-client.ts
@@ -2,8 +2,6 @@ import { z } from "zod";
 import { createJsonRequester, type HttpClientOptions } from "./http-client.ts";
 import type { BranchName, GitLabToken, RepoSlug } from "./types/brands.ts";
 
-const DEFAULT_BASE_URL = "https://gitlab.com";
-
 const gitlabFileSchema = z.object({
 	content: z.string(),
 });
@@ -41,18 +39,6 @@ export type GitLabClient = {
 type GitLabClientOptions = HttpClientOptions & {
 	baseUrl?: string;
 };
-
-function trimTrailingSlash(value: string): string {
-	return value.replace(/\/+$/, "");
-}
-
-function encodeProjectPath(projectPath: RepoSlug): string {
-	return encodeURIComponent(projectPath);
-}
-
-function encodeFilePath(filePath: string): string {
-	return encodeURIComponent(filePath);
-}
 
 export function createGitLabClient(
 	token: GitLabToken,
@@ -96,4 +82,18 @@ export function createGitLabClient(
 			);
 		},
 	};
+}
+
+const DEFAULT_BASE_URL = "https://gitlab.com";
+
+function trimTrailingSlash(value: string): string {
+	return value.replace(/\/+$/, "");
+}
+
+function encodeProjectPath(projectPath: RepoSlug): string {
+	return encodeURIComponent(projectPath);
+}
+
+function encodeFilePath(filePath: string): string {
+	return encodeURIComponent(filePath);
 }

--- a/server/http-client.ts
+++ b/server/http-client.ts
@@ -1,9 +1,5 @@
 import type { z } from "zod";
 
-const DEFAULT_TIMEOUT_MS = 30_000;
-const DEFAULT_MAX_ATTEMPTS = 3;
-const DEFAULT_BASE_DELAY_MS = 1_000;
-
 export type HttpClientOptions = {
 	maxAttempts?: number;
 	baseDelayMs?: number;
@@ -26,26 +22,6 @@ type VoidRequestOptions = {
 	method?: string;
 	body?: Record<string, unknown>;
 };
-
-function isRetryableStatus(status: number): boolean {
-	return status === 429 || status >= 500;
-}
-
-function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function retryDelay(
-	response: Response,
-	attempt: number,
-	baseDelayMs: number,
-): number {
-	if (response.status === 429) {
-		const retryAfter = response.headers.get("Retry-After");
-		if (retryAfter) return Number.parseInt(retryAfter, 10) * 1000;
-	}
-	return baseDelayMs * 2 ** (attempt - 1);
-}
 
 export function createJsonRequester(options: JsonRequesterOptions) {
 	const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
@@ -121,4 +97,28 @@ export function createJsonRequester(options: JsonRequesterOptions) {
 	}
 
 	return request;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 1_000;
+
+function isRetryableStatus(status: number): boolean {
+	return status === 429 || status >= 500;
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function retryDelay(
+	response: Response,
+	attempt: number,
+	baseDelayMs: number,
+): number {
+	if (response.status === 429) {
+		const retryAfter = response.headers.get("Retry-After");
+		if (retryAfter) return Number.parseInt(retryAfter, 10) * 1000;
+	}
+	return baseDelayMs * 2 ** (attempt - 1);
 }

--- a/server/jira-client.ts
+++ b/server/jira-client.ts
@@ -2,15 +2,6 @@ import { z } from "zod";
 import { createJsonRequester, type HttpClientOptions } from "./http-client.ts";
 import type { JiraApiToken, JiraEmail } from "./types/brands.ts";
 
-const ISSUE_FIELDS = [
-	"summary",
-	"description",
-	"status",
-	"created",
-	"labels",
-] as const;
-const DEFAULT_SEARCH_MAX_RESULTS = 100;
-
 const jiraIssueSchema = z.object({
 	key: z.string(),
 	fields: z.object({
@@ -65,18 +56,6 @@ type JiraClientOptions = HttpClientOptions & {
 	email: JiraEmail;
 	apiToken: JiraApiToken;
 };
-
-function trimTrailingSlash(value: string): string {
-	return value.replace(/\/+$/, "");
-}
-
-function encodeIssueKey(key: string): string {
-	return encodeURIComponent(key);
-}
-
-function basicAuth(email: JiraEmail, apiToken: JiraApiToken): string {
-	return Buffer.from(`${email}:${apiToken}`, "utf8").toString("base64");
-}
 
 export function createJiraClient(options: JiraClientOptions): JiraClient {
 	const baseUrl = trimTrailingSlash(options.baseUrl);
@@ -146,4 +125,25 @@ export function createJiraClient(options: JiraClientOptions): JiraClient {
 			});
 		},
 	};
+}
+
+const ISSUE_FIELDS = [
+	"summary",
+	"description",
+	"status",
+	"created",
+	"labels",
+] as const;
+const DEFAULT_SEARCH_MAX_RESULTS = 100;
+
+function trimTrailingSlash(value: string): string {
+	return value.replace(/\/+$/, "");
+}
+
+function encodeIssueKey(key: string): string {
+	return encodeURIComponent(key);
+}
+
+function basicAuth(email: JiraEmail, apiToken: JiraApiToken): string {
+	return Buffer.from(`${email}:${apiToken}`, "utf8").toString("base64");
 }

--- a/server/run-repository.ts
+++ b/server/run-repository.ts
@@ -13,8 +13,6 @@ import {
 import type { IssueKey, RepoSlug, RunId } from "./types/brands.ts";
 import { assertNever } from "./types/exhaustive.ts";
 
-type RunRow = typeof runs.$inferSelect;
-
 type RunBase = {
 	id: RunId;
 	agentName: string;
@@ -40,50 +38,6 @@ export type FailedRun = RunBase & {
 export type Run = RunningRun | CompletedRun | FailedRun;
 
 export type RunEvent = typeof runEvents.$inferSelect;
-
-function rowToRun(row: RunRow): Run {
-	const base: RunBase = {
-		id: row.id,
-		agentName: row.agentName,
-		repo: row.repo,
-		issueKey: row.issueKey,
-		issueTitle: row.issueTitle,
-		startedAt: row.startedAt,
-	};
-
-	switch (row.status) {
-		case "running":
-			return { ...base, status: "running" };
-		case "completed":
-			if (row.completedAt == null || row.durationMs == null) {
-				throw new Error(
-					`Invariant: completed run ${row.id} missing completedAt or durationMs`,
-				);
-			}
-			return {
-				...base,
-				status: "completed",
-				completedAt: row.completedAt,
-				durationMs: row.durationMs,
-			};
-		case "failed":
-			if (row.completedAt == null || row.error == null) {
-				throw new Error(
-					`Invariant: failed run ${row.id} missing completedAt or error`,
-				);
-			}
-			return {
-				...base,
-				status: "failed",
-				completedAt: row.completedAt,
-				durationMs: row.durationMs,
-				error: row.error,
-			};
-		/* v8 ignore next 2 -- unreachable; RunStatus is exhaustively handled above */
-		default:
-			return assertNever(row.status);
-	}
-}
 
 export type RunRepository = {
 	insertRun(run: {
@@ -207,4 +161,50 @@ export function createRunRepository(db: Db): RunRepository {
 				.run();
 		},
 	};
+}
+
+type RunRow = typeof runs.$inferSelect;
+
+function rowToRun(row: RunRow): Run {
+	const base: RunBase = {
+		id: row.id,
+		agentName: row.agentName,
+		repo: row.repo,
+		issueKey: row.issueKey,
+		issueTitle: row.issueTitle,
+		startedAt: row.startedAt,
+	};
+
+	switch (row.status) {
+		case "running":
+			return { ...base, status: "running" };
+		case "completed":
+			if (row.completedAt == null || row.durationMs == null) {
+				throw new Error(
+					`Invariant: completed run ${row.id} missing completedAt or durationMs`,
+				);
+			}
+			return {
+				...base,
+				status: "completed",
+				completedAt: row.completedAt,
+				durationMs: row.durationMs,
+			};
+		case "failed":
+			if (row.completedAt == null || row.error == null) {
+				throw new Error(
+					`Invariant: failed run ${row.id} missing completedAt or error`,
+				);
+			}
+			return {
+				...base,
+				status: "failed",
+				completedAt: row.completedAt,
+				durationMs: row.durationMs,
+				error: row.error,
+			};
+		/* v8 ignore next 2 -- unreachable; RunStatus is exhaustively handled above */
+		default:
+			return assertNever(row.status);
+	}
 }

--- a/server/trackers/jira.ts
+++ b/server/trackers/jira.ts
@@ -16,47 +16,6 @@ type JiraTrackerOptions = {
 	triggerLabel: string;
 };
 
-const REPO_LABEL_PREFIX = "repo:";
-
-type DropReason =
-	| "no_repo_label"
-	| "multiple_repo_labels"
-	| "unresolved_repo_label";
-
-function jiraIssueKey(project: string, num: number): string {
-	return `${project}-${num}`;
-}
-
-function trimTrailingSlash(value: string): string {
-	return value.replace(/\/+$/, "");
-}
-
-function quoteJqlString(value: string): string {
-	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-}
-
-function extractText(value: unknown): string {
-	if (typeof value === "string") return value;
-	if (Array.isArray(value))
-		return value.map(extractText).filter(Boolean).join("\n");
-	if (value !== null && typeof value === "object") {
-		if ("text" in value && typeof value.text === "string") return value.text;
-		if ("content" in value && Array.isArray(value.content))
-			return extractText(value.content);
-	}
-	return "";
-}
-
-function parseJiraKey(project: string, key: string): number | null {
-	const match = /^([A-Z][A-Z0-9_]*)-(\d+)$/.exec(key);
-	const matchedProject = match?.[1];
-	const matchedNumber = match?.[2];
-	if (!matchedProject || !matchedNumber || matchedProject !== project) {
-		return null;
-	}
-	return Number.parseInt(matchedNumber, 10);
-}
-
 export function jiraTrackerAdapter(
 	client: JiraClient,
 	options: JiraTrackerOptions,
@@ -174,4 +133,45 @@ export function jiraTrackerAdapter(
 			});
 		},
 	});
+}
+
+const REPO_LABEL_PREFIX = "repo:";
+
+type DropReason =
+	| "no_repo_label"
+	| "multiple_repo_labels"
+	| "unresolved_repo_label";
+
+function jiraIssueKey(project: string, num: number): string {
+	return `${project}-${num}`;
+}
+
+function trimTrailingSlash(value: string): string {
+	return value.replace(/\/+$/, "");
+}
+
+function quoteJqlString(value: string): string {
+	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function extractText(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (Array.isArray(value))
+		return value.map(extractText).filter(Boolean).join("\n");
+	if (value !== null && typeof value === "object") {
+		if ("text" in value && typeof value.text === "string") return value.text;
+		if ("content" in value && Array.isArray(value.content))
+			return extractText(value.content);
+	}
+	return "";
+}
+
+function parseJiraKey(project: string, key: string): number | null {
+	const match = /^([A-Z][A-Z0-9_]*)-(\d+)$/.exec(key);
+	const matchedProject = match?.[1];
+	const matchedNumber = match?.[2];
+	if (!matchedProject || !matchedNumber || matchedProject !== project) {
+		return null;
+	}
+	return Number.parseInt(matchedNumber, 10);
 }

--- a/server/workflow/prompt-preprocessor.ts
+++ b/server/workflow/prompt-preprocessor.ts
@@ -1,11 +1,11 @@
 import { spawn } from "node:child_process";
 
 export const SHELL_BLOCK_MARKER = "\uE000";
-const SHELL_EXPANSION_TIMEOUT_MS = 30_000;
-const SHELL_EXPANSION_MAX_BUFFER = 1024 * 1024;
 
-const unmarkedShellBlockPattern = /!`([^`]*)`/g;
-const markedShellBlockPattern = /!\uE000`([^`]*)`/g;
+type ExpandShellBlocksOptions = {
+	cwd: string;
+	timeoutMs?: number;
+};
 
 export function stripShellBlockMarkers(value: string): string {
 	return value.replaceAll(SHELL_BLOCK_MARKER, "");
@@ -18,11 +18,6 @@ export function markTrustedShellBlocks(template: string): string {
 		(_match, command: string) => `!${SHELL_BLOCK_MARKER}\`${command}\``,
 	);
 }
-
-type ExpandShellBlocksOptions = {
-	cwd: string;
-	timeoutMs?: number;
-};
 
 export async function expandMarkedShellBlocks(
 	prompt: string,
@@ -53,6 +48,12 @@ export async function expandMarkedShellBlocks(
 		return output;
 	});
 }
+
+const SHELL_EXPANSION_TIMEOUT_MS = 30_000;
+const SHELL_EXPANSION_MAX_BUFFER = 1024 * 1024;
+
+const unmarkedShellBlockPattern = /!`([^`]*)`/g;
+const markedShellBlockPattern = /!\uE000`([^`]*)`/g;
 
 async function runShellBlock(
 	command: string,

--- a/server/workflow/workflow-validator.ts
+++ b/server/workflow/workflow-validator.ts
@@ -1,23 +1,5 @@
 import type { RepoWorkflow, WorkflowStep } from "./workflow.ts";
 
-const STEPS_REFERENCE_RE =
-	/\{\{\s*steps\.(?<stepName>\w+)\.output(?<rest>(?:\.\w+)*)\s*\}\}/g;
-
-const COMPOSITION_KEYWORDS = ["$ref", "anyOf", "oneOf", "allOf"] as const;
-
-type StepReference = {
-	raw: string;
-	stepName: string;
-	path: string[];
-};
-
-type ValidationContext = {
-	sourcePath: string | undefined;
-	location: string;
-	stepsByName: Map<string, WorkflowStep>;
-	allowedSteps: Set<string>;
-};
-
 export function validateOutputReferences(
 	workflow: RepoWorkflow,
 	sourcePath?: string,
@@ -50,6 +32,24 @@ export function validateOutputReferences(
 		}
 	}
 }
+
+const STEPS_REFERENCE_RE =
+	/\{\{\s*steps\.(?<stepName>\w+)\.output(?<rest>(?:\.\w+)*)\s*\}\}/g;
+
+const COMPOSITION_KEYWORDS = ["$ref", "anyOf", "oneOf", "allOf"] as const;
+
+type StepReference = {
+	raw: string;
+	stepName: string;
+	path: string[];
+};
+
+type ValidationContext = {
+	sourcePath: string | undefined;
+	location: string;
+	stepsByName: Map<string, WorkflowStep>;
+	allowedSteps: Set<string>;
+};
 
 function extractReferences(template: string): StepReference[] {
 	const references: StepReference[] = [];


### PR DESCRIPTION
## Summary
- Adds a "Module layout" section to `docs/coding-standards.md`: imports → public types (incl. the module's main interface) → main implementation → private helpers and helper types.
- Applies the convention across `server/`: `run-repository.ts`, `jira-client.ts`, `gitlab-client.ts`, `trackers/jira.ts`, `workflow/workflow-validator.ts`, `workflow/prompt-preprocessor.ts`, `env.ts`, `http-client.ts`.
- Pure reorder — no behaviour changes.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (237 passing)
- [x] `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)