### PR TITLE
refactor: trim canonical log noise and capture run cost

### DIFF
--- a/server/__tests__/canonical-log.test.ts
+++ b/server/__tests__/canonical-log.test.ts
@@ -135,6 +135,45 @@ describe("canonicalLog", () => {
 		});
 	});
 
+	describe("incrementMap", () => {
+		it("counts up nested keys across multiple calls", async () => {
+			const { logger, bag } = capturingLogger();
+
+			await canonicalLog.run(
+				{ scope: "test" },
+				async () => {
+					canonicalLog.incrementMap("tool_use_by_name", "Read");
+					canonicalLog.incrementMap("tool_use_by_name", "Read");
+					canonicalLog.incrementMap("tool_use_by_name", "Edit");
+				},
+				logger,
+			);
+
+			expect(bag()).toEqual(
+				expect.objectContaining({
+					tool_use_by_name: { Read: 2, Edit: 1 },
+				}),
+			);
+		});
+
+		it("accepts a custom delta", async () => {
+			const { logger, bag } = capturingLogger();
+
+			await canonicalLog.run(
+				{ scope: "test" },
+				async () => {
+					canonicalLog.incrementMap("bytes_by_kind", "json", 512);
+					canonicalLog.incrementMap("bytes_by_kind", "json", 256);
+				},
+				logger,
+			);
+
+			expect(bag()).toEqual(
+				expect.objectContaining({ bytes_by_kind: { json: 768 } }),
+			);
+		});
+	});
+
 	describe("scenarios", () => {
 		it("http request that hits an error", async () => {
 			const { logger, bag } = capturingLogger();

--- a/server/canonical-log.ts
+++ b/server/canonical-log.ts
@@ -42,6 +42,50 @@ export function increment(key: string, delta = 1): void {
 }
 
 /**
+ * Increment a numeric counter inside a map-typed bag entry. Creates the map
+ * and the sub-key as needed. Used for things like `{ Read: 12, Edit: 3 }`.
+ */
+export function incrementMap(key: string, subKey: string, delta = 1): void {
+	const bag = getBag();
+	if (!bag) return;
+	const map = getOrCreateMap<number>(bag, key);
+	map[subKey] = (typeof map[subKey] === "number" ? map[subKey] : 0) + delta;
+}
+
+/**
+ * Add numeric values into nested numeric fields of a map-typed bag entry.
+ * Used for things like `{ "claude-sonnet-4-6": { input_tokens: 100, ... } }`.
+ */
+export function addToMapEntry(
+	key: string,
+	subKey: string,
+	fields: Record<string, number>,
+): void {
+	const bag = getBag();
+	if (!bag) return;
+	const map = getOrCreateMap<Record<string, number>>(bag, key);
+	map[subKey] ??= {};
+	const entry = map[subKey];
+	for (const [k, v] of Object.entries(fields)) {
+		entry[k] = (typeof entry[k] === "number" ? entry[k] : 0) + v;
+	}
+}
+
+function getOrCreateMap<V>(bag: LogFields, key: string): Record<string, V> {
+	const existing = bag[key];
+	if (
+		existing !== null &&
+		typeof existing === "object" &&
+		!Array.isArray(existing)
+	) {
+		return existing as Record<string, V>;
+	}
+	const fresh: Record<string, V> = {};
+	bag[key] = fresh;
+	return fresh;
+}
+
+/**
  * Run a function inside a canonical log scope.
  * When the function completes (or throws), the accumulated bag is flushed
  * as a single structured log line.

--- a/server/code-hosts/decorator.ts
+++ b/server/code-hosts/decorator.ts
@@ -5,20 +5,9 @@ export function decorateCodeHost(inner: CodeHostAdapter): CodeHostAdapter {
 	return {
 		...inner,
 		async createChangeRequest(repo, head, base, title, body) {
-			try {
-				const pr = await inner.createChangeRequest(
-					repo,
-					head,
-					base,
-					title,
-					body,
-				);
-				canonicalLog.set({ pr_url: pr.url });
-				return pr;
-			} catch (err) {
-				canonicalLog.append("warnings", `pr_create_failed: ${repo}`);
-				throw err;
-			}
+			const pr = await inner.createChangeRequest(repo, head, base, title, body);
+			canonicalLog.set({ pr_url: pr.url });
+			return pr;
 		},
 	};
 }

--- a/server/orchestrator/__tests__/agent-logging.test.ts
+++ b/server/orchestrator/__tests__/agent-logging.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it, vi } from "vitest";
+import * as canonicalLog from "../../canonical-log.ts";
 import { type AgentMessage, logAgentMessage } from "../agent-logging.ts";
+
+function capturingLogger(): {
+	logger: { info(obj: Record<string, unknown>, msg: string): void };
+	bag: () => Record<string, unknown>;
+} {
+	let captured: Record<string, unknown> = {};
+	return {
+		logger: {
+			info(obj: Record<string, unknown>) {
+				captured = obj;
+			},
+		},
+		bag: () => captured,
+	};
+}
 
 function toolUseMsg(
 	name: string,
@@ -51,6 +67,26 @@ describe("logAgentMessage", () => {
 		);
 
 		expect(emitToolUse).toHaveBeenCalledWith("WebSearch", "");
+	});
+
+	it("aggregates a tool_use_by_name counter on the canonical bag", async () => {
+		const { logger, bag } = capturingLogger();
+
+		await canonicalLog.run(
+			{ scope: "run" },
+			async () => {
+				logAgentMessage(toolUseMsg("Read", { file_path: "a.ts" }), "/work");
+				logAgentMessage(toolUseMsg("Read", { file_path: "b.ts" }), "/work");
+				logAgentMessage(toolUseMsg("Edit", { file_path: "c.ts" }), "/work");
+			},
+			logger,
+		);
+
+		expect(bag()).toEqual(
+			expect.objectContaining({
+				tool_use_by_name: { Read: 2, Edit: 1 },
+			}),
+		);
 	});
 
 	it("reads file_path, pattern, or command from tool input", () => {

--- a/server/orchestrator/__tests__/step-runner.test.ts
+++ b/server/orchestrator/__tests__/step-runner.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import * as canonicalLog from "../../canonical-log.ts";
 import type { StepEvent } from "../../event-bus.ts";
 import type { RunContext } from "../../runner/runner.ts";
 import type { Issue } from "../../trackers/types.ts";
@@ -10,6 +11,58 @@ import type {
 	AgentMessage,
 } from "../agent-invoker.ts";
 import { runWorkflowSteps } from "../step-runner.ts";
+
+type StepCostFields = {
+	model: string;
+	costUsd: number;
+	inputTokens: number;
+	outputTokens: number;
+};
+
+function resultMessage(uuid: string, fields: StepCostFields): AgentMessage {
+	return {
+		type: "result",
+		subtype: "success",
+		duration_ms: 1,
+		duration_api_ms: 1,
+		is_error: false,
+		num_turns: 1,
+		result: "ok",
+		stop_reason: "end_turn",
+		total_cost_usd: fields.costUsd,
+		usage: {} as never,
+		modelUsage: {
+			[fields.model]: {
+				inputTokens: fields.inputTokens,
+				outputTokens: fields.outputTokens,
+				cacheReadInputTokens: 0,
+				cacheCreationInputTokens: 0,
+				webSearchRequests: 0,
+				costUSD: fields.costUsd,
+				contextWindow: 200_000,
+				maxOutputTokens: 8_000,
+			},
+		},
+		permission_denials: [],
+		uuid,
+		session_id: "sess",
+	} as AgentMessage;
+}
+
+function captureBag(): {
+	logger: { info(obj: Record<string, unknown>, msg: string): void };
+	bag: () => Record<string, unknown>;
+} {
+	let captured: Record<string, unknown> = {};
+	return {
+		logger: {
+			info(obj: Record<string, unknown>) {
+				captured = obj;
+			},
+		},
+		bag: () => captured,
+	};
+}
 
 const issue: Issue = {
 	key: issueKey("owner/repo#1"),
@@ -395,6 +448,278 @@ describe("runWorkflowSteps", () => {
 			"Summarise",
 			"Use Earlier title",
 		]);
+	});
+
+	it("flushes step counters and durations into the canonical log", async () => {
+		const recorder = createCtx();
+		const agent = createAgent(() => yieldAssistant("sess"));
+		const workflow: RepoWorkflow = {
+			branch: "b",
+			steps: [
+				{ name: "implement", prompt: "do it", resume_previous: false },
+				{ name: "summarise", prompt: "summarise", resume_previous: false },
+			],
+			change_request: baseChangeRequest,
+		};
+
+		const { logger, bag } = captureBag();
+		await canonicalLog.run(
+			{ scope: "run" },
+			() =>
+				runWorkflowSteps({
+					ctx: recorder.ctx,
+					agent,
+					workflow,
+					issue,
+					cwd: "/work",
+					branch: "agent/issue-1",
+					baseBranch: "main",
+					model: "test-model",
+				}),
+			logger,
+		);
+
+		const result = bag();
+		expect(result["steps_total"]).toBe(2);
+		expect(result["steps_completed"]).toBe(2);
+		const durations = result["step_durations_ms"] as Record<string, number>;
+		expect(Object.keys(durations).sort()).toEqual(["implement", "summarise"]);
+		expect(durations["implement"]).toEqual(expect.any(Number));
+		expect(durations["summarise"]).toEqual(expect.any(Number));
+	});
+
+	it("collects step output names without persisting payloads to the bag", async () => {
+		const recorder = createCtx();
+		const agent = createAgent(async function* () {
+			yield* yieldAssistant("sess");
+			yield {
+				type: "result",
+				subtype: "success",
+				duration_ms: 1,
+				duration_api_ms: 1,
+				is_error: false,
+				num_turns: 1,
+				result: "ok",
+				stop_reason: "end_turn",
+				total_cost_usd: 0,
+				usage: {} as never,
+				modelUsage: {},
+				permission_denials: [],
+				structured_output: { title: "Hello" },
+				uuid: "00000000-0000-0000-0000-000000000081",
+				session_id: "sess",
+			} as AgentMessage;
+		});
+		const workflow: RepoWorkflow = {
+			branch: "b",
+			steps: [
+				{
+					name: "summarise",
+					prompt: "summarise",
+					resume_previous: false,
+					output_schema: outputSchema,
+				},
+			],
+			change_request: baseChangeRequest,
+		};
+
+		const { logger, bag } = captureBag();
+		await canonicalLog.run(
+			{ scope: "run" },
+			() =>
+				runWorkflowSteps({
+					ctx: recorder.ctx,
+					agent,
+					workflow,
+					issue,
+					cwd: "/work",
+					branch: "agent/issue-1",
+					baseBranch: "main",
+					model: "test-model",
+				}),
+			logger,
+		);
+
+		expect(bag()["step_outputs_collected"]).toEqual(["summarise"]);
+		expect(bag()).not.toHaveProperty("step_outputs");
+		expect(bag()).not.toHaveProperty("step_events");
+	});
+
+	it("sets failed_step on the canonical bag when a step throws", async () => {
+		const recorder = createCtx();
+		const agent = createAgent(async function* () {
+			yield {
+				type: "result",
+				subtype: "error_max_turns",
+				duration_ms: 1,
+				duration_api_ms: 1,
+				is_error: true,
+				num_turns: 1,
+				stop_reason: null,
+				total_cost_usd: 0,
+				usage: {} as never,
+				modelUsage: {},
+				permission_denials: [],
+				errors: [],
+				uuid: "00000000-0000-0000-0000-000000000090",
+				session_id: "sess",
+			} as AgentMessage;
+		});
+		const workflow: RepoWorkflow = {
+			branch: "b",
+			steps: [
+				{ name: "implement", prompt: "do it", resume_previous: false },
+				{ name: "after", prompt: "after", resume_previous: false },
+			],
+			change_request: baseChangeRequest,
+		};
+
+		const { logger, bag } = captureBag();
+		await expect(
+			canonicalLog.run(
+				{ scope: "run" },
+				() =>
+					runWorkflowSteps({
+						ctx: recorder.ctx,
+						agent,
+						workflow,
+						issue,
+						cwd: "/work",
+						branch: "agent/issue-1",
+						baseBranch: "main",
+						model: "test-model",
+					}),
+				logger,
+			),
+		).rejects.toThrow(/error_max_turns/);
+
+		expect(bag()["failed_step"]).toEqual({
+			name: "implement",
+			index: 0,
+			error: "error_max_turns",
+		});
+		expect(bag()["steps_total"]).toBe(2);
+		expect(bag()["steps_completed"]).toBe(0);
+	});
+
+	it("aggregates cost and token usage into the canonical log", async () => {
+		const recorder = createCtx();
+		const agent = createAgent(async function* (opts) {
+			yield* yieldAssistant("sess");
+			if (opts.model === "claude-sonnet-4-6") {
+				yield resultMessage("00000000-0000-0000-0000-000000000060", {
+					model: "claude-sonnet-4-6",
+					costUsd: 0.05,
+					inputTokens: 1000,
+					outputTokens: 200,
+				});
+			} else {
+				yield resultMessage("00000000-0000-0000-0000-000000000061", {
+					model: "claude-haiku-4-5",
+					costUsd: 0.01,
+					inputTokens: 500,
+					outputTokens: 100,
+				});
+			}
+		});
+		const workflow: RepoWorkflow = {
+			branch: "b",
+			steps: [
+				{ name: "implement", prompt: "do it", resume_previous: false },
+				{
+					name: "summarise",
+					prompt: "summarise",
+					resume_previous: false,
+					model: "claude-haiku-4-5",
+				},
+			],
+			change_request: baseChangeRequest,
+		};
+
+		const { logger, bag } = captureBag();
+		await canonicalLog.run(
+			{ scope: "run" },
+			() =>
+				runWorkflowSteps({
+					ctx: recorder.ctx,
+					agent,
+					workflow,
+					issue,
+					cwd: "/work",
+					branch: "agent/issue-1",
+					baseBranch: "main",
+					model: "claude-sonnet-4-6",
+				}),
+			logger,
+		);
+
+		const result = bag();
+		expect(result["total_cost_usd"]).toBeCloseTo(0.06, 6);
+		expect(result["total_input_tokens"]).toBe(1500);
+		expect(result["total_output_tokens"]).toBe(300);
+		expect(result["models_used"]).toEqual({
+			"claude-sonnet-4-6": {
+				input_tokens: 1000,
+				output_tokens: 200,
+				cost_usd: 0.05,
+			},
+			"claude-haiku-4-5": {
+				input_tokens: 500,
+				output_tokens: 100,
+				cost_usd: 0.01,
+			},
+		});
+	});
+
+	it("flushes accumulated cost even when a step fails", async () => {
+		const recorder = createCtx();
+		const agent = createAgent(async function* () {
+			yield* yieldAssistant("sess");
+			yield {
+				...resultMessage("00000000-0000-0000-0000-000000000070", {
+					model: "claude-sonnet-4-6",
+					costUsd: 0.04,
+					inputTokens: 800,
+					outputTokens: 150,
+				}),
+				subtype: "error_max_turns",
+				is_error: true,
+				stop_reason: null,
+				errors: [],
+			} as AgentMessage;
+		});
+		const workflow: RepoWorkflow = {
+			branch: "b",
+			steps: [{ name: "implement", prompt: "do it", resume_previous: false }],
+			change_request: baseChangeRequest,
+		};
+
+		const { logger, bag } = captureBag();
+		await expect(
+			canonicalLog.run(
+				{ scope: "run" },
+				() =>
+					runWorkflowSteps({
+						ctx: recorder.ctx,
+						agent,
+						workflow,
+						issue,
+						cwd: "/work",
+						branch: "agent/issue-1",
+						baseBranch: "main",
+						model: "claude-sonnet-4-6",
+					}),
+				logger,
+			),
+		).rejects.toThrow(/error_max_turns/);
+
+		expect(bag()).toEqual(
+			expect.objectContaining({
+				total_cost_usd: 0.04,
+				total_input_tokens: 800,
+				total_output_tokens: 150,
+			}),
+		);
 	});
 
 	it("uses the per-step model when set, otherwise the default model", async () => {

--- a/server/orchestrator/agent-logging.ts
+++ b/server/orchestrator/agent-logging.ts
@@ -1,36 +1,9 @@
-/**
- * Shared agent message logging utilities.
- */
 import * as canonicalLog from "../canonical-log.ts";
-
-type TextBlock = { type: "text"; text: string };
-type ToolUseBlock = {
-	type: "tool_use";
-	name: string;
-	input: Record<string, unknown>;
-};
-type ContentBlock = TextBlock | ToolUseBlock | { type: string };
 
 export type AgentMessage = {
 	type: "assistant";
 	message: { content: ContentBlock[] };
 };
-
-function isToolUse(block: ContentBlock): block is ToolUseBlock {
-	return block.type === "tool_use";
-}
-
-/** Strip the workdir prefix from a path for cleaner logging. */
-function shortPath(fullPath: string, workDir: string): string {
-	const privatePrefixed = `/private${workDir}`;
-	if (fullPath.startsWith(privatePrefixed)) {
-		return fullPath.slice(privatePrefixed.length + 1);
-	}
-	if (fullPath.startsWith(workDir)) {
-		return fullPath.slice(workDir.length + 1);
-	}
-	return fullPath;
-}
 
 /** Log assistant text and tool use activity from an agent message. */
 export function logAgentMessage(
@@ -47,7 +20,31 @@ export function logAgentMessage(
 				"",
 		);
 		const detail = shortPath(raw, workDir).slice(0, 100);
-		canonicalLog.increment("tool_use_count");
+		canonicalLog.incrementMap("tool_use_by_name", block.name);
 		emitToolUse?.(block.name, detail);
 	}
+}
+
+type TextBlock = { type: "text"; text: string };
+type ToolUseBlock = {
+	type: "tool_use";
+	name: string;
+	input: Record<string, unknown>;
+};
+type ContentBlock = TextBlock | ToolUseBlock | { type: string };
+
+function isToolUse(block: ContentBlock): block is ToolUseBlock {
+	return block.type === "tool_use";
+}
+
+/** Strip the workdir prefix from a path for cleaner logging. */
+function shortPath(fullPath: string, workDir: string): string {
+	const privatePrefixed = `/private${workDir}`;
+	if (fullPath.startsWith(privatePrefixed)) {
+		return fullPath.slice(privatePrefixed.length + 1);
+	}
+	if (fullPath.startsWith(workDir)) {
+		return fullPath.slice(workDir.length + 1);
+	}
+	return fullPath;
 }

--- a/server/orchestrator/agent-metrics.ts
+++ b/server/orchestrator/agent-metrics.ts
@@ -1,0 +1,21 @@
+import * as canonicalLog from "../canonical-log.ts";
+import type { AgentMessage } from "./agent-invoker.ts";
+
+/**
+ * Accumulate cost and token usage from an SDK result message into the
+ * surrounding canonical log scope.
+ */
+export function recordAgentResult(
+	msg: Extract<AgentMessage, { type: "result" }>,
+): void {
+	canonicalLog.increment("total_cost_usd", msg.total_cost_usd);
+	for (const [model, usage] of Object.entries(msg.modelUsage)) {
+		canonicalLog.addToMapEntry("models_used", model, {
+			input_tokens: usage.inputTokens,
+			output_tokens: usage.outputTokens,
+			cost_usd: usage.costUSD,
+		});
+		canonicalLog.increment("total_input_tokens", usage.inputTokens);
+		canonicalLog.increment("total_output_tokens", usage.outputTokens);
+	}
+}

--- a/server/orchestrator/branch-resolver.ts
+++ b/server/orchestrator/branch-resolver.ts
@@ -3,6 +3,7 @@ import type { WorkflowBranch } from "../workflow/workflow.ts";
 import { renderPrompt } from "../workflow/workflow.ts";
 import type { AgentInvoker, OutputFormat } from "./agent-invoker.ts";
 import { logAgentMessage } from "./agent-logging.ts";
+import { recordAgentResult } from "./agent-metrics.ts";
 
 type ResolveBranchParams = {
 	workflowBranch: WorkflowBranch;
@@ -43,6 +44,7 @@ export async function resolveBranch({
 			continue;
 		}
 		if (msg.type !== "result") continue;
+		recordAgentResult(msg);
 		if (msg.subtype === "success") {
 			const value = msg.structured_output as { name?: unknown };
 			if (typeof value?.name !== "string" || value.name.length === 0) {

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -1,3 +1,4 @@
+import * as canonicalLog from "../canonical-log.ts";
 import type { CodeHostAdapter } from "../code-hosts/types.ts";
 import type { Config } from "../config.ts";
 import { logger } from "../logger.ts";
@@ -36,6 +37,11 @@ type Orchestrator = {
 type TickState = {
 	runningIssueKeys: Set<IssueKey>;
 	pending: Issue[];
+};
+
+type DispatchTally = {
+	dispatched: number;
+	skippedAtCapacity: number;
 };
 
 export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
@@ -82,8 +88,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		try {
 			const result = await tracker.fetchActiveIssues("pending");
 			pending = [...result.issues];
-		} catch (err) {
-			logger.warn({ err }, "orchestrator.fetch_pending_failed");
+		} catch {
 			pending = [];
 		}
 		pending.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
@@ -92,42 +97,66 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 	}
 
 	async function recover() {
-		const completedAt = new Date(clock.now()).toISOString();
-		for (const run of runRepo.getRunningSnapshot()) {
-			runRepo.failRun(run.id, {
-				error: "Stale run from previous session",
-				completedAt,
-			});
-		}
+		await canonicalLog.run(
+			{ scope: "recovery" },
+			async () => {
+				const completedAt = new Date(clock.now()).toISOString();
+				let staleRunsFailed = 0;
+				for (const run of runRepo.getRunningSnapshot()) {
+					runRepo.failRun(run.id, {
+						error: "Stale run from previous session",
+						completedAt,
+					});
+					staleRunsFailed += 1;
+				}
+				canonicalLog.set({
+					stale_runs_failed: staleRunsFailed,
+					tracker_orphans_recovered: 0,
+				});
 
-		// Tracker issues stuck "running" mean the previous process died mid-flight;
-		// push them back to "pending" so the next tick re-dispatches.
-		let runningIssues: readonly Issue[];
-		try {
-			const result = await tracker.fetchActiveIssues("running");
-			runningIssues = result.issues;
-		} catch (err) {
-			logger.warn({ err }, "orchestrator.recovery_fetch_failed");
-			return;
-		}
+				// Tracker issues stuck "running" mean the previous process died mid-flight;
+				// push them back to "pending" so the next tick re-dispatches.
+				let runningIssues: readonly Issue[];
+				try {
+					const result = await tracker.fetchActiveIssues("running");
+					runningIssues = result.issues;
+				} catch {
+					return;
+				}
 
-		for (const issue of runningIssues) {
-			logger.info({ key: issue.key }, "orchestrator.recovery_orphan");
-			await tracker
-				.transitionState(issue.repo, issue.number, "running", "pending")
-				.catch((err) =>
-					logger.warn(
-						{ key: issue.key, err },
-						"orchestrator.recovery_transition_failed",
+				const results = await Promise.allSettled(
+					runningIssues.map((issue) =>
+						tracker.transitionState(
+							issue.repo,
+							issue.number,
+							"running",
+							"pending",
+						),
 					),
 				);
-		}
+				canonicalLog.set({
+					tracker_orphans_recovered: results.filter(
+						(r) => r.status === "fulfilled",
+					).length,
+				});
+			},
+			logger,
+		);
 	}
 
-	async function dispatchPendingIssues(state: TickState) {
+	async function dispatchPendingIssues(
+		state: TickState,
+	): Promise<DispatchTally> {
+		const tally: DispatchTally = {
+			dispatched: 0,
+			skippedAtCapacity: 0,
+		};
 		for (const issue of state.pending) {
 			if (state.runningIssueKeys.has(issue.key)) continue;
-			if (state.runningIssueKeys.size >= defaults.max_concurrent) break;
+			if (state.runningIssueKeys.size >= defaults.max_concurrent) {
+				tally.skippedAtCapacity += 1;
+				continue;
+			}
 
 			const { repo } = issue;
 			await tracker.transitionState(repo, issue.number, "pending", "running");
@@ -136,21 +165,21 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 				const handle = await lifecycle.dispatch({ issue, repo, workflow });
 				trackPostRun(handle.done);
 			} catch (err) {
-				logger.warn({ issue: issue.key, err }, "orchestrator.dispatch_failed");
+				canonicalLog.append("warnings", {
+					kind: "dispatch_failed",
+					issue_key: issue.key,
+					error: canonicalLog.errorMessage(err),
+				});
 				await tracker
 					.transitionState(repo, issue.number, "running", "pending")
-					.catch((rollbackErr) =>
-						logger.warn(
-							{ issue: issue.key, err: rollbackErr },
-							"orchestrator.rollback_failed",
-						),
-					);
+					.catch(() => {});
 				continue;
 			}
 
 			state.runningIssueKeys.add(issue.key);
-			logger.info({ issue: issue.key }, "orchestrator.dispatched");
+			tally.dispatched += 1;
 		}
+		return tally;
 	}
 
 	async function tick() {
@@ -158,8 +187,22 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		ticking = true;
 
 		try {
-			const state = await fetchTickState();
-			await dispatchPendingIssues(state);
+			await canonicalLog.run(
+				{ scope: "tick" },
+				async () => {
+					const state = await fetchTickState();
+					canonicalLog.set({
+						pending_count: state.pending.length,
+						running_count: state.runningIssueKeys.size,
+					});
+					const tally = await dispatchPendingIssues(state);
+					canonicalLog.set({
+						dispatched_count: tally.dispatched,
+						skipped_at_capacity: tally.skippedAtCapacity,
+					});
+				},
+				logger,
+			);
 		} finally {
 			ticking = false;
 		}

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -42,6 +42,18 @@ type RunLifecycleDeps = {
 	model: string;
 };
 
+type FailurePhase =
+	| "branch_resolver"
+	| "setup"
+	| "step"
+	| "push"
+	| "change_request"
+	| "tracker_transition";
+
+function recordFailure(phase: FailurePhase, error: string): void {
+	canonicalLog.set({ failure_phase: phase, failure_error: error });
+}
+
 export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 	const {
 		runner,
@@ -73,13 +85,16 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 						run_id: ctx.runId,
 						agent: `issue-${issue.number}`,
 						issue_key: issue.key,
+						workspace_reused: !ws.created,
 					},
 					async () => {
 						const startTime = clock.now();
 						let result: RunResult;
 						let branch: BranchName | undefined;
+						let phase: FailurePhase = "branch_resolver";
 
 						try {
+							const branchResolverStart = clock.now();
 							const resolvedBranch = await resolveBranch({
 								workflowBranch: workflow.branch,
 								issue,
@@ -88,11 +103,18 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 								model,
 								signal: ctx.signal,
 							});
+							canonicalLog.set({
+								branch_resolver_ms: clock.now() - branchResolverStart,
+							});
 							branch = branchName(resolvedBranch);
+							canonicalLog.set({ branch });
 
+							phase = "setup";
 							await ensureBranch(ws.path, branch);
-							await runRepoSetup(ws.path, runShell);
+							const repoSetupRan = await runRepoSetup(ws.path, runShell);
+							canonicalLog.set({ repo_setup_ran: repoSetupRan });
 
+							phase = "step";
 							await runWorkflowSteps({
 								ctx,
 								agent,
@@ -109,17 +131,16 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 								durationMs: clock.now() - startTime,
 							};
 						} catch (err) {
+							const error = canonicalLog.errorMessage(err);
+							recordFailure(phase, error);
 							result = {
 								status: "failed",
-								error: canonicalLog.errorMessage(err),
+								error,
 								durationMs: clock.now() - startTime,
 							};
 						}
 
-						canonicalLog.set({
-							status: result.status,
-							...(result.status === "failed" && { error: result.error }),
-						});
+						canonicalLog.set({ status: result.status });
 
 						const succeeded =
 							result.status === "completed" &&
@@ -162,10 +183,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 		try {
 			await pushBranch(wsPath, branch);
 		} catch (err) {
-			canonicalLog.append(
-				"warnings",
-				`push_failed: ${canonicalLog.errorMessage(err)}`,
-			);
+			recordFailure("push", canonicalLog.errorMessage(err));
 			return false;
 		}
 
@@ -178,33 +196,26 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 		try {
 			await codeHost.createChangeRequest(repo, branch, baseBranch, title, body);
 		} catch (err) {
-			canonicalLog.append(
-				"warnings",
-				`on_complete_failed: ${canonicalLog.errorMessage(err)}`,
-			);
+			recordFailure("change_request", canonicalLog.errorMessage(err));
 			return false;
 		}
 
-		await tracker
-			.transitionState(repo, issue.number, "running", "awaiting_review")
-			.catch((err) =>
-				canonicalLog.append(
-					"warnings",
-					`state_recovery_failed: ${canonicalLog.errorMessage(err)}`,
-				),
+		try {
+			await tracker.transitionState(
+				repo,
+				issue.number,
+				"running",
+				"awaiting_review",
 			);
+		} catch (err) {
+			recordFailure("tracker_transition", canonicalLog.errorMessage(err));
+			return false;
+		}
 		return true;
 	}
 
 	async function markIssueFailed(repo: RepoSlug, issue: Issue): Promise<void> {
-		await tracker
-			.markFailed(repo, issue.number)
-			.catch((err) =>
-				canonicalLog.append(
-					"warnings",
-					`mark_failed_failed: ${canonicalLog.errorMessage(err)}`,
-				),
-			);
+		await tracker.markFailed(repo, issue.number).catch(() => {});
 	}
 
 	return { dispatch };

--- a/server/orchestrator/step-runner.ts
+++ b/server/orchestrator/step-runner.ts
@@ -1,5 +1,4 @@
 import * as canonicalLog from "../canonical-log.ts";
-import type { StepEvent } from "../event-bus.ts";
 import type { RunContext } from "../runner/runner.ts";
 import type { Issue } from "../trackers/types.ts";
 import {
@@ -10,6 +9,7 @@ import type { RepoWorkflow, WorkflowStep } from "../workflow/workflow.ts";
 import { renderPrompt } from "../workflow/workflow.ts";
 import type { AgentInvoker, OutputFormat } from "./agent-invoker.ts";
 import { logAgentMessage } from "./agent-logging.ts";
+import { recordAgentResult } from "./agent-metrics.ts";
 
 type RunWorkflowStepsParams = {
 	ctx: RunContext;
@@ -34,6 +34,7 @@ export async function runWorkflowSteps({
 }: RunWorkflowStepsParams): Promise<void> {
 	const { steps } = workflow;
 	let previousSessionId: string | undefined;
+	canonicalLog.set({ steps_total: steps.length, steps_completed: 0 });
 
 	for (const [index, step] of steps.entries()) {
 		const stepResumeSessionId = step.resume_previous
@@ -87,7 +88,7 @@ async function runWorkflowStep({
 }: RunWorkflowStepParams): Promise<string | undefined> {
 	const startedAt = Date.now();
 	let currentSessionId = resumeSessionId;
-	emitStepMarker(ctx, {
+	ctx.emitStepEvent({
 		type: "step.started",
 		data: { name: step.name, index: stepIndex, total: totalSteps },
 	});
@@ -120,13 +121,11 @@ async function runWorkflowStep({
 			}
 			if (msg.type === "result") {
 				currentSessionId = msg.session_id;
+				recordAgentResult(msg);
 				if (msg.subtype === "success") {
 					if (outputFormat) {
 						ctx.setStepOutput(step.name, msg.structured_output);
-						canonicalLog.append("step_outputs", {
-							name: step.name,
-							output: msg.structured_output,
-						});
+						canonicalLog.append("step_outputs_collected", step.name);
 					}
 					continue;
 				}
@@ -134,29 +133,23 @@ async function runWorkflowStep({
 			}
 		}
 
-		emitStepMarker(ctx, {
+		const durationMs = Date.now() - startedAt;
+		canonicalLog.increment("steps_completed");
+		canonicalLog.incrementMap("step_durations_ms", step.name, durationMs);
+		ctx.emitStepEvent({
 			type: "step.completed",
-			data: {
-				name: step.name,
-				index: stepIndex,
-				durationMs: Date.now() - startedAt,
-			},
+			data: { name: step.name, index: stepIndex, durationMs },
 		});
 		return currentSessionId;
 	} catch (err) {
-		emitStepMarker(ctx, {
+		const error = canonicalLog.errorMessage(err);
+		canonicalLog.set({
+			failed_step: { name: step.name, index: stepIndex, error },
+		});
+		ctx.emitStepEvent({
 			type: "step.failed",
-			data: {
-				name: step.name,
-				index: stepIndex,
-				error: canonicalLog.errorMessage(err),
-			},
+			data: { name: step.name, index: stepIndex, error },
 		});
 		throw err;
 	}
-}
-
-function emitStepMarker(ctx: RunContext, event: StepEvent): void {
-	ctx.emitStepEvent(event);
-	canonicalLog.append("step_events", event);
 }

--- a/server/orchestrator/workspace.ts
+++ b/server/orchestrator/workspace.ts
@@ -67,13 +67,14 @@ const SETUP_SCRIPT_PATH = ".agent/setup.sh";
 export async function runRepoSetup(
 	wsPath: string,
 	runShell: RunShell,
-): Promise<void> {
+): Promise<boolean> {
 	const scriptPath = join(wsPath, SETUP_SCRIPT_PATH);
 	try {
 		await access(scriptPath);
 	} catch {
-		return;
+		return false;
 	}
 
 	await runShell(`bash ${SETUP_SCRIPT_PATH}`, wsPath);
+	return true;
 }

--- a/server/trackers/decorator.ts
+++ b/server/trackers/decorator.ts
@@ -1,62 +1,46 @@
 import * as canonicalLog from "../canonical-log.ts";
 import type { TrackerAdapter } from "./types.ts";
 
+/**
+ * Wrap a tracker so any thrown error is appended as a structured entry to the
+ * canonical-log `warnings` array before being re-thrown. Callers can therefore
+ * use bare `.catch(() => {})` swallow blocks where appropriate.
+ */
 export function decorateTracker(inner: TrackerAdapter): TrackerAdapter {
 	return {
-		async fetchIssue(repo, issueNumber) {
-			try {
-				const issue = await inner.fetchIssue(repo, issueNumber);
-				canonicalLog.set({ tracker_fetch_issue: `${repo}#${issueNumber}` });
-				return issue;
-			} catch (err) {
-				canonicalLog.set({
-					tracker_error: `fetch_issue_failed: ${repo}#${issueNumber}`,
-				});
-				throw err;
-			}
-		},
-
-		async fetchActiveIssues(state) {
-			try {
-				const page = await inner.fetchActiveIssues(state);
-				canonicalLog.set({
-					tracker_active_issues_count: page.issues.length,
-				});
-				return page;
-			} catch (err) {
-				canonicalLog.append("warnings", `fetch_active_issues_failed: ${state}`);
-				throw err;
-			}
-		},
-
-		async transitionState(repo, issueNumber, from, to) {
-			try {
-				await inner.transitionState(repo, issueNumber, from, to);
-				canonicalLog.append("state_transitions", { from, to });
-			} catch (err) {
-				canonicalLog.append(
-					"warnings",
-					`state_transition_failed: ${repo}#${issueNumber}`,
-				);
-				throw err;
-			}
-		},
-
-		async markFailed(repo, issueNumber) {
-			try {
-				await inner.markFailed(repo, issueNumber);
-				canonicalLog.append("state_transitions", { to: "failed" });
-			} catch (err) {
-				canonicalLog.append(
-					"warnings",
-					`mark_failed_failed: ${repo}#${issueNumber}`,
-				);
-				throw err;
-			}
-		},
-
-		parseIssueKey(key) {
-			return inner.parseIssueKey(key);
-		},
+		...inner,
+		fetchActiveIssues: (state) =>
+			withWarning("fetch_active_issues_failed", { state }, () =>
+				inner.fetchActiveIssues(state),
+			),
+		transitionState: (repo, issueNumber, from, to) =>
+			withWarning(
+				"state_transition_failed",
+				{ issue: `${repo}#${issueNumber}`, from, to },
+				() => inner.transitionState(repo, issueNumber, from, to),
+			),
+		markFailed: (repo, issueNumber) =>
+			withWarning(
+				"mark_failed_failed",
+				{ issue: `${repo}#${issueNumber}` },
+				() => inner.markFailed(repo, issueNumber),
+			),
 	};
+}
+
+async function withWarning<T>(
+	kind: string,
+	context: Record<string, unknown>,
+	fn: () => Promise<T>,
+): Promise<T> {
+	try {
+		return await fn();
+	} catch (err) {
+		canonicalLog.append("warnings", {
+			kind,
+			...context,
+			error: canonicalLog.errorMessage(err),
+		});
+		throw err;
+	}
 }


### PR DESCRIPTION
## Summary

- Trim per-run canonical log lines: drop the `step_events` transcript, full `step_outputs` payloads, `tool_use_count`, `state_transitions`, `tracker_fetch_issue`, and string-formatted warnings — replace with summary fields (`steps_total`/`steps_completed`/`step_durations_ms`/`failed_step`, `step_outputs_collected` names only, `tool_use_by_name`, flat `failure_phase`/`failure_error`).
- Capture cost and token usage from every agent invocation (step-runner *and* branch-resolver) via a shared `recordAgentResult` helper. Surfaces `total_cost_usd`, `total_input_tokens`, `total_output_tokens`, and a per-model `models_used` breakdown — useful now that per-step model overrides exist.
- Add `scope=tick` and `scope=recovery` canonical scopes, collapsing eight scattered `logger.info`/`warn` calls per tick into one structured line each. Tracker decorator now appends structured warning objects (with `kind` + context) instead of formatted strings.
- Fill previously silent gaps: `branch`, `branch_resolver_ms`, `workspace_reused`, `repo_setup_ran`.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (259 tests; +6 new)
- [ ] Run a real agent end-to-end and eyeball the trimmed run line + new tick/recovery lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)