### PR TITLE
docs: split architecture and configuration, drop legacy workflow tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,11 @@ LOG_LEVEL=info
 # Dashboard API port (default: 3000)
 # PORT=3000
 
-# GitLab Personal/Project/Group Access Token (required)
+# Code-host token. Set the one that matches `code_host.kind` in config.yaml.
 #
-# Needs API access to read repository files and create merge requests.
+# GitHub: needs `repo` scope to read repo contents and open pull requests.
+# GitLab: needs API access to read repo files and open merge requests.
+GITHUB_TOKEN=
 GITLAB_TOKEN=
 
 # Jira Cloud credentials (required)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 AI agents that run on your machine, triggered by issue trackers, powered by your Claude subscription.
 
-A polling orchestrator watches a configured repo for Jira issues in a configured status, creates an isolated workspace per issue, and runs a Claude agent to do the work. Currently the orchestrator supports Jira as the tracker and GitLab as the code host.
+A polling orchestrator watches Jira for triggered issues, resolves the target repo from each issue's `repo:` label, creates an isolated workspace, and runs a Claude agent to do the work. Jira is the supported tracker, and either GitHub or GitLab can be configured as the code host.
 
-See [docs/architecture.md](docs/architecture.md) for how it works and the full `config.yaml` and `workflow.yaml` schemas.
+- [docs/architecture.md](docs/architecture.md) — how the system works.
+- [docs/configuration.md](docs/configuration.md) — `config.yaml` and `workflow.yaml` reference.
 
 ## Setup
 
@@ -13,11 +14,11 @@ pnpm install
 cp .env.example .env
 ```
 
-Fill in `JIRA_EMAIL`, `JIRA_API_TOKEN`, and `GITLAB_TOKEN`.
+Fill in `JIRA_EMAIL`, `JIRA_API_TOKEN`, and either `GITHUB_TOKEN` or `GITLAB_TOKEN` to match the configured code host.
 
 The Agent SDK uses your existing Claude Code login automatically. Make sure you're logged into Claude Code with an active subscription.
 
-Edit `config.yaml` to point at your Jira project, your GitLab instance, and the target repo the orchestrator may clone and open merge requests against. Create `workflow.yaml` in the local-agents working directory to define the prompt, hooks, and branch naming. See [docs/architecture.md](docs/architecture.md) for the full schemas and examples.
+Edit `config.yaml` to point at your Jira project and the user or organisation scopes the orchestrator is allowed to clone from. Create `workflow.yaml` in the local-agents working directory to define branch naming, the steps the agent runs, and the change-request template. See [docs/configuration.md](docs/configuration.md) for the full schemas, and [`examples/`](examples) for ready-to-copy starting points.
 
 ## Running
 
@@ -27,18 +28,18 @@ pnpm dev
 
 This starts:
 
-- **Orchestrator** on `http://localhost:3000` — polls Jira, runs agents, serves API
-- **Dashboard** on `http://localhost:5173` — live monitoring via SSE
+- **Orchestrator** on `http://localhost:3000`. Polls Jira, runs agents, and serves the API.
+- **Dashboard** on `http://localhost:5173`. Live monitoring over SSE.
 
 ## Creating Work
 
-Move (or create) a Jira issue into the configured `pending` status. The orchestrator picks it up on the next tick (default: 30 seconds), clones the repo, runs the agent, and pushes a branch with a merge request. Transition the issue out of `pending` (or close it) to stop the agent.
+Add the configured `tracker.trigger_label` (for example `local-agents`) to a Jira issue, attach a `repo:<scope>/<name>` label that points at one of your configured code-host scopes, and move it into the configured `pending` status. The orchestrator picks it up on the next tick (default: 30 seconds), clones the repo, runs the workflow, and pushes a branch with a pull or merge request. Transition the issue out of `pending` (or close it) to stop the agent.
 
 The fastest way to create or transition issues:
 
