### PR TITLE
feat: re-introduce github code host

### DIFF
--- a/server/__tests__/config.test.ts
+++ b/server/__tests__/config.test.ts
@@ -86,6 +86,34 @@ ${fullDefaults}`);
 		expect(() => loadConfig(configFile.path)).toThrow();
 	});
 
+	it("accepts github code host without a base_url", () => {
+		using configFile = writeConfig(`
+${validJiraTracker}code_host:
+  kind: github
+  scopes:
+    - acme/widgets
+${fullDefaults}`);
+
+		const config = loadConfig(configFile.path);
+
+		expect(config.code_host).toEqual({
+			kind: "github",
+			scopes: ["acme/widgets"],
+		});
+	});
+
+	it("rejects github code host with a base_url (github.com only)", () => {
+		using configFile = writeConfig(`
+${validJiraTracker}code_host:
+  kind: github
+  base_url: https://github.example.test
+  scopes:
+    - acme/widgets
+${fullDefaults}`);
+
+		expect(() => loadConfig(configFile.path)).toThrow();
+	});
+
 	it("rejects jira tracker without statuses", () => {
 		using configFile = writeConfig(`
 tracker:

--- a/server/__tests__/github-client.integration.test.ts
+++ b/server/__tests__/github-client.integration.test.ts
@@ -1,0 +1,42 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../github-client.ts";
+import { GITHUB_API, REPO } from "../testing/support/fixtures.ts";
+import { server } from "../testing/support/msw.ts";
+import { githubToken } from "../types/brands.ts";
+
+describe("GitHub client retry", () => {
+	it("retries on 500 and succeeds on the next attempt", async () => {
+		server.use(
+			http.get(`${GITHUB_API}/repos/${REPO}`, function* () {
+				yield new HttpResponse(null, { status: 500 });
+				return HttpResponse.json({ default_branch: "main" });
+			}),
+		);
+
+		const client = createGitHubClient(githubToken("test-token"), {
+			baseDelayMs: 1,
+		});
+		const repo = await client.getRepo(REPO);
+
+		expect(repo).toEqual({ default_branch: "main" });
+	});
+
+	it("throws after exhausting all retry attempts", async () => {
+		server.use(
+			http.get(
+				`${GITHUB_API}/repos/${REPO}/contents/:path+`,
+				() => new HttpResponse(null, { status: 500 }),
+			),
+		);
+
+		const client = createGitHubClient(githubToken("test-token"), {
+			maxAttempts: 2,
+			baseDelayMs: 1,
+		});
+
+		await expect(client.getFileContent(REPO, "README.md")).rejects.toThrow(
+			"GitHub API GET /repos/test-owner/test-repo/contents/README.md failed (500)",
+		);
+	});
+});

