### PR TITLE
refactor: resolve base branch from code host, drop workflow.base_branch

### DIFF
--- a/examples/dynamic-branch.yaml
+++ b/examples/dynamic-branch.yaml
@@ -27,8 +27,6 @@ branch:
         pattern: "^(feat|fix|chore|docs|refactor|test)/[A-Z]+-[0-9]+-[a-z0-9-]+$"
     required: [name]
 
-base_branch: main
-
 steps:
   - name: implement
     prompt: |
@@ -41,9 +39,9 @@ steps:
       </issue-description>
 
       Only work on this one issue. The orchestrator has cloned the repo fresh
-      and created branch `{{ branch }}` from `main` for you. Make commits as
-      you go — the orchestrator pushes the branch and opens the change request
-      after the final step completes.
+      and created branch `{{ branch }}` from `{{ base_branch }}` for you. Make
+      commits as you go — the orchestrator pushes the branch and opens the
+      change request after the final step completes.
 
       # Project Context
 
@@ -93,13 +91,13 @@ steps:
       Diff against the base branch:
 
       <diff>
-      !`git diff main...HEAD`
+      !`git diff origin/{{ base_branch }}...HEAD`
       </diff>
 
       Commits on this branch:
 
       <commits>
-      !`git log main..HEAD --oneline`
+      !`git log origin/{{ base_branch }}..HEAD --oneline`
       </commits>
 
       # Review Focus
@@ -125,11 +123,11 @@ steps:
       {{ issue.key }}.
 
       <diff>
-      !`git diff main...HEAD`
+      !`git diff origin/{{ base_branch }}...HEAD`
       </diff>
 
       <commits>
-      !`git log main..HEAD --oneline`
+      !`git log origin/{{ base_branch }}..HEAD --oneline`
       </commits>
 
       Produce a one-line title and a short markdown body explaining what

--- a/examples/static-branch.yaml
+++ b/examples/static-branch.yaml
@@ -1,5 +1,4 @@
 branch: "agent/issue-{{ issue.number }}"
-base_branch: main
 
 steps:
   - name: implement
@@ -13,9 +12,10 @@ steps:
       </issue-description>
 
       Only work on this one issue. The orchestrator has cloned the repo fresh
-      and created branch `agent/issue-{{ issue.number }}` from `main` for you.
-      Make commits as you go — the orchestrator pushes the branch and opens
-      the change request after the final step completes.
+      and created branch `agent/issue-{{ issue.number }}` from
+      `{{ base_branch }}` for you. Make commits as you go — the orchestrator
+      pushes the branch and opens the change request after the final step
+      completes.
 
       # Project Context
 
@@ -65,13 +65,13 @@ steps:
       Diff against the base branch:
 
       <diff>
-      !`git diff main...HEAD`
+      !`git diff origin/{{ base_branch }}...HEAD`
       </diff>
 
       Commits on this branch:
 
       <commits>
-      !`git log main..HEAD --oneline`
+      !`git log origin/{{ base_branch }}..HEAD --oneline`
       </commits>
 
       # Review Focus
@@ -97,11 +97,11 @@ steps:
       reviewers of issue {{ issue.key }}.
 
       <diff>
-      !`git diff main...HEAD`
+      !`git diff origin/{{ base_branch }}...HEAD`
       </diff>
 
       <commits>
-      !`git log main..HEAD --oneline`
+      !`git log origin/{{ base_branch }}..HEAD --oneline`
       </commits>
 
       Produce a one-line title and a short markdown body explaining what

--- a/server/code-hosts/__tests__/gitlab.integration.test.ts
+++ b/server/code-hosts/__tests__/gitlab.integration.test.ts
@@ -103,6 +103,27 @@ describe("fetchFile", () => {
 	});
 });
 