-- **Jira web UI** — universal, no setup.
-- **Atlassian MCP** — if you're driving from Claude Code, install the Atlassian MCP server and ask Claude to create or transition issues directly.
-- **`jira` CLI** — Atlassian's official CLI if you'd rather stay in the terminal.
+- **Jira web UI.** Universal, no setup.
+- **Atlassian MCP.** If you're driving from Claude Code, install the Atlassian MCP server and ask Claude to create or transition issues directly.
+- **`jira` CLI.** Atlassian's official CLI if you'd rather stay in the terminal.
 
 Jira issue keys use native Jira format, for example `PROJ-42`.
 
@@ -46,11 +47,11 @@ Jira issue keys use native Jira format, for example `PROJ-42`.
 
 The dashboard shows all agent runs in real-time:
 
-- Live connection status via SSE
-- Runs grouped by agent with issue key and title
-- Drill into run details to see tool use activity
-- Kill running agents
-- Dark/light theme
+- Live connection status over SSE.
+- Runs grouped by agent, with issue key and title.
+- Drill into a run to see tool-use activity.
+- Kill running agents.
+- Dark and light themes.
 
 ## Requirements
 
@@ -58,4 +59,4 @@ The dashboard shows all agent runs in real-time:
 - pnpm
 - Claude Code (logged in with active subscription)
 - `JIRA_EMAIL` and `JIRA_API_TOKEN`
-- `GITLAB_TOKEN`
+- `GITHUB_TOKEN` or `GITLAB_TOKEN`, depending on the configured code host

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,8 @@
 # Architecture
 
-A polling orchestrator watches multiple repos for labelled issues, merges them into an oldest-first queue, creates isolated workspaces, and runs Claude agents powered by your existing Claude Code subscription.
+A polling orchestrator watches an issue tracker for triggered issues, resolves the target repo, creates an isolated workspace, and runs Claude agents through your existing Claude Code subscription.
+
+For configuration reference, see [configuration.md](configuration.md).
 
 ```
 Issue Tracker (Jira)
@@ -9,177 +11,118 @@ Issue Tracker (Jira)
 Polling Orchestrator (tick every N seconds)
         │
         ▼
-Fetch All Repos → Merge → Sort oldest first
+Fetch active issues → Resolve repo from labels → Sort oldest first
         │
         ▼
-State transition → Create Workspace (git clone) → Run Agent
+Clone workspace → Resolve branch → Run workflow steps
         │
         ▼
 Claude Agent SDK (query)
         │
         ▼
-Push Result (commits, branches, PRs/MRs)
+Push branch → Open change request → Transition tracker
 ```
 
-The issue tracker is the orchestration layer. Polling means the orchestrator is resilient to downtime (it catches up on the next tick), works behind NATs and firewalls, and needs nothing exposed publicly.
+The issue tracker is the orchestration layer. Polling means the orchestrator catches up on its next tick after downtime, runs behind NATs and firewalls, and exposes nothing publicly.
 
-## How It Works
+## Components
 
-### 1. Central Config
+The orchestrator is one process composed of a few cooperating pieces.
 
-A `config.yaml` defines one tracker (Jira), one code host (GitLab), the
-code-host repo list, and operational settings. Every field below is required
-— the parser does not fall back to defaults, so misconfiguration fails loudly
-at startup. Jira tracking maps logical orchestrator states to Jira status
-names; set the `statuses` block to whatever your Jira project uses. Because
-Jira issues do not identify a code repo, Jira mode requires exactly one
-configured code-host repo. `code_host.base_url` is required so self-hosted
-GitLab instances do not silently target `gitlab.com`.
+- **Tracker adapter.** Fetches active issues for a logical state, transitions issue state, and marks issues as failed. Jira is the implemented adapter today.
+- **Code-host adapter.** Resolves clone URLs and default branches, and creates the change request. GitHub and GitLab are both implemented.
+- **Orchestrator loop.** Ticks on an interval, decides which issues to dispatch, and reconciles tracker state against in-flight work.
+- **Run lifecycle.** Owns a single issue's run from clone through tracker transition. Pins lifecycle actions at fixed points around the workflow steps.
+- **Runner.** Bounded concurrency pool that owns the run handle, abort signal, and step events for the dashboard.
+- **Workflow engine.** Loads and validates `workflow.yaml`, renders prompts with issue and step-output context, expands trusted shell blocks, and invokes the Claude Agent SDK for each step.
+- **Run repository.** SQLite-backed store for run history that survives restarts.
+- **Dashboard API.** Streams run and step events over SSE so the dashboard can show live activity.
 