--- a/server/code-hosts/__tests__/github.integration.test.ts
+++ b/server/code-hosts/__tests__/github.integration.test.ts
@@ -1,0 +1,161 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+import { createGitHubClient } from "../../github-client.ts";
+import { GITHUB_API, REPO } from "../../testing/support/fixtures.ts";
+import { server } from "../../testing/support/msw.ts";
+import { branchName, githubToken } from "../../types/brands.ts";
+import { githubCodeHostAdapter } from "../github.ts";
+
+const adapter = githubCodeHostAdapter(
+	createGitHubClient(githubToken("test-token")),
+);
+
+describe("cloneUrl", () => {
+	it("targets github.com", () => {
+		expect(adapter.cloneUrl(REPO)).toBe(
+			"https://github.com/test-owner/test-repo.git",
+		);
+	});
+
+	it("embeds the configured token as x-access-token basic auth when provided", () => {
+		const tokenAdapter = githubCodeHostAdapter(
+			createGitHubClient(githubToken("test-token")),
+			githubToken("token-with/special:chars"),
+		);
+
+		expect(tokenAdapter.cloneUrl(REPO)).toBe(
+			"https://x-access-token:token-with%2Fspecial%3Achars@github.com/test-owner/test-repo.git",
+		);
+	});
+});
+
+describe("fetchFile", () => {
+	it("fetches base64-decoded file content from the GitHub contents API at the requested ref", async () => {
+		const expectedPath = `/repos/${REPO}/contents/docs/guide.md`;
+
+		server.use(
+			http.get(`${GITHUB_API}/repos/${REPO}/contents/:path+`, ({ request }) => {
+				const url = new URL(request.url);
+				if (
+					url.pathname !== expectedPath ||
+					url.searchParams.get("ref") !== "feature/github" ||
+					request.headers.get("Authorization") !== "Bearer test-token"
+				) {
+					return new HttpResponse(null, { status: 400 });
+				}
+				return HttpResponse.json({
+					content: Buffer.from("hello from github").toString("base64"),
+				});
+			}),
+		);
+
+		const content = await adapter.fetchFile(
+			REPO,
+			"docs/guide.md",
+			"feature/github",
+		);
+
+		expect(content).toBe("hello from github");
+	});
+
+	it("returns null when the file does not exist", async () => {
+		server.use(
+			http.get(
+				`${GITHUB_API}/repos/${REPO}/contents/:path+`,
+				() => new HttpResponse(null, { status: 404 }),
+			),
+		);
+
+		const content = await adapter.fetchFile(REPO, "missing.md");
+		expect(content).toBeNull();
+	});
+});
+
+describe("defaultBranch", () => {
+	it("returns the repo's default_branch from the GitHub repo endpoint", async () => {
+		server.use(
+			http.get(`${GITHUB_API}/repos/${REPO}`, () =>
+				HttpResponse.json({ default_branch: "develop" }),
+			),
+		);
+
+		await expect(adapter.defaultBranch(REPO)).resolves.toBe("develop");
+	});
+});
+
+describe("createChangeRequest", () => {
+	it("creates a new PR when none exists", async () => {
+		const expectedBody = {
+			title: "Fix issue 1",
+			body: "Closes TEST-1",
+			head: "agent/issue-1",
+			base: "main",
+		};
+
+		server.use(
+			http.get(`${GITHUB_API}/repos/${REPO}/pulls`, ({ request }) => {
+				const params = new URL(request.url).searchParams;
+				if (
+					params.get("head") !== "test-owner:agent/issue-1" ||
+					params.get("base") !== "main" ||
+					params.get("state") !== "open"
+				) {
+					return new HttpResponse(null, { status: 400 });
+				}
+				return HttpResponse.json([]);
+			}),
+			http.post(`${GITHUB_API}/repos/${REPO}/pulls`, async ({ request }) => {
+				const body = await request.json();
+				if (JSON.stringify(body) !== JSON.stringify(expectedBody)) {
+					return new HttpResponse(null, { status: 400 });
+				}
+				return HttpResponse.json({
+					number: 5,
+					html_url: `https://github.com/${REPO}/pull/5`,
+				});
+			}),
+		);
+
+		const result = await adapter.createChangeRequest(
+			REPO,
+			branchName("agent/issue-1"),
+			branchName("main"),
+			"Fix issue 1",
+			"Closes TEST-1",
+		);
+
+		expect(result).toEqual({
+			number: 5,
+			url: `https://github.com/${REPO}/pull/5`,
+		});
+	});
+
+	it("returns an existing PR for the source branch", async () => {
+		server.use(
+			http.get(`${GITHUB_API}/repos/${REPO}/pulls`, () =>
+				HttpResponse.json([
+					{
+						number: 3,
+						html_url: `https://github.com/${REPO}/pull/3`,
+					},
+				]),
+			),
+			http.post(`${GITHUB_API}/repos/${REPO}/pulls`, () =>
+				HttpResponse.json(null, { status: 400 }),
+			),
+		);
+
+		const result = await adapter.createChangeRequest(
+			REPO,
+			branchName("agent/issue-1"),
+			branchName("main"),
+			"Fix issue 1",
+			"Closes TEST-1",
+		);
+
+		expect(result).toEqual({
+			number: 3,
+			url: `https://github.com/${REPO}/pull/3`,
+		});
+	});
+});

