### PR TITLE
feat: per-step model override in workflow.yaml

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { parse } from "yaml";
 import { z } from "zod";
 import { type RepoSlug, repoSlug } from "./types/brands.ts";
+import { modelIdSchema } from "./types/model-id.ts";
 
 export type Config = {
 	tracker: {
@@ -62,7 +63,7 @@ const configSchema = z
 			.object({
 				polling_interval_ms: z.number().int().positive(),
 				max_concurrent: z.number().int().positive(),
-				model: z.string().min(1),
+				model: modelIdSchema,
 				workspace_root: z.string().min(1),
 			})
 			.strict(),

--- a/server/orchestrator/__tests__/step-runner.test.ts
+++ b/server/orchestrator/__tests__/step-runner.test.ts
@@ -396,4 +396,38 @@ describe("runWorkflowSteps", () => {
 			"Use Earlier title",
 		]);
 	});
+
+	it("uses the per-step model when set, otherwise the default model", async () => {
+		const recorder = createCtx();
+		const agent = createAgent(() => yieldAssistant("sess"));
+		const workflow: RepoWorkflow = {
+			branch: "b",
+			steps: [
+				{ name: "implement", prompt: "do it", resume_previous: false },
+				{
+					name: "review",
+					prompt: "review it",
+					resume_previous: false,
+					model: "claude-opus-4-7",
+				},
+			],
+			change_request: baseChangeRequest,
+		};
+
+		await runWorkflowSteps({
+			ctx: recorder.ctx,
+			agent,
+			workflow,
+			issue,
+			cwd: "/work",
+			branch: "agent/issue-1",
+			baseBranch: "main",
+			model: "claude-sonnet-4-6",
+		});
+
+		expect(agent.calls.map((c) => c.model)).toEqual([
+			"claude-sonnet-4-6",
+			"claude-opus-4-7",
+		]);
+	});
 });

--- a/server/orchestrator/step-runner.ts
+++ b/server/orchestrator/step-runner.ts
@@ -50,7 +50,7 @@ export async function runWorkflowSteps({
 			branch,
 			baseBranch,
 			cwd,
-			model,
+			model: step.model ?? model,
 			...(stepResumeSessionId && { resumeSessionId: stepResumeSessionId }),
 		});
 

--- a/server/types/__tests__/model-id.test.ts
+++ b/server/types/__tests__/model-id.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { modelIdSchema } from "../model-id.ts";
+
+describe("modelIdSchema", () => {
+	it.each([
+		"claude-opus-4-7",
+		"claude-sonnet-4-6",
+		"claude-haiku-4-5-20251001",
+	])("accepts %s", (id) => {
+		expect(modelIdSchema.parse(id)).toBe(id);
+	});
+
+	it.each([
+		"gpt-4",
+		"banana",
+		"claud-opus-4-7",
+		"claude-opus",
+		"claude-opus-4",
+		"",
+	])("rejects %s", (id) => {
+		expect(() => modelIdSchema.parse(id)).toThrow();
+	});
+});

--- a/server/types/model-id.ts
+++ b/server/types/model-id.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const modelIdSchema = z
+	.string()
+	.regex(
+		/^claude-(opus|sonnet|haiku)-\d+-\d+(-\d{8})?$/,
+		"must be a Claude model id like 'claude-opus-4-7'",
+	);

--- a/server/workflow/__tests__/workflow.test.ts
+++ b/server/workflow/__tests__/workflow.test.ts
@@ -320,6 +320,20 @@ ${validChangeRequest}`;
 		]);
 	});
 
+	it("accepts a step with a model override", () => {
+		const yaml = `
+branch: my-branch
+steps:
+  - name: review
+    prompt: Review it
+    model: claude-opus-4-7
+${validChangeRequest}`;
+
+		const result = parseRepoWorkflow(yaml);
+
+		expect(result.steps[0]?.model).toBe("claude-opus-4-7");
+	});
+
 	it("throws on invalid YAML", () => {
 		const yaml = ":\n  :\n    - ][";
 

--- a/server/workflow/workflow.ts
+++ b/server/workflow/workflow.ts
@@ -1,6 +1,7 @@
 import { parse } from "yaml";
 import { z } from "zod";
 import type { Issue } from "../trackers/types.ts";
+import { modelIdSchema } from "../types/model-id.ts";
 import { stripShellBlockMarkers } from "./prompt-preprocessor.ts";
 
 const jsonSchemaDocument = z.record(z.string(), z.unknown());
@@ -16,6 +17,7 @@ const workflowStepSchema = z
 		prompt: z.string(),
 		resume_previous: z.boolean().optional().default(false),
 		output_schema: jsonSchemaDocument.optional(),
+		model: modelIdSchema.optional(),
 	})
 	.strict();
 

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -72,6 +72,7 @@ steps:
       orchestrator-owned.
 
   - name: review
+    model: claude-opus-4-7
     prompt: |
       # Task
 


### PR DESCRIPTION
## Summary

- Steps in `workflow.yaml` can specify `model: claude-opus-4-7` to override `defaults.model` from `config.yaml`. Use case: cheaper model for `implement`, stronger model for `review`.
- Adds shared `modelIdSchema` (regex-validated against `^claude-(opus|sonnet|haiku)-\d+-\d+(-\d{8})?$`) used by both `defaults.model` and the new per-step `model` field, replacing the previous unvalidated `z.string().min(1)`. Bogus IDs now fail at config/workflow load instead of at SDK invocation.
- `workflow.yaml`'s `review` step set to `claude-opus-4-7` as a working example.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (251 passing, including new schema and resolution tests)
- [ ] Drop a test issue and confirm the review step actually invokes Opus while implement uses the global Sonnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)