-```yaml
-tracker:
-  kind: jira
-  base_url: https://yourco.atlassian.net
-  project: PROJ
-  statuses:
-    pending: "Backlog"
-    running: "Doing"
-    awaiting_review: "Code Review"
+## The Orchestrator Loop
 
-code_host:
-  kind: gitlab
-  base_url: https://gitlab.example.com
-  repos:
-    - group/project
+Each tick proceeds through five steps.
 
-defaults:
-  polling_interval_ms: 30000
-  max_concurrent: 2
-  max_retries: 3
-  model: claude-sonnet-4-6
-  workspace_root: /tmp/local-agent-workspaces
+1. **Fetch** Jira issues whose status maps to `pending` and which carry the configured `trigger_label`.
+2. **Resolve repo** from each issue's `repo:<scope>/<name>` label. Issues without a recognised label are dropped with a logged reason.
+3. **Sort** oldest first so issues from different repos compete fairly.
+4. **Reconcile.** If a previously running issue is no longer active in the tracker, kill its run.
+5. **Dispatch.** For each unclaimed pending issue, up to `max_concurrent`, transition it to `running`, ensure the workspace exists, and start the workflow.
+
+A single tick is serial against itself: a new tick will not start until the previous one finishes. Dispatched runs continue in the background between ticks.
+
+### Logical Tracker State
+
+The orchestrator works in three logical states. The Jira adapter maps each state onto the configured Jira status name, so the orchestrator never has to know about specific Jira status strings.
+
+| Logical state     | Example Jira status |
+|-------------------|---------------------|
+| `pending`         | `To Do`             |
+| `running`         | `In Progress`       |
+| `awaiting_review` | `In Review`         |
+
+This keeps the tracker as the single source of truth for what work exists and what state it is in.
+
+### Reconciliation
+
+The orchestrator detects when issues are closed or moved out of an active state and kills the corresponding run. Only repos whose issues were successfully fetched are considered for reconciliation, so transient fetch failures do not kill active runs.
+
+## The Run Lifecycle
+
+Once an issue is dispatched, its run goes through a fixed sequence. Each box below corresponds to a pinned lifecycle action; the workflow steps run inside the middle box.
+
+```
+clone → resolve branch → checkout → repo bootstrap → [ workflow steps ] → push → change request → tracker transition
 ```
 
-### 2. Global Workflow
+### Workspaces
 
-The local-agents working directory contains one `workflow.yaml` with hooks and
-the prompt. The same workflow is used for every configured repo. `branch` and
-`base_branch` are required:
+Each issue gets an isolated workspace under `defaults.workspace_root`. The orchestrator clones the repo into it, resolves the branch (either by template or by running the branch-naming agent), checks the branch out, and runs `.agent/setup.sh` from the cloned repo if one is present. Workflow files do not contain `pnpm install` or codegen warm-ups themselves, since the same workflow targets repos with different toolchains. Repo-side bootstrap belongs to the repo.
 
-```yaml
-branch: "agent/issue-{{ issue.number }}"
-base_branch: main
+A failing run keeps its workspace on disk so the work can be inspected. A fully successful run removes its workspace afterwards. Success here means every step succeeded, the branch was pushed, the change request was opened, and the tracker transition went through.
 
-hooks:
-  after_create: |
-    git checkout -b agent/issue-{{ issue.number }}
-  before_run: |
-    git fetch origin main && git rebase origin/main
-  after_run: |
-    git push -u origin agent/issue-{{ issue.number }}
+### Fixed Lifecycle Pins
 
