### PR TITLE
chore: allow deps and deps-dev scopes in commitlint

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -2,6 +2,10 @@ export default {
 	extends: ["@commitlint/config-conventional"],
 	rules: {
 		"scope-empty": [0], // scope is optional
-		"scope-enum": [2, "always", ["server", "dashboard", "docs"]],
+		"scope-enum": [
+			2,
+			"always",
+			["server", "dashboard", "docs", "deps", "deps-dev"],
+		],
 	},
 };


### PR DESCRIPTION
## Summary
- Add `deps` and `deps-dev` to the commitlint `scope-enum` so dependabot PRs stop failing the Commitlint check.

## Test plan
- [ ] Commitlint job passes on this PR
- [ ] After merge, rebase open dependabot PRs (#79–#86) and confirm Commitlint goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)