+describe("defaultBranch", () => {
+	it("returns the project's default_branch from the GitLab project endpoint", async () => {
+		const expectedPath = "/api/v4/projects/group%2Fsubgroup%2Fproject";
+
+		server.use(
+			http.get(`${GITLAB_API}/projects/:project`, ({ request }) => {
+				const url = new URL(request.url);
+				if (
+					url.pathname !== expectedPath ||
+					request.headers.get("PRIVATE-TOKEN") !== "test-token"
+				) {
+					return new HttpResponse(null, { status: 400 });
+				}
+				return HttpResponse.json({ default_branch: "develop" });
+			}),
+		);
+
+		await expect(adapter.defaultBranch(REPO)).resolves.toBe("develop");
+	});
+});
+
 describe("createChangeRequest", () => {
 	it("creates a new MR when none exists", async () => {
 		const expectedBody = {

--- a/server/code-hosts/gitlab.ts
+++ b/server/code-hosts/gitlab.ts
@@ -1,5 +1,5 @@
 import type { GitLabClient } from "../gitlab-client.ts";
-import type { GitLabToken } from "../types/brands.ts";
+import { branchName, type GitLabToken } from "../types/brands.ts";
 import { decorateCodeHost } from "./decorator.ts";
 import type { ChangeRequest, CodeHostAdapter } from "./types.ts";
 
@@ -33,6 +33,11 @@ export function gitlabCodeHostAdapter(
 				/^(https?:\/\/)/,
 				`$1oauth2:${encodeURIComponent(cloneToken)}@`,
 			);
+		},
+
+		async defaultBranch(repo) {
+			const project = await client.getProject(repo);
+			return branchName(project.default_branch);
 		},
 
 		async createChangeRequest(

--- a/server/code-hosts/types.ts
+++ b/server/code-hosts/types.ts
@@ -8,6 +8,7 @@ export type ChangeRequest = {
 export type CodeHostAdapter = {
 	fetchFile(repo: RepoSlug, path: string, ref?: string): Promise<string | null>;
 	cloneUrl(repo: RepoSlug): string;
+	defaultBranch(repo: RepoSlug): Promise<BranchName>;
 	createChangeRequest(
 		repo: RepoSlug,
 		head: BranchName,

--- a/server/gitlab-client.ts
+++ b/server/gitlab-client.ts
@@ -11,7 +11,12 @@ const gitlabMergeRequestSchema = z.object({
 	web_url: z.string(),
 });
 
+const gitlabProjectSchema = z.object({
+	default_branch: z.string().min(1),
+});
+
 export type GitLabClient = {
+	getProject(projectPath: RepoSlug): Promise<{ default_branch: string }>;
 	getFileContent(
 		projectPath: RepoSlug,
 		filePath: string,
@@ -55,6 +60,12 @@ export function createGitLabClient(
 	});
 
 	return {
+		getProject(projectPath) {
+			return request(`/projects/${encodeProjectPath(projectPath)}`, {
+				schema: gitlabProjectSchema,
+			});
+		},
+
 		getFileContent(projectPath, filePath, ref = "HEAD") {
 			const query = new URLSearchParams({ ref });
 			return request(

--- a/server/orchestrator/__tests__/step-runner.test.ts
+++ b/server/orchestrator/__tests__/step-runner.test.ts
@@ -89,7 +89,6 @@ describe("runWorkflowSteps", () => {
 		const agent = createAgent(() => yieldAssistant("sess"));
 		const workflow: RepoWorkflow = {
 			branch: "b",
-			base_branch: "main",
 			steps: [{ name: "implement", prompt: "do it", resume_previous: false }],
 			change_request: baseChangeRequest,
 		};
@@ -101,6 +100,7 @@ describe("runWorkflowSteps", () => {
 			issue,
 			cwd: "/work",
 			branch: "agent/issue-1",
+			baseBranch: "main",
 			model: "test-model",
 		});
 
@@ -140,7 +140,6 @@ describe("runWorkflowSteps", () => {
 		});
 		const workflow: RepoWorkflow = {
 			branch: "b",
-			base_branch: "main",
 			steps: [
 				{
 					name: "summarise",
@@ -159,6 +158,7 @@ describe("runWorkflowSteps", () => {
 			issue,
 			cwd: "/work",
 			branch: "agent/issue-1",
+			baseBranch: "main",
 			model: "test-model",
 		});
 
@@ -198,7 +198,6 @@ describe("runWorkflowSteps", () => {
 		});
 		const workflow: RepoWorkflow = {
 			branch: "b",
-			base_branch: "main",
 			steps: [
 				{
 					name: "summarise",
@@ -219,6 +218,7 @@ describe("runWorkflowSteps", () => {
 				issue,
 				cwd: "/work",
 				branch: "agent/issue-1",
+				baseBranch: "main",
 				model: "test-model",
 			}),
 		).rejects.toThrow(/error_max_structured_output_retries/);
@@ -255,7 +255,6 @@ describe("runWorkflowSteps", () => {
 		});
 		const workflow: RepoWorkflow = {
 			branch: "b",
-			base_branch: "main",
 			steps: [{ name: "implement", prompt: "do it", resume_previous: false }],
 			change_request: baseChangeRequest,
 		};
@@ -267,6 +266,7 @@ describe("runWorkflowSteps", () => {
 			issue,
 			cwd: "/work",
 			branch: "agent/issue-1",
+			baseBranch: "main",
 			model: "test-model",
 		});
 
@@ -286,7 +286,6 @@ describe("runWorkflowSteps", () => {
 		});
 		const workflow: RepoWorkflow = {
 			branch: "b",
-			base_branch: "main",
 			steps: [{ name: "after", prompt: "after", resume_previous: false }],
 			change_request: baseChangeRequest,
 		};
@@ -298,6 +297,7 @@ describe("runWorkflowSteps", () => {
 			issue,
 			cwd: "/work",
 			branch: "agent/issue-1",
+			baseBranch: "main",
 			model: "test-model",
 		});
 
@@ -309,7 +309,6 @@ describe("runWorkflowSteps", () => {
 		const agent = createAgent(() => yieldAssistant("sess"));
 		const workflow: RepoWorkflow = {
 			branch: "ignored",
-			base_branch: "main",
 			steps: [
 				{
 					name: "implement",
@@ -327,6 +326,7 @@ describe("runWorkflowSteps", () => {
 			issue,
 			branch: "feat/proposed",
 			cwd: "/work",
+			baseBranch: "main",
 			model: "test-model",
 		});
 
@@ -364,7 +364,6 @@ describe("runWorkflowSteps", () => {
 		});
 		const workflow: RepoWorkflow = {
 			branch: "b",
-			base_branch: "main",
 			steps: [
 				{
 					name: "summarise",
@@ -388,6 +387,7 @@ describe("runWorkflowSteps", () => {
 			issue,
 			cwd: "/work",
 			branch: "agent/issue-1",
+			baseBranch: "main",
 			model: "test-model",
 		});
 

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -57,6 +57,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 		const { issue, repo, workflow } = req;
 
 		const cloneUrl = codeHost.cloneUrl(repo);
+		const baseBranch = await codeHost.defaultBranch(repo);
 		const ws = await ensureWorkspace(issue, workspaceRoot, cloneUrl);
 
 		return runner.enqueue({
@@ -97,6 +98,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 								workflow,
 								issue,
 								branch,
+								baseBranch,
 								cwd: ws.path,
 								model,
 							});
@@ -119,7 +121,14 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 						});
 
 						if (result.status === "completed" && branch) {
-							await finalizeSuccess(repo, issue, workflow, branch, ctx.outputs);
+							await finalizeSuccess(
+								repo,
+								issue,
+								workflow,
+								branch,
+								baseBranch,
+								ctx.outputs,
+							);
 						}
 
 						await removeWorkspace(ws.path);
@@ -140,6 +149,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 		issue: Issue,
 		workflow: RepoWorkflow,
 		branch: BranchName,
+		baseBranch: BranchName,
 		outputs: Record<string, unknown>,
 	): Promise<void> {
 		const { title, body } = renderChangeRequest({
@@ -149,13 +159,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 			outputs,
 		});
 		try {
-			await codeHost.createChangeRequest(
-				repo,
-				branch,
-				branchName(workflow.base_branch),
-				title,
-				body,
-			);
+			await codeHost.createChangeRequest(repo, branch, baseBranch, title, body);
 		} catch (err) {
 			canonicalLog.append(
 				"warnings",

--- a/server/orchestrator/step-runner.ts
+++ b/server/orchestrator/step-runner.ts
@@ -17,6 +17,7 @@ type RunWorkflowStepsParams = {
 	workflow: RepoWorkflow;
 	issue: Issue;
 	branch: string;
+	baseBranch: string;
 	cwd: string;
 	model: string;
 };
@@ -27,6 +28,7 @@ export async function runWorkflowSteps({
 	workflow,
 	issue,
 	branch,
+	baseBranch,
 	cwd,
 	model,
 }: RunWorkflowStepsParams): Promise<void> {
@@ -46,6 +48,7 @@ export async function runWorkflowSteps({
 			totalSteps: steps.length,
 			issue,
 			branch,
+			baseBranch,
 			cwd,
 			model,
 			...(stepResumeSessionId && { resumeSessionId: stepResumeSessionId }),
@@ -63,6 +66,7 @@ type RunWorkflowStepParams = {
 	totalSteps: number;
 	issue: Issue;
 	branch: string;
+	baseBranch: string;
 	cwd: string;
 	model: string;
 	resumeSessionId?: string;
@@ -76,6 +80,7 @@ async function runWorkflowStep({
 	totalSteps,
 	issue,
 	branch,
+	baseBranch,
 	cwd,
 	model,
 	resumeSessionId,
@@ -91,6 +96,7 @@ async function runWorkflowStep({
 		const renderedPrompt = renderPrompt(markTrustedShellBlocks(step.prompt), {
 			issue,
 			branch,
+			base_branch: baseBranch,
 			outputs: ctx.outputs,
 		});
 		const prompt = await expandMarkedShellBlocks(renderedPrompt, { cwd });

--- a/server/testing/support/fixtures.ts
+++ b/server/testing/support/fixtures.ts
@@ -99,7 +99,6 @@ export function createTestWorkflow(
 ): RepoWorkflow {
 	return {
 		branch: "agent/issue-{{ issue.number }}",
-		base_branch: "main",
 		steps: [
 			{
 				name: "prompt",

--- a/server/testing/support/msw.ts
+++ b/server/testing/support/msw.ts
@@ -10,7 +10,16 @@ import {
 	type StatusKey,
 } from "./fixtures.ts";
 
-export const server = setupServer();
+// Always-on handlers: every dispatch resolves the repo's default branch
+// before doing anything else. Tests that care about the value can override
+// with server.use(...).
+const defaultHandlers = [
+	http.get(`${GITLAB_API}/projects/:project`, () =>
+		HttpResponse.json({ default_branch: "main" }),
+	),
+];
+
+export const server = setupServer(...defaultHandlers);
 
 type JiraIssue = ReturnType<typeof createJiraIssue>;
 

--- a/server/workflow/__tests__/workflow-loader.test.ts
+++ b/server/workflow/__tests__/workflow-loader.test.ts
@@ -6,7 +6,6 @@ import { loadWorkflow } from "../workflow-loader.ts";
 
 const validWorkflowYaml = `
 branch: "agent/issue-{{ issue.number }}"
-base_branch: "main"
 steps:
   - name: implement
     prompt: "Fix the issue"
@@ -40,7 +39,6 @@ describe("loadWorkflow", () => {
 
 		expect(workflow).toEqual({
 			branch: "agent/issue-{{ issue.number }}",
-			base_branch: "main",
 			steps: [
 				{ name: "implement", prompt: "Fix the issue", resume_previous: false },
 			],
@@ -66,7 +64,6 @@ describe("loadWorkflow", () => {
 	it("rejects an output reference that points at a step the workflow doesn't define", () => {
 		using workflowFile = writeWorkflow(`
 branch: agent
-base_branch: main
 steps:
   - name: implement
     prompt: "Use {{ steps.missing.output.title }}"
@@ -86,7 +83,6 @@ change_request:
 	it("loads cleanly when output references resolve through the schema", () => {
 		using workflowFile = writeWorkflow(`
 branch: agent
-base_branch: main
 steps:
   - name: summarise
     prompt: "Write a summary"

--- a/server/workflow/__tests__/workflow-validator.test.ts
+++ b/server/workflow/__tests__/workflow-validator.test.ts
@@ -5,7 +5,6 @@ import { validateOutputReferences } from "../workflow-validator.ts";
 function workflow(overrides: Partial<RepoWorkflow> = {}): RepoWorkflow {
 	return {
 		branch: "agent/issue-{{ issue.number }}",
-		base_branch: "main",
 		steps: [
 			{ name: "implement", prompt: "Fix the issue", resume_previous: false },
 		],

--- a/server/workflow/__tests__/workflow.test.ts
+++ b/server/workflow/__tests__/workflow.test.ts
@@ -66,7 +66,6 @@ describe("parseRepoWorkflow", () => {
 	it("accepts a single-step workflow", () => {
 		const yaml = `
 branch: "agent/issue-{{ issue.number }}"
-base_branch: main
 steps:
   - name: implement
     prompt: Fix this issue
@@ -76,7 +75,6 @@ ${validChangeRequest}`;
 
 		expect(result).toEqual({
 			branch: "agent/issue-{{ issue.number }}",
-			base_branch: "main",
 			steps: [
 				{ name: "implement", prompt: "Fix this issue", resume_previous: false },
 			],
@@ -90,7 +88,6 @@ ${validChangeRequest}`;
 	it("accepts a multi-step workflow with resume_previous", () => {
 		const yaml = `
 branch: "agent/issue-{{ issue.number }}"
-base_branch: main
 steps:
   - name: plan
     prompt: Write a plan
@@ -114,7 +111,6 @@ ${validChangeRequest}`;
 	it("rejects workflows missing change_request", () => {
 		const yaml = `
 branch: my-branch
-base_branch: main
 steps:
   - name: implement
     prompt: Fix it
@@ -126,7 +122,6 @@ steps:
 	it("rejects change_request missing title", () => {
 		const yaml = `
 branch: my-branch
-base_branch: main
 steps:
   - name: implement
     prompt: Fix it
@@ -140,7 +135,6 @@ change_request:
 	it("rejects change_request missing body", () => {
 		const yaml = `
 branch: my-branch
-base_branch: main
 steps:
   - name: implement
     prompt: Fix it
@@ -154,7 +148,6 @@ change_request:
 	it("rejects change_request with unknown keys", () => {
 		const yaml = `
 branch: my-branch
-base_branch: main
 steps:
   - name: implement
     prompt: Fix it
@@ -168,25 +161,19 @@ change_request:
 	});
 
 	it("rejects workflows missing branch", () => {
-		const yaml = "base_branch: main\nsteps:\n  - name: x\n    prompt: Fix it\n";
-
-		expect(() => parseRepoWorkflow(yaml)).toThrow();
-	});
-
-	it("rejects workflows missing base_branch", () => {
-		const yaml = "branch: agent/x\nsteps:\n  - name: x\n    prompt: Fix it\n";
+		const yaml = "steps:\n  - name: x\n    prompt: Fix it\n";
 
 		expect(() => parseRepoWorkflow(yaml)).toThrow();
 	});
 
 	it("rejects workflows missing steps", () => {
-		const yaml = "branch: my-branch\nbase_branch: main\n";
+		const yaml = "branch: my-branch\n";
 
 		expect(() => parseRepoWorkflow(yaml)).toThrow();
 	});
 
 	it("rejects workflows with an empty steps array", () => {
-		const yaml = "branch: my-branch\nbase_branch: main\nsteps: []\n";
+		const yaml = "branch: my-branch\nsteps: []\n";
 
 		expect(() => parseRepoWorkflow(yaml)).toThrow();
 	});
@@ -194,7 +181,6 @@ change_request:
 	it("rejects the legacy top-level prompt form", () => {
 		const yaml = `
 branch: my-branch
-base_branch: main
 prompt: Fix this issue
 `;
 
@@ -204,7 +190,6 @@ prompt: Fix this issue
 	it("rejects the legacy phases key", () => {
 		const yaml = `
 branch: my-branch
-base_branch: main
 phases:
   - name: plan
     prompt: Write a plan
@@ -216,7 +201,6 @@ phases:
 	it("rejects the legacy hooks block", () => {
 		const yaml = `
 branch: my-branch
-base_branch: main
 hooks:
   before_run: echo hi
 steps:
@@ -230,7 +214,6 @@ steps:
 	it("rejects unknown step keys", () => {
 		const yaml = `
 branch: my-branch
-base_branch: main
 steps:
   - name: implement
     prompt: Fix it
@@ -251,7 +234,6 @@ branch:
         type: string
         pattern: "^feat/"
     required: [name]
-base_branch: main
 steps:
   - name: implement
     prompt: Fix it
@@ -274,7 +256,6 @@ ${validChangeRequest}`;
 branch:
   schema:
     type: object
-base_branch: main
 steps:
   - name: implement
     prompt: Fix it
@@ -287,7 +268,6 @@ ${validChangeRequest}`;
 		const yaml = `
 branch:
   prompt: "Propose a name"
-base_branch: main
 steps:
   - name: implement
     prompt: Fix it
@@ -302,7 +282,6 @@ branch:
   prompt: "Propose a name"
   schema: { type: object }
   bogus: true
-base_branch: main
 steps:
   - name: implement
     prompt: Fix it
@@ -314,7 +293,6 @@ ${validChangeRequest}`;
 	it("accepts a step with an output_schema (raw JSON Schema)", () => {
 		const yaml = `
 branch: my-branch
-base_branch: main
 steps:
   - name: summarise
     prompt: Summarise the issue

--- a/server/workflow/workflow.ts
+++ b/server/workflow/workflow.ts
@@ -44,7 +44,6 @@ export type WorkflowBranch = z.infer<typeof branchSchema>;
 const repoWorkflowSchema = z
 	.object({
 		branch: branchSchema,
-		base_branch: z.string().min(1),
 		steps: z.array(workflowStepSchema).min(1),
 		change_request: changeRequestSchema,
 	})
@@ -68,6 +67,7 @@ export function renderPrompt(
 	vars: {
 		issue: Issue;
 		branch?: string;
+		base_branch?: string;
 		outputs?: Record<string, unknown> | undefined;
 	},
 ): string {

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -27,8 +27,6 @@ branch:
         pattern: "^(feat|fix|chore|docs|refactor|test)/[A-Z]+-[0-9]+-[a-z0-9-]+$"
     required: [name]
 
-base_branch: main
-
 steps:
   - name: implement
     prompt: |
@@ -41,9 +39,9 @@ steps:
       </issue-description>
 
       Only work on this one issue. The orchestrator has cloned the repo fresh
-      and created branch `{{ branch }}` from `main` for you. Make commits as
-      you go — the orchestrator pushes the branch and opens the change request
-      after the final step completes.
+      and created branch `{{ branch }}` from `{{ base_branch }}` for you. Make
+      commits as you go — the orchestrator pushes the branch and opens the
+      change request after the final step completes.
 
       # Project Context
 
@@ -87,13 +85,13 @@ steps:
       Diff against the base branch:
 
       <diff>
-      !`git diff main...HEAD`
+      !`git diff origin/{{ base_branch }}...HEAD`
       </diff>
 
       Commits on this branch:
 
       <commits>
-      !`git log main..HEAD --oneline`
+      !`git log origin/{{ base_branch }}..HEAD --oneline`
       </commits>
 
       # Review Focus
@@ -119,11 +117,11 @@ steps:
       {{ issue.key }}.
 
       <diff>
-      !`git diff main...HEAD`
+      !`git diff origin/{{ base_branch }}...HEAD`
       </diff>
 
       <commits>
-      !`git log main..HEAD --oneline`
+      !`git log origin/{{ base_branch }}..HEAD --oneline`
       </commits>
 
       Produce a one-line title and a short markdown body explaining what


### PR DESCRIPTION
## Summary
- Code-host adapters now expose `defaultBranch(repo)`; the orchestrator queries it once per dispatch instead of reading `workflow.base_branch`.
- Workflow schema drops the `base_branch` field. Prompt templates receive `{{ base_branch }}` from the run context, and the example/built-in workflows are updated to use `origin/{{ base_branch }}` in their git refs.
- GitLab client gains `getProject` to back the new `defaultBranch`. MSW test scaffolding gets an always-on handler for the project endpoint so existing tests keep working.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (237 passed)
- [ ] End-to-end run against GitLab to confirm the MR opens against the project's actual default branch