-prompt: |
-  You are working on: {{ issue.key }} - {{ issue.title }}
-  {{ issue.description }}
-```
+Step outputs are pure typed data. They flow into later step prompts and into the `change_request` template, but they never reorder when the orchestrator does anything. Lifecycle actions fire at fixed pins instead, with the pinned order recorded in [ADR 0001](adr/0001-phase-outputs-and-fixed-lifecycle.md).
 
-Hooks must use plain git commands, not platform-specific CLI tools. The orchestrator handles cloning via `git clone` before the `after_create` hook runs.
+1. Run all workflow steps to completion.
+2. `git push --force` the branch to origin.
+3. Open the change request through the code-host adapter, using the rendered `change_request` template.
+4. Transition the tracker issue from `running` to `awaiting_review`.
 
-Workflows define exactly one of `prompt` or `phases`. Multi-phase workflows run
-ordered prompts in one dispatch. By default each phase starts a fresh Claude
-session; a phase can set `resume_previous: true` to resume the previous phase's
-session:
+If any of these fail, the run is marked failed, the workspace is preserved, and the tracker issue is moved to a failed state through the adapter rather than left in `running`.
 
-```yaml
-phases:
-  - name: plan
-    prompt: |
-      Analyze {{ issue.key }} and write PLAN.md.
+### The Agent
 
