### PR TITLE
refactor: remove avoidable biome ignores

### DIFF
--- a/server/orchestrator/__tests__/branch-resolver.test.ts
+++ b/server/orchestrator/__tests__/branch-resolver.test.ts
@@ -140,11 +140,10 @@ describe("resolveBranch", () => {
 			yield {
 				type: "assistant",
 				session_id: "sess",
-				// biome-ignore lint/suspicious/noExplicitAny: decouple from SDK shape
-				message: { content: [] } as any,
+				message: { content: [] },
 				parent_tool_use_id: null,
 				uuid: "00000000-0000-0000-0000-000000000040",
-			} as AgentMessage;
+			} as unknown as AgentMessage;
 		});
 
 		await expect(

--- a/server/orchestrator/__tests__/step-runner.test.ts
+++ b/server/orchestrator/__tests__/step-runner.test.ts
@@ -129,11 +129,10 @@ async function* yieldAssistant(sessionId: string): AsyncIterable<AgentMessage> {
 	yield {
 		type: "assistant",
 		session_id: sessionId,
-		// biome-ignore lint/suspicious/noExplicitAny: decouple from SDK shape
-		message: { content: [] } as any,
+		message: { content: [] },
 		parent_tool_use_id: null,
 		uuid: "00000000-0000-0000-0000-000000000010",
-	} as AgentMessage;
+	} as unknown as AgentMessage;
 }
 
 describe("runWorkflowSteps", () => {
@@ -168,11 +167,10 @@ describe("runWorkflowSteps", () => {
 			yield {
 				type: "assistant",
 				session_id: "sess",
-				// biome-ignore lint/suspicious/noExplicitAny: decouple from SDK shape
-				message: { content: [] } as any,
+				message: { content: [] },
 				parent_tool_use_id: null,
 				uuid: "00000000-0000-0000-0000-000000000010",
-			} as AgentMessage;
+			} as unknown as AgentMessage;
 			yield {
 				type: "result",
 				subtype: "success",
@@ -392,11 +390,10 @@ describe("runWorkflowSteps", () => {
 			yield {
 				type: "assistant",
 				session_id: "sess",
-				// biome-ignore lint/suspicious/noExplicitAny: decouple from SDK shape
-				message: { content: [] } as any,
+				message: { content: [] },
 				parent_tool_use_id: null,
 				uuid: "00000000-0000-0000-0000-000000000050",
-			} as AgentMessage;
+			} as unknown as AgentMessage;
 			yield {
 				type: "result",
 				subtype: "success",

--- a/server/runner/queue.ts
+++ b/server/runner/queue.ts
@@ -31,9 +31,9 @@ export function createJobQueue(config: QueueConfig = {}): JobQueue {
 	}
 
 	function drain(): void {
-		while (running < maxConcurrency && pending.length > 0) {
-			// biome-ignore lint/style/noNonNullAssertion: while loop guarantees pending.length > 0
-			const execute = pending.shift()!;
+		while (running < maxConcurrency) {
+			const execute = pending.shift();
+			if (!execute) return;
 			running++;
 			execute().finally(() => {
 				running--;

--- a/server/workflow/prompt-preprocessor.ts
+++ b/server/workflow/prompt-preprocessor.ts
@@ -64,6 +64,11 @@ async function runShellBlock(
 			cwd,
 			stdio: ["ignore", "pipe", "pipe"],
 		});
+		const { stdout: childStdout, stderr: childStderr } = child;
+		/* v8 ignore next 3 -- unreachable; stdio: ["ignore", "pipe", "pipe"] guarantees both streams */
+		if (!childStdout || !childStderr) {
+			throw new Error("Invariant: spawned child missing piped stdout/stderr");
+		}
 
 		let stdout = "";
 		let stderr = "";
@@ -85,10 +90,8 @@ async function runShellBlock(
 			);
 		}, timeoutMs);
 
-		// biome-ignore lint/style/noNonNullAssertion: stdout is present because stdio is configured as "pipe"
-		child.stdout!.setEncoding("utf8");
-		// biome-ignore lint/style/noNonNullAssertion: stdout is present because stdio is configured as "pipe"
-		child.stdout!.on("data", (chunk: string) => {
+		childStdout.setEncoding("utf8");
+		childStdout.on("data", (chunk: string) => {
 			stdout += chunk;
 			if (stdout.length + stderr.length > SHELL_EXPANSION_MAX_BUFFER) {
 				fail(
@@ -103,10 +106,8 @@ async function runShellBlock(
 			}
 		});
 
-		// biome-ignore lint/style/noNonNullAssertion: stderr is present because stdio is configured as "pipe"
-		child.stderr!.setEncoding("utf8");
-		// biome-ignore lint/style/noNonNullAssertion: stderr is present because stdio is configured as "pipe"
-		child.stderr!.on("data", (chunk: string) => {
+		childStderr.setEncoding("utf8");
+		childStderr.on("data", (chunk: string) => {
 			stderr += chunk;
 			if (stdout.length + stderr.length > SHELL_EXPANSION_MAX_BUFFER) {
 				fail(


### PR DESCRIPTION
## Summary
- Drain the job queue via `pending.shift()`'s return value instead of asserting non-null after a length guard.
- Narrow `child.stdout` / `child.stderr` once after `spawn` instead of four inline `!` assertions.
- Move test scaffolding casts behind a single outer `as unknown as AgentMessage` instead of inline `as any` on the `message` field.

Nine of ten ignores removed. The remaining ignore in `server/db/schema.ts` is justified — only the variadic `primaryKey` overload is `@deprecated`, and we use the `{ columns }` form.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (266 passing)
- [x] `pnpm biome check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)