--- a/server/code-hosts/__tests__/gitlab.integration.test.ts
+++ b/server/code-hosts/__tests__/gitlab.integration.test.ts
@@ -9,7 +9,6 @@ import { gitlabCodeHostAdapter } from "../gitlab.ts";
 const REPO = repoSlug("group/subgroup/project");
 const adapter = gitlabCodeHostAdapter(
 	createGitLabClient(gitlabToken("test-token"), { baseUrl: GITLAB_BASE_URL }),
-	GITLAB_BASE_URL,
 );
 
 describe("cloneUrl", () => {
@@ -24,7 +23,6 @@ describe("cloneUrl", () => {
 			createGitLabClient(gitlabToken("test-token"), {
 				baseUrl: GITLAB_BASE_URL,
 			}),
-			GITLAB_BASE_URL,
 			gitlabToken("token-with/special:chars"),
 		);
 

--- a/server/code-hosts/create-code-host.ts
+++ b/server/code-hosts/create-code-host.ts
@@ -1,0 +1,31 @@
+import type { Config } from "../config.ts";
+import { createGitHubClient } from "../github-client.ts";
+import { createGitLabClient } from "../gitlab-client.ts";
+import type { GitHubToken, GitLabToken } from "../types/brands.ts";
+import { githubCodeHostAdapter } from "./github.ts";
+import { gitlabCodeHostAdapter } from "./gitlab.ts";
+import type { CodeHostAdapter } from "./types.ts";
+
+export function createCodeHost(
+	codeHost: Config["code_host"],
+	tokens: { gitlab: GitLabToken | undefined; github: GitHubToken | undefined },
+): CodeHostAdapter {
+	switch (codeHost.kind) {
+		case "gitlab": {
+			if (!tokens.gitlab) {
+				throw new Error("GITLAB_TOKEN is required for GitLab code host");
+			}
+			const gitlab = createGitLabClient(tokens.gitlab, {
+				baseUrl: codeHost.base_url,
+			});
+			return gitlabCodeHostAdapter(gitlab, tokens.gitlab);
+		}
+		case "github": {
+			if (!tokens.github) {
+				throw new Error("GITHUB_TOKEN is required for GitHub code host");
+			}
+			const github = createGitHubClient(tokens.github);
+			return githubCodeHostAdapter(github, tokens.github);
+		}
+	}
+}

--- a/server/code-hosts/github.ts
+++ b/server/code-hosts/github.ts
@@ -1,0 +1,59 @@
+import type { GitHubClient } from "../github-client.ts";
+import { branchName, type GitHubToken } from "../types/brands.ts";
+import { decorateCodeHost } from "./decorator.ts";
+import type { ChangeRequest, CodeHostAdapter } from "./types.ts";
+
+export function githubCodeHostAdapter(
+	client: GitHubClient,
+	cloneToken?: GitHubToken,
+): CodeHostAdapter {
+	return decorateCodeHost({
+		async fetchFile(repo, path, ref): Promise<string | null> {
+			try {
+				const content = await client.getFileContent(repo, path, ref);
+				return Buffer.from(content.content, "base64").toString("utf-8");
+			} catch {
+				return null;
+			}
+		},
+
+		cloneUrl(repo): string {
+			if (!cloneToken) return `https://github.com/${repo}.git`;
+			// GitHub's documented PAT-over-HTTPS form: the literal username
+			// `x-access-token`, with the token in the password slot.
+			return `https://x-access-token:${encodeURIComponent(cloneToken)}@github.com/${repo}.git`;
+		},
+
+		async defaultBranch(repo) {
+			const project = await client.getRepo(repo);
+			return branchName(project.default_branch);
+		},
+
+		async createChangeRequest(
+			repo,
+			head,
+			base,
+			title,
+			body,
+		): Promise<ChangeRequest> {
+			const owner = repo.split("/")[0];
+			const [existing] = await client.listPullRequests(repo, {
+				head: `${owner}:${head}`,
+				base,
+				state: "open",
+			});
+
+			if (existing) {
+				return { number: existing.number, url: existing.html_url };
+			}
+
+			const pr = await client.createPullRequest(repo, {
+				title,
+				body,
+				head,
+				base,
+			});
+			return { number: pr.number, url: pr.html_url };
+		},
+	});
+}

--- a/server/code-hosts/gitlab.ts
+++ b/server/code-hosts/gitlab.ts
@@ -3,17 +3,10 @@ import { branchName, type GitLabToken } from "../types/brands.ts";
 import { decorateCodeHost } from "./decorator.ts";
 import type { ChangeRequest, CodeHostAdapter } from "./types.ts";
 
-function trimTrailingSlash(value: string): string {
-	return value.replace(/\/+$/, "");
-}
-
 export function gitlabCodeHostAdapter(
 	client: GitLabClient,
-	baseUrl = "https://gitlab.com",
 	cloneToken?: GitLabToken,
 ): CodeHostAdapter {
-	const cloneBaseUrl = trimTrailingSlash(baseUrl);
-
 	return decorateCodeHost({
 		async fetchFile(repo, path, ref): Promise<string | null> {
 			try {
@@ -25,7 +18,7 @@ export function gitlabCodeHostAdapter(
 		},
 
 		cloneUrl(repo): string {
-			const url = `${cloneBaseUrl}/${repo}.git`;
+			const url = `${client.baseUrl}/${repo}.git`;
 			if (!cloneToken) return url;
 			// Embed the token as HTTP basic auth so `git clone` (and later
 			// push/fetch from the same remote) authenticate to GitLab.

--- a/server/config.ts
+++ b/server/config.ts
@@ -16,11 +16,16 @@ export type Config = {
 			awaiting_review: string;
 		};
 	};
-	code_host: {
-		kind: "gitlab";
-		scopes: RepoSlug[];
-		base_url: string;
-	};
+	code_host:
+		| {
+				kind: "gitlab";
+				scopes: RepoSlug[];
+				base_url: string;
+		  }
+		| {
+				kind: "github";
+				scopes: RepoSlug[];
+		  };
 	defaults: {
 		polling_interval_ms: number;
 		max_concurrent: number;
@@ -56,6 +61,12 @@ const configSchema = z
 					kind: z.literal("gitlab"),
 					scopes: z.array(repoSlugSchema).min(1),
 					base_url: z.url(),
+				})
+				.strict(),
+			z
+				.object({
+					kind: z.literal("github"),
+					scopes: z.array(repoSlugSchema).min(1),
 				})
 				.strict(),
 		]),

--- a/server/env.ts
+++ b/server/env.ts
@@ -2,7 +2,9 @@ import "dotenv/config";
 import { z } from "zod";
 import type { Config } from "./config.ts";
 import {
+	type GitHubToken,
 	type GitLabToken,
+	githubToken,
 	gitlabToken,
 	type JiraApiToken,
 	type JiraEmail,
@@ -15,14 +17,19 @@ const envSchema = z.object({
 	PORT: z.coerce.number().default(3000),
 	LOG_LEVEL: z.string().default("info"),
 	GITLAB_TOKEN: z.string().optional(),
+	GITHUB_TOKEN: z.string().optional(),
 	JIRA_EMAIL: z.string().optional(),
 	JIRA_API_TOKEN: z.string().optional(),
 });
 
 type RawEnv = z.infer<typeof envSchema>;
 
-type Env = Omit<RawEnv, "GITLAB_TOKEN" | "JIRA_EMAIL" | "JIRA_API_TOKEN"> & {
+type Env = Omit<
+	RawEnv,
+	"GITLAB_TOKEN" | "GITHUB_TOKEN" | "JIRA_EMAIL" | "JIRA_API_TOKEN"
+> & {
 	GITLAB_TOKEN?: GitLabToken;
+	GITHUB_TOKEN?: GitHubToken;
 	JIRA_EMAIL?: JiraEmail;
 	JIRA_API_TOKEN?: JiraApiToken;
 };
@@ -32,6 +39,10 @@ export function loadEnv(config?: Pick<Config, "tracker" | "code_host">): Env {
 
 	if (config?.code_host.kind === "gitlab") {
 		requireToken(env, "GITLAB_TOKEN");
+	}
+
+	if (config?.code_host.kind === "github") {
+		requireToken(env, "GITHUB_TOKEN");
 	}
 
 	if (config?.tracker.kind === "jira") {
@@ -66,10 +77,12 @@ function requireToken(env: RawEnv, name: keyof RawEnv) {
 }
 
 function brandEnv(env: RawEnv): Env {
-	const { GITLAB_TOKEN, JIRA_EMAIL, JIRA_API_TOKEN, ...rest } = env;
+	const { GITLAB_TOKEN, GITHUB_TOKEN, JIRA_EMAIL, JIRA_API_TOKEN, ...rest } =
+		env;
 	return {
 		...rest,
 		...(GITLAB_TOKEN != null && { GITLAB_TOKEN: gitlabToken(GITLAB_TOKEN) }),
+		...(GITHUB_TOKEN != null && { GITHUB_TOKEN: githubToken(GITHUB_TOKEN) }),
 		...(JIRA_EMAIL != null && { JIRA_EMAIL: jiraEmail(JIRA_EMAIL) }),
 		...(JIRA_API_TOKEN != null && {
 			JIRA_API_TOKEN: jiraApiToken(JIRA_API_TOKEN),

--- a/server/github-client.ts
+++ b/server/github-client.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import { createJsonRequester, type HttpClientOptions } from "./http-client.ts";
+import type { BranchName, GitHubToken, RepoSlug } from "./types/brands.ts";
+
+const githubRepoSchema = z.object({
+	default_branch: z.string().min(1),
+});
+
+const githubContentSchema = z.object({
+	content: z.string(),
+});
+
+const githubPullRequestSchema = z.object({
+	number: z.number(),
+	html_url: z.string(),
+});
+
+export type GitHubClient = {
+	getRepo(repo: RepoSlug): Promise<{ default_branch: string }>;
+	getFileContent(
+		repo: RepoSlug,
+		path: string,
+		ref?: string,
+	): Promise<{ content: string }>;
+	listPullRequests(
+		repo: RepoSlug,
+		params: { head: string; base: BranchName; state: string },
+	): Promise<{ number: number; html_url: string }[]>;
+	createPullRequest(
+		repo: RepoSlug,
+		params: {
+			title: string;
+			body: string;
+			head: BranchName;
+			base: BranchName;
+		},
+	): Promise<{ number: number; html_url: string }>;
+};
+
+export function createGitHubClient(
+	token: GitHubToken,
+	options: HttpClientOptions = {},
+): GitHubClient {
+	const request = createJsonRequester({
+		...options,
+		baseUrl: BASE_URL,
+		serviceName: "GitHub",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			Accept: "application/vnd.github+json",
+			"X-GitHub-Api-Version": "2022-11-28",
+		},
+	});
+
+	return {
+		getRepo(repo) {
+			return request(`/repos/${repo}`, { schema: githubRepoSchema });
+		},
+
+		getFileContent(repo, path, ref) {
+			const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+			const query = ref ? `?ref=${encodeURIComponent(ref)}` : "";
+			return request(`/repos/${repo}/contents/${encodedPath}${query}`, {
+				schema: githubContentSchema,
+			});
+		},
+
+		listPullRequests(repo, params) {
+			const query = new URLSearchParams(params);
+			return request(`/repos/${repo}/pulls?${query}`, {
+				schema: z.array(githubPullRequestSchema),
+			});
+		},
+
+		createPullRequest(repo, params) {
+			return request(`/repos/${repo}/pulls`, {
+				method: "POST",
+				body: params,
+				schema: githubPullRequestSchema,
+			});
+		},
+	};
+}
+
+const BASE_URL = "https://api.github.com";

--- a/server/gitlab-client.ts
+++ b/server/gitlab-client.ts
@@ -16,6 +16,7 @@ const gitlabProjectSchema = z.object({
 });
 
 export type GitLabClient = {
+	baseUrl: string;
 	getProject(projectPath: RepoSlug): Promise<{ default_branch: string }>;
 	getFileContent(
 		projectPath: RepoSlug,
@@ -60,6 +61,7 @@ export function createGitLabClient(
 	});
 
 	return {
+		baseUrl,
 		getProject(projectPath) {
 			return request(`/projects/${encodeProjectPath(projectPath)}`, {
 				schema: gitlabProjectSchema,

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,11 +1,10 @@
 import { serve } from "@hono/node-server";
 import { createApi, type HealthCheck } from "./api/api.ts";
-import { gitlabCodeHostAdapter } from "./code-hosts/gitlab.ts";
+import { createCodeHost } from "./code-hosts/create-code-host.ts";
 import { loadConfig } from "./config.ts";
 import { closeDb, getDb } from "./db/db.ts";
 import { migrate } from "./db/migrate.ts";
 import { loadEnv } from "./env.ts";
-import { createGitLabClient } from "./gitlab-client.ts";
 import { createJiraClient } from "./jira-client.ts";
 import { logger } from "./logger.ts";
 import { createOrchestrator } from "./orchestrator/orchestrator.ts";
@@ -20,9 +19,6 @@ const env = loadEnv(config);
 
 if (!env.JIRA_EMAIL || !env.JIRA_API_TOKEN) {
 	throw new Error("JIRA_EMAIL and JIRA_API_TOKEN are required for Jira");
-}
-if (!env.GITLAB_TOKEN) {
-	throw new Error("GITLAB_TOKEN is required for GitLab code host");
 }
 
 const db = getDb();
@@ -41,14 +37,10 @@ const tracker = jiraTrackerAdapter(jira, {
 	triggerLabel: config.tracker.trigger_label,
 });
 
-const gitlab = createGitLabClient(env.GITLAB_TOKEN, {
-	baseUrl: config.code_host.base_url,
+const codeHost = createCodeHost(config.code_host, {
+	gitlab: env.GITLAB_TOKEN,
+	github: env.GITHUB_TOKEN,
 });
-const codeHost = gitlabCodeHostAdapter(
-	gitlab,
-	config.code_host.base_url,
-	env.GITLAB_TOKEN,
-);
 
 const repo = createRunRepository(db);
 

--- a/server/testing/support/fixtures.ts
+++ b/server/testing/support/fixtures.ts
@@ -32,6 +32,7 @@ export function adaptRunAgent(runAgent: LegacyRunAgent): AgentInvoker {
 
 export const GITLAB_BASE_URL = "https://gitlab.example.test";
 export const GITLAB_API = `${GITLAB_BASE_URL}/api/v4`;
+export const GITHUB_API = "https://api.github.com";
 export const JIRA_BASE_URL = "https://jira.example.test";
 export const JIRA_API = `${JIRA_BASE_URL}/rest/api/3`;
 export const JIRA_PROJECT = "TEST";

--- a/server/testing/support/test-orchestrator.ts
+++ b/server/testing/support/test-orchestrator.ts
@@ -74,11 +74,7 @@ export async function createTestOrchestrator(
 		baseUrl: GITLAB_BASE_URL,
 		maxAttempts: 1,
 	});
-	const defaultCodeHost = gitlabCodeHostAdapter(
-		gitlab,
-		GITLAB_BASE_URL,
-		gitlabCloneToken,
-	);
+	const defaultCodeHost = gitlabCodeHostAdapter(gitlab, gitlabCloneToken);
 
 	const agent = options.agent ?? adaptRunAgent(options.runAgent ?? noopAgent);
 

--- a/server/types/brands.ts
+++ b/server/types/brands.ts
@@ -22,6 +22,9 @@ export const runId = (value: string): RunId => value as RunId;
 export type GitLabToken = Brand<string, "GitLabToken">;
 export const gitlabToken = (value: string): GitLabToken => value as GitLabToken;
 
+export type GitHubToken = Brand<string, "GitHubToken">;
+export const githubToken = (value: string): GitHubToken => value as GitHubToken;
+
 export type JiraApiToken = Brand<string, "JiraApiToken">;
 export const jiraApiToken = (value: string): JiraApiToken =>
 	value as JiraApiToken;


### PR DESCRIPTION
## Summary

Re-introduces a GitHub code host adapter alongside the existing GitLab one so this repo can be worked on by `local-agents` itself. Same pattern as gitlab — a slim `github-client.ts` plus a `githubCodeHostAdapter` behind the unchanged `CodeHostAdapter` seam.

- `kind: github` added to the `code_host` discriminated union in config (no `base_url` — github.com only; GHE not in scope).
- `GITHUB_TOKEN` env handling, required only when the github variant is selected.
- New `server/code-hosts/create-code-host.ts` factory takes the narrowed config slice + a `{ gitlab, github }` token bag and switches exhaustively on `kind`. `server.ts` drops the per-host imports.
- GitLab adapter signature aligned with GitHub's `(client, cloneToken?)`. `GitLabClient` now exposes `baseUrl`; the adapter reads the clone host from the client instead of taking it as a separate arg (it was being threaded through twice).

## Tests

- `server/__tests__/github-client.integration.test.ts` — retry/exhaustion smoke (mirrors gitlab-client).
- `server/code-hosts/__tests__/github.integration.test.ts` — `cloneUrl` (with/without embedded token), `fetchFile` (path encoding + ref + 404), `defaultBranch`, `createChangeRequest` (new vs existing).
- No orchestrator-level GitHub tests: that layer is already pinned through gitlab; duplicating would re-test the orchestrator, not the adapter.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 270/270 passing
- [x] `pnpm lint`
- [x] `pnpm knip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)