-  - name: implement
-    resume_previous: true
-    prompt: |
-      Implement PLAN.md.
-      !`test -f PLAN.md`
-```
+Each workflow step runs through `query()` from the Claude Agent SDK with full tool access. Prompts are rendered from the workflow template with issue and step-output context, then any trusted shell blocks are expanded against the workspace before the prompt reaches the SDK. By default each step starts a fresh Claude session; a step can resume the previous step's session if the workflow asks for it. A step can also force a JSON-Schema-shaped output, which the orchestrator stores under `steps.<name>.output` for use by later prompts and the change-request template.
 
-Shell blocks written in workflow prompts with `` !`command` `` run in the
-workspace after template rendering and before the Claude Agent SDK receives the
-prompt. Stdout replaces the block. Non-zero exit, timeout, signal termination,
-spawn failure, or output overflow fails the run. Issue fields cannot inject
-executable shell blocks because only blocks authored in the raw workflow
-template are marked for execution.
-
-### 3. The Orchestrator Loop
-
-Each tick:
-
-1. **Fetch** active issues from all configured repos (concurrent)
-2. **Merge** all issues into a single list, sorted oldest-first for cross-repo fairness
-3. **Reconcile** — if a previously running issue is no longer active, kill the run
-4. **Dispatch** — for each unclaimed issue (up to `max_concurrent`), transition it to `running`, create a workspace, and start a Claude agent
-
-### 4. Logical Tracker State
-
-The orchestrator tracks work through logical states and lets each tracker
-adapter map those states to platform-specific labels or statuses:
-
-| Logical state | Default Jira status |
-|---|---|
-| `pending` | `To Do` |
-| `running` | `In Progress` |
-| `awaiting_review` | `In Review` |
-
-This keeps the issue tracker as the single source of truth for what's happening
-without making the orchestrator know Jira status strings.
-
-Jira issue keys use native Jira format, for example `PROJ-42`.
-
-### 5. Workflow Loading
-
-The orchestrator loads `./workflow.yaml` once from the local-agents working
-directory at startup. Restart the orchestrator to pick up workflow changes.
-
-### 6. Workspaces And Hooks
-
-Each issue gets an isolated workspace directory. The orchestrator runs `git clone` to set up the workspace, then executes lifecycle hooks:
-
-- `after_create` — runs once when workspace is first created (e.g. create a branch)
-- `before_run` — runs before each agent execution (e.g. fetch latest, rebase)
-- `after_run` — runs after agent completes (e.g. push the branch)
-
-### 7. The Agent
-
-Uses `query()` from the Claude Agent SDK with full tool access. Each prompt or
-phase prompt is rendered from the workflow template with issue context injected
-via `{{ variable.path }}` interpolation, then shell-expanded if it contains
-trusted shell blocks.
-
-Retries skip previously completed phases and resume from the failed phase when
-the previous in-flight session ID is available.
-
-### 8. Reconciliation
-
-The orchestrator detects when issues are closed or resolved and kills the corresponding agent run. Only repos whose issues were successfully fetched are considered for reconciliation, so transient fetch failures do not kill active runs.
+The full template-language and step-options reference lives in [configuration.md](configuration.md).
 
 ## Adapter Interfaces
 
-The system uses two adapter interfaces to stay decoupled from any specific platform:
+The system uses two adapters to stay decoupled from any specific platform.
 
-- **TrackerAdapter** — fetches active issues from a tracker and manages label state
-- **CodeHostAdapter** — fetches files from repos, generates clone URLs, and creates pull requests or merge requests
+- **TrackerAdapter** fetches active issues, transitions issue state, and marks issues as failed.
+- **CodeHostAdapter** resolves clone URLs and default branches, and creates the change request.
 
-Jira is implemented as a tracker. GitLab is implemented as a code host.
-Adding support for another platform means implementing the relevant adapter
-interface.
+Adding another platform means writing the relevant adapter and wiring it into the config-driven factory. The orchestrator itself stays unchanged.
+
+## Recovery
+
+When the process restarts, any runs that were in flight at shutdown are dead. The orchestrator runs a recovery pass before its first tick:
+
+- Runs marked `running` in the run repository are failed with a "stale run" reason.
+- Tracker issues stuck in the `running` state are pushed back to `pending` so the next tick re-dispatches them.
+
+This makes restarting safe. Anything mid-flight is rerun cleanly rather than left orphaned.
 
 ## Design Principles
 
-- **Issue tracker as orchestration** — no separate task queue or job system. The tracker is the source of truth for what work exists and what state it's in.
-- **Multi-repo, single orchestrator** — one process polls all configured repos with a shared concurrency pool, keeping deployment and configuration simple.
-- **Cross-repo fairness** — issues are merged into a single queue so no repo starves another.
-- **Narrow scope** — each agent works on one issue at a time in an isolated workspace.
-- **Codebase as context** — agents discover what they need by reading the repo, not from configuration passed to them.
-- **Disposable work environments** — clone fresh, work in /tmp, clean up after.
-- **Same toolchain as engineers** — agents run tests, hooks, and linters the same way you would.
-- **Plain git hooks** — no platform-specific commands in repo workflows, keeping them portable across code hosts.
+- **Issue tracker as orchestration.** No separate task queue or job system. The tracker is the source of truth for what work exists.
+- **Multi-repo, single orchestrator.** One process polls the configured tracker and dispatches across all in-scope repos with a shared concurrency pool.
+- **Cross-repo fairness.** Issues are merged into a single oldest-first queue so no repo starves another.
+- **Narrow scope.** Each agent works on one issue at a time in an isolated workspace.
+- **Codebase as context.** Agents discover what they need by reading the repo, not from configuration passed to them.
+- **Disposable work environments.** Clone fresh, work in `/tmp`, clean up after a fully successful run.
+- **Same toolchain as engineers.** Agents run tests, linters, and the repo's own bootstrap the same way you would.
+- **Repo-owned bootstrap.** `.agent/setup.sh` lives in the target repo so workflows stay portable.
+- **Orchestrator-owned lifecycle.** Push, change-request creation, and tracker transitions fire at fixed pins, not at points the workflow author has to choose.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,300 @@
+# Configuration Reference
+
+Canonical reference for the two YAML files the orchestrator reads at startup. For how the system actually runs, see [architecture.md](architecture.md).
+
+- `config.yaml` defines the tracker, the code host, and operational defaults.
+- `workflow.yaml` defines the branch, the steps the agent runs, and the change-request template.
+
+Both files are validated by Zod schemas at startup. Unknown fields, missing fields, and type mismatches all fail loudly before the orchestrator opens any sockets.
+
+## Sections
+
+- [`config.yaml`](#configyaml)
+- [`workflow.yaml`](#workflowyaml)
+- [Template language](#template-language)
+- [Shell blocks](#shell-blocks)
+- [Repo-side bootstrap](#repo-side-bootstrap)
+
+---
+
+## `config.yaml`
+
+```yaml
+tracker:
+  kind: jira
+  base_url: https://yourco.atlassian.net
+  project: PROJ
+  trigger_label: local-agents
+  statuses:
+    pending: "To Do"
+    running: "In Progress"
+    awaiting_review: "In Review"
+
+code_host:
+  kind: github
+  scopes:
+    - acme
+
+defaults:
+  polling_interval_ms: 30000
+  max_concurrent: 2
+  model: claude-sonnet-4-6
+  workspace_root: /tmp/local-agent-workspaces
+```
+
+### `tracker`
+
+Jira is the supported tracker.
+
+| Field            | Type   | Description |
+|------------------|--------|-------------|
+| `kind`           | string | Must be `jira`. |
+| `base_url`       | URL    | Your Jira Cloud base URL, for example `https://yourco.atlassian.net`. |
+| `project`        | string | Jira project key, for example `PROJ`. |
+| `trigger_label`  | string | Issues without this label are ignored. Used to opt issues into the orchestrator. |
+| `statuses`       | object | Maps the three logical states onto your project's Jira status names. All three are required. |
+
+Logical states: `pending`, `running`, `awaiting_review`. The orchestrator does not assume any particular Jira status names; whatever you put on the right-hand side is what it queries for and transitions to.
+
+### `code_host`
+
+A discriminated union on `kind`. Configure exactly one.
+
+#### GitHub
+
+```yaml
+code_host:
+  kind: github
+  scopes:
+    - acme
+```
+
+| Field    | Type     | Description |
+|----------|----------|-------------|
+| `kind`   | string   | Must be `github`. |
+| `scopes` | string[] | List of GitHub user or organisation slugs the orchestrator may clone from. |
+
+#### GitLab
+
+```yaml
+code_host:
+  kind: gitlab
+  base_url: https://gitlab.example.com
+  scopes:
+    - widgets
+```
+
+| Field      | Type     | Description |
+|------------|----------|-------------|
+| `kind`     | string   | Must be `gitlab`. |
+| `base_url` | URL      | GitLab base URL. Required even on `gitlab.com` so self-hosted instances are explicit. |
+| `scopes`   | string[] | List of group or user paths the orchestrator may clone from. |
+
+`scopes` controls which `repo:<scope>/<name>` labels the orchestrator will accept. A scope of `acme` matches `repo:acme/widgets`, `repo:acme/anvils`, and so on. Any label whose path does not start with one of the configured scopes is dropped with a logged reason.
+
+### `defaults`
+
+Operational settings shared across all runs.
+
+| Field                  | Type    | Description |
+|------------------------|---------|-------------|
+| `polling_interval_ms`  | integer | How often the orchestrator ticks. |
+| `max_concurrent`       | integer | Maximum number of runs in flight at once across all repos. |
+| `model`                | string  | Default Claude model ID for steps. Steps may override this individually. |
+| `workspace_root`       | string  | Filesystem path where per-issue workspaces are created. |
+
+### Environment
+
+Tokens and credentials live in `.env`, not in `config.yaml`. The orchestrator validates them on the basis of the configured `kind` values:
+
+- `JIRA_EMAIL` and `JIRA_API_TOKEN` are required.
+- `GITHUB_TOKEN` is required when `code_host.kind` is `github`.
+- `GITLAB_TOKEN` is required when `code_host.kind` is `gitlab`.
+
+---
+
+## `workflow.yaml`
+
+The orchestrator loads `./workflow.yaml` once at startup. Restart the orchestrator to pick up workflow changes. The same workflow is used for every dispatched issue regardless of target repo, which is why repo-specific concerns belong in the repo rather than here.
+
+A workflow has exactly three top-level fields:
+
+```yaml
+branch: ...           # how the run's branch is named
+steps:                # ordered list of agent prompts
+  - name: ...
+    prompt: ...
+change_request:       # title and body for the resulting PR/MR
+  title: ...
+  body: ...
+```
+
+### `branch`
+
+`branch` is a first-class field because it is the one lifecycle action whose timing is structurally constrained: a branch must exist before any step writes commits. See [ADR 0001](adr/0001-phase-outputs-and-fixed-lifecycle.md) for the reasoning.
+
+It can take one of two forms.
+
+#### Static template
+
+```yaml
+branch: "agent/issue-{{ issue.number }}"
+```
+
+A non-empty string, with the [template language](#template-language) available.
+
+#### Branch-naming agent
+
+```yaml
+branch:
+  prompt: |
+    Propose a branch name for issue {{ issue.key }}: {{ issue.title }}.
+    Use kebab-case under a `<type>/` prefix.
+  schema:
+    type: object
+    properties:
+      name:
+        type: string
+        pattern: "^(feat|fix|chore|docs|refactor|test)/[A-Z]+-[0-9]+-[a-z0-9-]+$"
+    required: [name]
+```
+
+| Field    | Type    | Description |
+|----------|---------|-------------|
+| `prompt` | string  | Template rendered against `issue.*`. The branch agent runs at clone time, before any step. |
+| `schema` | object  | JSON Schema the agent's structured output must satisfy. Validated by the SDK; the orchestrator reads `name` from the result. |
+
+The resolved branch name is exposed to later prompts and to `change_request` as `{{ branch }}`.
+
+### `steps`
+
+A non-empty ordered array of step objects. Steps run sequentially.
+
+```yaml
+steps:
+  - name: implement
+    prompt: |
+      Work on {{ issue.key }}: {{ issue.title }}.
+```
+
+| Field             | Type    | Default | Description |
+|-------------------|---------|---------|-------------|
+| `name`            | string  | —       | Identifier for the step. Letters, digits, underscores. Used in output references and event logs. |
+| `prompt`          | string  | —       | Prompt template, rendered against the [available variables](#template-language). |
+| `resume_previous` | boolean | `false` | When `true`, resume the previous step's Claude session instead of starting fresh. |
+| `output_schema`   | object  | —       | JSON Schema the step's structured output must satisfy. When set, the parsed output is stored under `steps.<name>.output`. |
+| `model`           | string  | inherits `defaults.model` | Override the model for this step. |
+
+#### Resuming a session
+
+```yaml
+steps:
+  - name: plan
+    prompt: |
+      Analyse {{ issue.key }} and write PLAN.md.
+
+  - name: implement
+    resume_previous: true
+    prompt: |
+      Now implement PLAN.md.
+```
+
+`resume_previous: true` keeps the conversational context between the two steps. Without it, each step is a clean session.
+
+#### Capturing structured output
+
+```yaml
+steps:
+  - name: summarise
+    prompt: |
+      Summarise the changes on `{{ branch }}` for reviewers.
+    output_schema:
+      type: object
+      properties:
+        title: { type: string }
+        body: { type: string }
+      required: [title, body]
+```
+
+Outputs are referenced as `{{ steps.<name>.output.<path> }}`. Object values are serialised with `JSON.stringify`; scalars are inserted directly.
+
+#### Per-step model
+
+```yaml
+steps:
+  - name: implement
+    prompt: ...
+
+  - name: review
+    model: claude-opus-4-7
+    prompt: ...
+```
+
+Useful when you want a stronger model for a specific step (e.g. review or summarisation) while keeping the cheaper default elsewhere.
+
+### `change_request`
+
+```yaml
+change_request:
+  title: "{{ steps.summarise.output.title }}"
+  body: |
+    Closes {{ issue.key }}: {{ issue.title }}.
+
+    {{ steps.summarise.output.body }}
+```
+
+| Field   | Type   | Description |
+|---------|--------|-------------|
+| `title` | string | Title template for the pull or merge request. |
+| `body`  | string | Body template. |
+
+Both are required. Both have the full [template language](#template-language) available, including step outputs and `{{ branch }}`.
+
+---
+
+## Template language
+
+Prompts, branch templates, and the change-request template all share a small mustache-style interpolation. References take the form `{{ variable.path }}` with optional whitespace.
+
+Available variables:
+
+- `issue.*`: tracker fields. `key`, `number`, `title`, `description`, `labels`, `url`, `createdAt`. Arrays are joined with `, ` when interpolated.
+- `branch`: the resolved working branch for this run.
+- `base_branch`: the repo's default branch, supplied by the code-host adapter.
+- `steps.<name>.output.<path>`: outputs produced by earlier steps that declare an `output_schema`. Object values are serialised with `JSON.stringify`; scalars are inserted directly. Nested paths drill into the JSON object.
+
+Unknown paths render as the empty string. Templates inside step outputs are rendered as plain text rather than re-substituted, so an output value that happens to contain `{{ ... }}` will not trigger another substitution pass.
+
+---
+
+## Shell blocks
+
+A prompt may include shell expansions written as `` !`command` ``. They run in the workspace after template rendering and before the prompt reaches the Claude Agent SDK. Stdout replaces the block.
+
+```yaml
+steps:
+  - name: review
+    prompt: |
+      <diff>
+      !`git diff origin/{{ base_branch }}...HEAD`
+      </diff>
+```
+
+A run fails immediately if any shell block exits non-zero, times out, is killed by a signal, fails to spawn, or overflows its output buffer.
+
+Only blocks that exist in the raw workflow template are marked for execution. Issue fields, branch values, and step outputs interpolated through `{{ ... }}` are inert even if they contain `` !`...` `` syntax, so untrusted text cannot inject executable commands.
+
+---
+
+## Repo-side bootstrap
+
+Workflow files stay repo-agnostic, so any bootstrap that depends on a repo's toolchain belongs in the repo itself. The orchestrator runs `.agent/setup.sh` from the cloned repo if one is present, after the branch is checked out and before the first step runs. A typical script installs dependencies and warms up codegen:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+pnpm install --frozen-lockfile
+pnpm codegen
+```
+
+If the script is missing, that step is skipped silently. If it exists and fails, the run fails before any step runs.

--- a/server/workflow/__tests__/workflow.test.ts
+++ b/server/workflow/__tests__/workflow.test.ts
@@ -178,39 +178,6 @@ change_request:
 		expect(() => parseRepoWorkflow(yaml)).toThrow();
 	});
 
-	it("rejects the legacy top-level prompt form", () => {
-		const yaml = `
-branch: my-branch
-prompt: Fix this issue
-`;
-
-		expect(() => parseRepoWorkflow(yaml)).toThrow();
-	});
-
-	it("rejects the legacy phases key", () => {
-		const yaml = `
-branch: my-branch
-phases:
-  - name: plan
-    prompt: Write a plan
-`;
-
-		expect(() => parseRepoWorkflow(yaml)).toThrow();
-	});
-
-	it("rejects the legacy hooks block", () => {
-		const yaml = `
-branch: my-branch
-hooks:
-  before_run: echo hi
-steps:
-  - name: implement
-    prompt: Fix it
-`;
-
-		expect(() => parseRepoWorkflow(yaml)).toThrow();
-	});
-
 	it("rejects unknown step keys", () => {
 		const yaml = `
 branch: my-branch


### PR DESCRIPTION
## Summary

- Rewrite `docs/architecture.md` so it actually describes the architecture: components, the orchestrator tick, the run lifecycle and its fixed pins, recovery, and the design principles. No schema walk-through, no per-host setup notes.
- Add `docs/configuration.md` as the canonical reference for `config.yaml` and `workflow.yaml`. Covers GitHub vs GitLab forms, the full `branch` / `steps` / `change_request` surface, the template language, shell blocks, and `.agent/setup.sh`.
- Refresh `README.md` and `.env.example` to reflect that either GitHub or GitLab can be the code host, drop dead references to workflow `hooks`, and link both new docs.
- Remove the legacy-rejection cases from `server/workflow/__tests__/workflow.test.ts`. The schema is `.strict()` and the project carries no backwards-compat surface, so testing rejection of removed shapes was busy work.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (267 tests pass)
- [ ] Reviewer eyeballs the rendered docs on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)