### PR TITLE
chore: add dependabot, wire knip and commitlint into CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      prod-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,23 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm typecheck
+      - run: pnpm knip
+
+  commitlint:
+    name: Commitlint
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
   test:
     name: Test


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` with weekly npm + github-actions updates, grouped dev/prod minor+patch PRs, conventional `chore` prefix so commitlint passes on dependabot PRs.
- Run `pnpm knip` in the existing quality job so the unused-export check actually gates merges.
- Add a `commitlint` job that runs on pull requests and validates every commit in the PR range against `commitlint.config.ts`.

## Test plan

- [x] `pnpm knip` passes locally
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test:coverage` all green (via pre-push hook)
- [ ] CI runs all three jobs (`quality`, `commitlint`, `test`) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)