### PR TITLE
feat: dashboard redesign slice 2 — typed transcript firehose with replay

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -1,7 +1,9 @@
 import type { ReactNode } from "react";
 import { RunBanner } from "./components/run-banner.tsx";
+import { Transcript } from "./components/transcript.tsx";
 import { WorkflowStripe } from "./components/workflow-stripe.tsx";
 import { useRunDetail } from "./hooks/use-run-detail.ts";
+import { useRunEvents } from "./hooks/use-run-events.ts";
 
 export function App() {
 	const runId = readRunIdFromUrl();
@@ -24,16 +26,20 @@ export function App() {
 }
 
 function CenterContent({ runId }: { runId: string | null }) {
-	const { data, isLoading, error } = useRunDetail(runId);
+	const detail = useRunDetail(runId);
+	const events = useRunEvents(runId);
 
 	if (runId == null) return <Placeholder>No run selected.</Placeholder>;
-	if (isLoading) return <Placeholder>Loading…</Placeholder>;
-	if (error) return <Placeholder>{error.message}</Placeholder>;
-	if (!data) return null;
+	if (detail.isLoading) return <Placeholder>Loading…</Placeholder>;
+	if (detail.error) return <Placeholder>{detail.error.message}</Placeholder>;
+	if (!detail.data) return null;
+
+	const eventsList = events.status === "ready" ? events.events : [];
 	return (
 		<>
-			<RunBanner run={data.run} />
-			<WorkflowStripe steps={data.steps} />
+			<RunBanner run={detail.data.run} />
+			<WorkflowStripe steps={detail.data.steps} />
+			<Transcript events={eventsList} steps={detail.data.steps} />
 		</>
 	);
 }

--- a/dashboard/src/components/run-banner.tsx
+++ b/dashboard/src/components/run-banner.tsx
@@ -1,3 +1,4 @@
+import { killRun } from "../lib/api.ts";
 import {
 	formatCost,
 	formatElapsed,
@@ -68,7 +69,14 @@ export function RunBanner({ run }: Props) {
 				<div className="banner-actions">
 					<StatusTag status={run.status} />
 					{run.status === "running" && (
-						<button type="button" className="btn danger" disabled>
+						<button
+							type="button"
+							className="btn danger"
+							data-testid="kill-button"
+							onClick={() => {
+								void killRun(run.id);
+							}}
+						>
 							Kill <span className="key">K</span>
 						</button>
 					)}

--- a/dashboard/src/components/transcript.tsx
+++ b/dashboard/src/components/transcript.tsx
@@ -1,0 +1,243 @@
+import {
+	formatStepDuration,
+	formatStepNumber,
+	formatTime,
+	STEP_STATE_CLASS,
+} from "../lib/format.ts";
+import type { RunEvent, RunStepState, Step } from "../lib/types.ts";
+
+type Props = {
+	events: RunEvent[];
+	steps: Step[];
+};
+
+export function Transcript({ events, steps }: Props) {
+	const groups = groupByStep(events, steps);
+	return (
+		<div className="transcript" data-testid="transcript">
+			{groups.map((group) => {
+				if (group.kind === "step") {
+					return (
+						<StepDivider
+							key={`step-${group.step.index}`}
+							step={group.step}
+							events={group.events}
+						/>
+					);
+				}
+				return <EventGroup key="unstepped-leading" events={group.events} />;
+			})}
+		</div>
+	);
+}
+
+type StepGroup = { kind: "step"; step: Step; events: RunEvent[] };
+type LooseGroup = { kind: "loose"; events: RunEvent[] };
+type Group = StepGroup | LooseGroup;
+
+function groupByStep(events: RunEvent[], steps: Step[]): Group[] {
+	const looseLeading: RunEvent[] = [];
+	const stepBuckets = new Map<string, RunEvent[]>();
+	for (const step of steps) stepBuckets.set(step.name, []);
+
+	let lastTouchedBucket: RunEvent[] | null = null;
+	for (const event of events) {
+		if (event.stepName == null) {
+			if (lastTouchedBucket == null) looseLeading.push(event);
+			else lastTouchedBucket.push(event);
+			continue;
+		}
+		const bucket = stepBuckets.get(event.stepName);
+		if (bucket == null) continue;
+		bucket.push(event);
+		lastTouchedBucket = bucket;
+	}
+
+	const groups: Group[] = [];
+	if (looseLeading.length > 0)
+		groups.push({ kind: "loose", events: looseLeading });
+	for (const step of steps) {
+		const bucket = stepBuckets.get(step.name) ?? [];
+		if (step.state === "pending" && bucket.length === 0) continue;
+		groups.push({ kind: "step", step, events: bucket });
+	}
+	return groups;
+}
+
+function StepDivider({ step, events }: { step: Step; events: RunEvent[] }) {
+	const klass = STEP_STATE_CLASS[step.state];
+	const stat = formatStepStat(step.state, step.durationMs);
+	return (
+		<>
+			<div
+				className={`step-divider${klass ? ` ${klass}` : ""}`}
+				data-testid={`step-divider-${step.index}`}
+			>
+				<span className="step-num mono">
+					step {formatStepNumber(step.index)}
+				</span>
+				<span className="step-name">{step.name}</span>
+				<span className="step-stat">{stat}</span>
+			</div>
+			<EventGroup events={events} />
+		</>
+	);
+}
+
+function formatStepStat(
+	state: RunStepState,
+	durationMs: number | null,
+): string {
+	switch (state) {
+		case "pending":
+			return "pending";
+		case "running":
+			return "in progress";
+		case "completed":
+			return `${formatStepDuration(durationMs)} · done`;
+		case "failed":
+			return `${formatStepDuration(durationMs)} · failed`;
+	}
+}
+
+function EventGroup({ events }: { events: RunEvent[] }) {
+	if (events.length === 0) return null;
+	return (
+		<div className="group">
+			{events.map((event) => (
+				<EventRow key={event.id} event={event} />
+			))}
+		</div>
+	);
+}
+
+function EventRow({ event }: { event: RunEvent }) {
+	return (
+		<div className="ev" data-testid={`ev-${event.id}`} data-kind={event.kind}>
+			<span className="ts mono">{formatTime(event.createdAt)}</span>
+			<div className="row">{renderRowBody(event)}</div>
+		</div>
+	);
+}
+
+function renderRowBody(event: RunEvent) {
+	switch (event.kind) {
+		case "agent:say":
+			return (
+				<>
+					<span className="kind say">agent</span>
+					<span className="body">
+						<span className="say-text">{event.data.text}</span>
+					</span>
+				</>
+			);
+		case "tool:read":
+			return (
+				<>
+					<span className="kind tool">Read</span>
+					<span className="body">
+						<span className="file">{event.data.path}</span>
+						{event.data.lines > 0 && (
+							<span className="quiet">{event.data.lines} lines</span>
+						)}
+					</span>
+				</>
+			);
+		case "tool:edit":
+			return (
+				<>
+					<span className="kind tool">Edit</span>
+					<span className="body">
+						<span className="file">{event.data.path}</span>
+						{(event.data.added > 0 || event.data.removed > 0) && (
+							<span className="quiet">
+								+{event.data.added} −{event.data.removed}
+								{event.data.summary ? ` · ${event.data.summary}` : ""}
+							</span>
+						)}
+					</span>
+				</>
+			);
+		case "tool:grep":
+			return (
+				<>
+					<span className="kind tool">Grep</span>
+					<span className="body">
+						<span className="cmd">"{event.data.pattern}"</span>
+						{event.data.path && (
+							<>
+								{" in "}
+								<span className="file">{event.data.path}</span>
+							</>
+						)}
+						{event.data.matches > 0 && (
+							<span className="quiet">{event.data.matches} matches</span>
+						)}
+					</span>
+				</>
+			);
+		case "tool:bash":
+			return (
+				<>
+					<span className="kind tool">Bash</span>
+					<span className="body">
+						<span className="cmd">{event.data.command}</span>
+						{event.data.state === "running" && (
+							<span className="cursor" data-testid="bash-cursor" />
+						)}
+						{event.data.state === "exited" && event.data.exitCode != null && (
+							<span className="ok-tag">exit {event.data.exitCode}</span>
+						)}
+						{event.data.state === "aborted" && (
+							<span className="quiet" data-testid="bash-aborted">
+								aborted
+							</span>
+						)}
+					</span>
+				</>
+			);
+		case "tool:other":
+			return (
+				<>
+					<span className="kind tool">{event.data.tool}</span>
+					<span className="body">
+						{event.data.summary && (
+							<span className="quiet">{event.data.summary}</span>
+						)}
+					</span>
+				</>
+			);
+		case "system":
+			return (
+				<>
+					<span className="kind system">system</span>
+					<span className="body">
+						{event.data.message}
+						{event.data.path != null && (
+							<>
+								{" "}
+								<span className="file">{event.data.path}</span>
+							</>
+						)}
+						{event.data.command != null && (
+							<>
+								{" "}
+								<span className="cmd">{event.data.command}</span>
+							</>
+						)}
+					</span>
+				</>
+			);
+		case "step:started":
+		case "step:completed":
+		case "step:failed":
+		case "run:started":
+		case "run:completed":
+		case "run:failed":
+			return null;
+		default: {
+			const _exhaustive: never = event;
+			return _exhaustive;
+		}
+	}
+}

--- a/dashboard/src/components/workflow-stripe.tsx
+++ b/dashboard/src/components/workflow-stripe.tsx
@@ -1,5 +1,9 @@
-import { formatStepDuration, formatStepNumber } from "../lib/format.ts";
-import type { RunStepState, Step } from "../lib/types.ts";
+import {
+	formatStepDuration,
+	formatStepNumber,
+	STEP_STATE_CLASS,
+} from "../lib/format.ts";
+import type { Step } from "../lib/types.ts";
 
 type Props = {
 	steps: Step[];
@@ -12,7 +16,7 @@ export function WorkflowStripe({ steps }: Props) {
 				{steps.map((step) => (
 					<div
 						key={step.index}
-						className={`ws ${STATE_CLASS[step.state]}`}
+						className={`ws ${STEP_STATE_CLASS[step.state]}`}
 						data-testid={`step-${step.index}`}
 					>
 						<div className="num mono">{formatStepNumber(step.index)}</div>
@@ -24,10 +28,3 @@ export function WorkflowStripe({ steps }: Props) {
 		</div>
 	);
 }
-
-const STATE_CLASS: Record<RunStepState, string> = {
-	pending: "",
-	running: "now",
-	completed: "done",
-	failed: "failed",
-};

--- a/dashboard/src/dashboard.run-detail.test.tsx
+++ b/dashboard/src/dashboard.run-detail.test.tsx
@@ -4,6 +4,7 @@ import { test } from "./testing/fixture.tsx";
 import {
 	runDetailHandler,
 	runDetailNotFoundHandler,
+	runEventsHandler,
 } from "./testing/handlers.ts";
 import { browserWorker } from "./testing/msw.ts";
 
@@ -12,6 +13,7 @@ describe("dashboard centre column", () => {
 		dashboardPage,
 	}) => {
 		browserWorker.use(
+			runEventsHandler("run_9f3b2e1c"),
 			runDetailHandler(
 				"run_9f3b2e1c",
 				createRunDetail({
@@ -63,6 +65,7 @@ describe("dashboard centre column", () => {
 		dashboardPage,
 	}) => {
 		browserWorker.use(
+			runEventsHandler("run-failed"),
 			runDetailHandler(
 				"run-failed",
 				createRunDetail({
@@ -110,7 +113,10 @@ describe("dashboard centre column", () => {
 	test("shows the error placeholder when the run is unknown", async ({
 		dashboardPage,
 	}) => {
-		browserWorker.use(runDetailNotFoundHandler("missing"));
+		browserWorker.use(
+			runEventsHandler("missing"),
+			runDetailNotFoundHandler("missing"),
+		);
 		const page = await dashboardPage.mountAt("missing");
 		await page.expectPlaceholder(/404|failed/i);
 	});

--- a/dashboard/src/dashboard.transcript.test.tsx
+++ b/dashboard/src/dashboard.transcript.test.tsx
@@ -1,0 +1,136 @@
+import { describe, expect } from "vitest";
+import {
+	createEvent,
+	createRun,
+	createRunDetail,
+	createStep,
+} from "./testing/contract.ts";
+import { test } from "./testing/fixture.tsx";
+import {
+	killRunHandler,
+	runDetailHandler,
+	runEventsHandler,
+} from "./testing/handlers.ts";
+import { browserWorker } from "./testing/msw.ts";
+
+const RUN_ID = "run-1";
+
+const detail = createRunDetail({
+	run: createRun({
+		id: RUN_ID,
+		status: "running",
+		issueTitle: "broken thing",
+	}),
+	steps: [
+		createStep({
+			index: 1,
+			name: "implement",
+			state: "running",
+			startedAt: "2026-05-09T14:28:19Z",
+		}),
+		createStep({ index: 2, name: "review", state: "pending" }),
+	],
+});
+
+describe("dashboard transcript", () => {
+	test("renders system, agent:say, and typed tool events with step dividers", async ({
+		dashboardPage,
+	}) => {
+		browserWorker.use(
+			runDetailHandler(RUN_ID, detail),
+			runEventsHandler(RUN_ID, [
+				createEvent({
+					kind: "system",
+					stepName: null,
+					data: {
+						message: "branch resolved",
+						command: null,
+						path: "fix/foo",
+						exitCode: null,
+					},
+				}),
+				createEvent({
+					kind: "step:started",
+					stepName: "implement",
+					data: { name: "implement", index: 1, total: 2 },
+				}),
+				createEvent({
+					kind: "agent:say",
+					stepName: "implement",
+					data: { text: "reading repo layout" },
+				}),
+				createEvent({
+					kind: "tool:read",
+					stepName: "implement",
+					data: { path: "scripts/install.sh", lines: 0 },
+				}),
+				createEvent({
+					kind: "tool:bash",
+					stepName: "implement",
+					data: {
+						command: "pnpm test",
+						cwd: "/work",
+						state: "running",
+						exitCode: null,
+					},
+				}),
+			]),
+		);
+
+		const page = await dashboardPage.mountAt(RUN_ID);
+
+		await page.expectTranscriptContains("branch resolved");
+		await page.expectTranscriptContains("reading repo layout");
+		await page.expectTranscriptContains("scripts/install.sh");
+		await page.expectTranscriptContains("pnpm test");
+		await expect.element(page.getStepDivider(1)).toHaveTextContent("implement");
+		await expect.element(page.getBashCursor()).toBeInTheDocument();
+	});
+
+	test("tool:bash aborted renders a distinct marker, not a blinking cursor", async ({
+		dashboardPage,
+	}) => {
+		browserWorker.use(
+			runDetailHandler(RUN_ID, detail),
+			runEventsHandler(RUN_ID, [
+				createEvent({
+					kind: "tool:bash",
+					stepName: "implement",
+					data: {
+						command: "sleep 60",
+						cwd: "/work",
+						state: "aborted",
+						exitCode: null,
+					},
+				}),
+			]),
+		);
+
+		const page = await dashboardPage.mountAt(RUN_ID);
+
+		await expect.element(page.getBashAborted()).toBeInTheDocument();
+		await expect.element(page.getBashCursor()).not.toBeInTheDocument();
+	});
+
+	test("kill button POSTs /runs/:id/kill", async ({ dashboardPage }) => {
+		let killed = false;
+		browserWorker.use(
+			runDetailHandler(RUN_ID, detail),
+			runEventsHandler(RUN_ID),
+			killRunHandler(RUN_ID),
+		);
+		// Spy on the network: register an additional handler that flips the flag.
+		browserWorker.events.on("request:start", ({ request }) => {
+			if (
+				request.method === "POST" &&
+				new URL(request.url).pathname === `/runs/${RUN_ID}/kill`
+			) {
+				killed = true;
+			}
+		});
+
+		const page = await dashboardPage.mountAt(RUN_ID);
+		await page.getKillButton().click();
+		await expect.poll(() => killed).toBe(true);
+	});
+});

--- a/dashboard/src/hooks/use-run-events.ts
+++ b/dashboard/src/hooks/use-run-events.ts
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+import { fetchRunEvents } from "../lib/api.ts";
+import type { RunEvent, RunEventKind } from "../lib/types.ts";
+
+const ALL_KINDS: RunEventKind[] = [
+	"run:started",
+	"run:completed",
+	"run:failed",
+	"step:started",
+	"step:completed",
+	"step:failed",
+	"agent:say",
+	"tool:read",
+	"tool:edit",
+	"tool:grep",
+	"tool:bash",
+	"tool:other",
+	"system",
+];
+
+type State =
+	| { status: "loading" }
+	| { status: "error"; error: Error }
+	| { status: "ready"; events: RunEvent[] };
+
+export function useRunEvents(runId: string | null): State {
+	const [state, setState] = useState<State>({ status: "loading" });
+
+	useEffect(() => {
+		if (runId == null) return;
+
+		let cancelled = false;
+		let source: EventSource | undefined;
+		setState({ status: "loading" });
+
+		const start = async () => {
+			let initial: RunEvent[];
+			try {
+				initial = await fetchRunEvents(runId);
+			} catch (err) {
+				if (cancelled) return;
+				setState({
+					status: "error",
+					error: err instanceof Error ? err : new Error(String(err)),
+				});
+				return;
+			}
+			if (cancelled) return;
+
+			const seenIds = new Set(initial.map((e) => e.id));
+			let events = [...initial].sort((a, b) => a.seq - b.seq);
+			setState({ status: "ready", events });
+
+			const last = events.at(-1);
+			const url =
+				last != null
+					? `/events?lastEventId=${encodeURIComponent(last.id)}`
+					: "/events";
+			source = new EventSource(url);
+			const onFrame = (msg: MessageEvent) => {
+				if (cancelled) return;
+				const event = parse(msg.data);
+				if (event == null || event.runId !== runId) return;
+				if (seenIds.has(event.id)) return;
+				seenIds.add(event.id);
+				const tail = events.at(-1);
+				events =
+					tail == null || event.seq > tail.seq
+						? [...events, event]
+						: [...events, event].sort((a, b) => a.seq - b.seq);
+				setState({ status: "ready", events });
+			};
+			for (const kind of ALL_KINDS) source.addEventListener(kind, onFrame);
+		};
+
+		void start();
+
+		return () => {
+			cancelled = true;
+			source?.close();
+		};
+	}, [runId]);
+
+	return state;
+}
+
+function parse(raw: string): RunEvent | null {
+	try {
+		return JSON.parse(raw) as RunEvent;
+	} catch {
+		return null;
+	}
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -437,6 +437,191 @@ h1.run-title {
 	box-shadow: inset 0 0 0 1px var(--failed);
 }
 
+/* ───── transcript ───── */
+
+.transcript {
+	flex: 1;
+	overflow-y: auto;
+	padding: 18px 28px 80px;
+	position: relative;
+}
+
+.transcript > .group,
+.transcript > .step-divider {
+	max-width: 1000px;
+}
+
+.group {
+	margin-bottom: 4px;
+}
+
+.ev {
+	display: grid;
+	grid-template-columns: 56px 1fr;
+	gap: 14px;
+	padding: 6px 0;
+	align-items: baseline;
+}
+
+.ev .ts {
+	font-family: "Geist Mono", monospace;
+	font-size: 11px;
+	color: var(--fg-3);
+	font-variant-numeric: tabular-nums;
+	padding-top: 1px;
+}
+
+.ev .row {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	gap: 12px;
+	align-items: baseline;
+}
+
+.ev .kind {
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 18px;
+	padding: 0 7px;
+	border-radius: 4px;
+	color: var(--fg-3);
+	background: var(--bg-1);
+	flex-shrink: 0;
+	white-space: nowrap;
+}
+
+.ev .kind.tool {
+	background: #ede9fe;
+	color: #5b21b6;
+}
+
+.ev .kind.say {
+	background: transparent;
+	color: var(--fg-3);
+	padding-left: 0;
+	font-style: italic;
+	font-weight: 400;
+}
+
+.ev .kind.system {
+	background: var(--bg-1);
+	color: var(--fg-3);
+}
+
+.ev .body {
+	color: var(--fg-2);
+	font-size: 13px;
+	line-height: 1.55;
+	min-width: 0;
+}
+
+.ev .body .file {
+	color: var(--link);
+	font-family: "Geist Mono", monospace;
+	font-size: 12px;
+}
+
+.ev .body .cmd {
+	color: var(--fg);
+	font-family: "Geist Mono", monospace;
+	font-size: 12px;
+	background: var(--bg-1);
+	padding: 1px 6px;
+	border-radius: 3px;
+	border: 1px solid var(--line);
+}
+
+.ev .body .quiet {
+	color: var(--fg-4);
+	margin-left: 4px;
+}
+
+.ev .body .ok-tag {
+	color: var(--completed);
+	font-family: "Geist Mono", monospace;
+	font-size: 11.5px;
+	margin-left: 6px;
+}
+
+.ev .body .say-text {
+	color: var(--fg-2);
+	font-style: italic;
+	line-height: 1.55;
+}
+
+.step-divider {
+	margin: 16px 0 8px;
+	padding: 8px 14px;
+	background: var(--bg-1);
+	border-radius: var(--r);
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.step-divider .step-num {
+	font-family: "Geist Mono", monospace;
+	font-size: 11px;
+	color: var(--fg-4);
+}
+
+.step-divider .step-name {
+	font-size: 12.5px;
+	font-weight: 500;
+	color: var(--fg);
+}
+
+.step-divider .step-stat {
+	margin-left: auto;
+	font-size: 11.5px;
+	color: var(--fg-3);
+	font-family: "Geist Mono", monospace;
+}
+
+.step-divider.now {
+	background: var(--running-bg);
+}
+
+.step-divider.now .step-name {
+	color: var(--running);
+}
+
+.step-divider.now .step-stat {
+	color: var(--running);
+}
+
+.step-divider.done .step-num {
+	color: var(--completed);
+}
+
+.step-divider.done .step-stat {
+	color: var(--completed);
+}
+
+.step-divider.failed .step-num {
+	color: var(--failed);
+}
+
+.step-divider.failed .step-stat {
+	color: var(--failed);
+}
+
+.cursor {
+	display: inline-block;
+	width: 2px;
+	height: 13px;
+	background: var(--running);
+	margin-left: 4px;
+	transform: translateY(2px);
+	animation: blink 1.05s steps(2, end) infinite;
+}
+
+@keyframes blink {
+	50% {
+		opacity: 0;
+	}
+}
+
 /* ───── empty / loading ───── */
 
 .placeholder {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { RunDetail } from "./types.ts";
+import type { RunDetail, RunEvent } from "./types.ts";
 
 async function apiFetch(url: string, init?: RequestInit): Promise<Response> {
 	const res = await fetch(url, init);
@@ -8,5 +8,15 @@ async function apiFetch(url: string, init?: RequestInit): Promise<Response> {
 
 export async function fetchRunDetail(runId: string): Promise<RunDetail> {
 	const res = await apiFetch(`/runs/${runId}`);
+	return res.json();
+}
+
+export async function fetchRunEvents(runId: string): Promise<RunEvent[]> {
+	const res = await apiFetch(`/runs/${runId}/events`);
+	return res.json();
+}
+
+export async function killRun(runId: string): Promise<{ killed: boolean }> {
+	const res = await apiFetch(`/runs/${runId}/kill`, { method: "POST" });
 	return res.json();
 }

--- a/dashboard/src/lib/format.ts
+++ b/dashboard/src/lib/format.ts
@@ -1,3 +1,5 @@
+import type { RunStepState } from "./types.ts";
+
 export function formatTime(iso: string): string {
 	const d = new Date(iso);
 	const hh = String(d.getHours()).padStart(2, "0");
@@ -36,3 +38,10 @@ export function formatTokens(total: number | null): string {
 export function formatStepNumber(index: number): string {
 	return String(index).padStart(2, "0");
 }
+
+export const STEP_STATE_CLASS: Record<RunStepState, string> = {
+	pending: "",
+	running: "now",
+	completed: "done",
+	failed: "failed",
+};

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -44,3 +44,90 @@ export type RunDetail = {
 	run: Run;
 	steps: Step[];
 };
+
+type RunEventBase = {
+	id: string;
+	seq: number;
+	runId: string;
+	stepName: string | null;
+	createdAt: string;
+};
+
+export type ToolBashState = "running" | "exited" | "aborted";
+
+export type RunEvent =
+	| (RunEventBase & {
+			kind: "run:started";
+			data: { issueKey: string | null; issueTitle: string | null };
+	  })
+	| (RunEventBase & {
+			kind: "run:completed";
+			data: {
+				durationMs: number;
+				costUsd: number;
+				tokens: { in: number; out: number };
+			};
+	  })
+	| (RunEventBase & {
+			kind: "run:failed";
+			data: { error: string; durationMs: number };
+	  })
+	| (RunEventBase & {
+			kind: "step:started";
+			data: { name: string; index: number; total: number };
+	  })
+	| (RunEventBase & {
+			kind: "step:completed";
+			data: { name: string; index: number; durationMs: number };
+	  })
+	| (RunEventBase & {
+			kind: "step:failed";
+			data: {
+				name: string;
+				index: number;
+				error: string;
+				durationMs: number;
+			};
+	  })
+	| (RunEventBase & { kind: "agent:say"; data: { text: string } })
+	| (RunEventBase & {
+			kind: "tool:read";
+			data: { path: string; lines: number };
+	  })
+	| (RunEventBase & {
+			kind: "tool:edit";
+			data: {
+				path: string;
+				added: number;
+				removed: number;
+				summary: string;
+			};
+	  })
+	| (RunEventBase & {
+			kind: "tool:grep";
+			data: { pattern: string; path: string; matches: number };
+	  })
+	| (RunEventBase & {
+			kind: "tool:bash";
+			data: {
+				command: string;
+				cwd: string | null;
+				state: ToolBashState;
+				exitCode: number | null;
+			};
+	  })
+	| (RunEventBase & {
+			kind: "tool:other";
+			data: { tool: string; summary: string };
+	  })
+	| (RunEventBase & {
+			kind: "system";
+			data: {
+				message: string;
+				command: string | null;
+				path: string | null;
+				exitCode: number | null;
+			};
+	  });
+
+export type RunEventKind = RunEvent["kind"];

--- a/dashboard/src/testing/contract.ts
+++ b/dashboard/src/testing/contract.ts
@@ -1,4 +1,4 @@
-import type { Run, RunDetail, Step } from "../lib/types.ts";
+import type { Run, RunDetail, RunEvent, Step } from "../lib/types.ts";
 
 export function createRun(overrides: Partial<Run> = {}): Run {
 	return {
@@ -40,4 +40,32 @@ export function createRunDetail(overrides: Partial<RunDetail> = {}): RunDetail {
 		run: overrides.run ?? createRun(),
 		steps: overrides.steps ?? [],
 	};
+}
+
+let nextSeq = 1;
+
+type EventInput = {
+	[K in RunEvent["kind"]]: Pick<
+		Extract<RunEvent, { kind: K }>,
+		"kind" | "data"
+	> & {
+		seq?: number;
+		id?: string;
+		runId?: string;
+		stepName?: string | null;
+		createdAt?: string;
+	};
+}[RunEvent["kind"]];
+
+export function createEvent(event: EventInput): RunEvent {
+	const seq = event.seq ?? nextSeq++;
+	return {
+		seq,
+		id: event.id ?? `evt_${String(seq).padStart(4, "0")}`,
+		runId: event.runId ?? "run-1",
+		stepName: event.stepName ?? null,
+		createdAt: event.createdAt ?? "2026-05-09T14:28:00Z",
+		kind: event.kind,
+		data: event.data,
+	} as RunEvent;
 }

--- a/dashboard/src/testing/handlers.ts
+++ b/dashboard/src/testing/handlers.ts
@@ -1,5 +1,5 @@
 import { HttpResponse, http } from "msw";
-import type { RunDetail } from "../lib/types.ts";
+import type { RunDetail, RunEvent } from "../lib/types.ts";
 
 export function runDetailHandler(runId: string, detail: RunDetail) {
 	return http.get(`/runs/${runId}`, () => HttpResponse.json(detail));
@@ -20,4 +20,35 @@ export function runDetailNotFoundHandler(runId: string) {
 	);
 }
 
-export const handlers = [];
+export function runEventsHandler(runId: string, events: RunEvent[] = []) {
+	return http.get(`/runs/${runId}/events`, () => HttpResponse.json(events));
+}
+
+export function killRunHandler(
+	runId: string,
+	body: { killed: boolean } = { killed: true },
+) {
+	return http.post(`/runs/${runId}/kill`, () => HttpResponse.json(body));
+}
+
+function eventsStreamHandler() {
+	return http.get(
+		"/events",
+		() =>
+			new HttpResponse(
+				new ReadableStream({
+					start(controller) {
+						controller.enqueue(new TextEncoder().encode(": keepalive\n\n"));
+					},
+				}),
+				{
+					headers: {
+						"Content-Type": "text/event-stream",
+						"Cache-Control": "no-cache",
+					},
+				},
+			),
+	);
+}
+
+export const handlers = [eventsStreamHandler()];

--- a/dashboard/src/testing/page-object.ts
+++ b/dashboard/src/testing/page-object.ts
@@ -39,6 +39,18 @@ export function dashboardPageObject(page: PageType) {
 		expectPlaceholder: async (text: string | RegExp) => {
 			await expect.element(self.getPlaceholder()).toHaveTextContent(text);
 		},
+
+		getTranscript: () => page.getByTestId("transcript"),
+		getEvent: (id: string) => page.getByTestId(`ev-${id}`),
+		getStepDivider: (index: number) =>
+			page.getByTestId(`step-divider-${index}`),
+		getKillButton: () => page.getByTestId("kill-button"),
+		getBashCursor: () => page.getByTestId("bash-cursor"),
+		getBashAborted: () => page.getByTestId("bash-aborted"),
+
+		expectTranscriptContains: async (text: string | RegExp) => {
+			await expect.element(self.getTranscript()).toHaveTextContent(text);
+		},
 	};
 	return Object.assign(page, self);
 }

--- a/drizzle/0008_dashboard_redesign_slice_2.sql
+++ b/drizzle/0008_dashboard_redesign_slice_2.sql
@@ -1,0 +1,13 @@
+DROP TABLE `run_events`;--> statement-breakpoint
+CREATE TABLE `run_events` (
+	`seq` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`id` text NOT NULL,
+	`run_id` text NOT NULL,
+	`kind` text NOT NULL,
+	`step_name` text,
+	`data` text NOT NULL,
+	`created_at` text NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX `run_events_id_unique` ON `run_events` (`id`);--> statement-breakpoint
+CREATE INDEX `idx_run_events_run_id` ON `run_events` (`run_id`);--> statement-breakpoint
+CREATE INDEX `idx_run_events_seq` ON `run_events` (`seq`);

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,350 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "b9f3a4d2-8c7e-4f1b-ac26-3e7f9d4a8b6c",
+	"prevId": "a7e2f3c1-9d4b-4e8a-bc15-2f6e8d3a9c7b",
+	"tables": {
+		"run_events": {
+			"name": "run_events",
+			"columns": {
+				"seq": {
+					"name": "seq",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"step_name": {
+					"name": "step_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"data": {
+					"name": "data",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"run_events_id_unique": {
+					"name": "run_events_id_unique",
+					"columns": ["id"],
+					"isUnique": true
+				},
+				"idx_run_events_run_id": {
+					"name": "idx_run_events_run_id",
+					"columns": ["run_id"],
+					"isUnique": false
+				},
+				"idx_run_events_seq": {
+					"name": "idx_run_events_seq",
+					"columns": ["seq"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"run_step_outputs": {
+			"name": "run_step_outputs",
+			"columns": {
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"step_name": {
+					"name": "step_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"output_json": {
+					"name": "output_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"run_step_outputs_run_id_step_name_pk": {
+					"columns": ["run_id", "step_name"],
+					"name": "run_step_outputs_run_id_step_name_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"run_steps": {
+			"name": "run_steps",
+			"columns": {
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"index": {
+					"name": "index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"run_steps_run_id_index_pk": {
+					"columns": ["run_id", "index"],
+					"name": "run_steps_run_id_index_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"runs": {
+			"name": "runs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repo": {
+					"name": "repo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"branch": {
+					"name": "branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"workspace_dir": {
+					"name": "workspace_dir",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"issue_key": {
+					"name": "issue_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"issue_title": {
+					"name": "issue_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"issue_url": {
+					"name": "issue_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"cost_usd": {
+					"name": "cost_usd",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_input": {
+					"name": "tokens_input",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_output": {
+					"name": "tokens_output",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_url": {
+					"name": "pr_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_number": {
+					"name": "pr_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_repo": {
+					"name": "pr_repo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_kind": {
+					"name": "pr_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
 			"when": 1778832000000,
 			"tag": "0007_dashboard_redesign_slice_1",
 			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "6",
+			"when": 1778918400000,
+			"tag": "0008_dashboard_redesign_slice_2",
+			"breakpoints": true
 		}
 	]
 }

--- a/server/api/api.test.ts
+++ b/server/api/api.test.ts
@@ -38,7 +38,7 @@ describe("GET /health", () => {
 });
 
 describe("GET /events", () => {
-	it("delivers run lifecycle events over SSE", async () => {
+	it("delivers run lifecycle events over SSE with id/event/data frames", async () => {
 		const { app, runner } = createTestApi();
 
 		const res = await app.request("/events");
@@ -83,9 +83,70 @@ describe("GET /events", () => {
 
 			expect(collected).toContain("event: run:started");
 			expect(collected).toContain("event: run:completed");
+			expect(collected).toContain("id: ");
 			expect(collected).toContain("test/repo#42");
 		} finally {
 			reader.cancel();
+		}
+	});
+
+	it("replays only events with seq > Last-Event-ID's seq on reconnect", async () => {
+		const { app, runner } = createTestApi();
+
+		const { runId, done } = runner.enqueue({
+			repo: repoSlug("test/repo"),
+			issueKey: issueKey("test/repo#100"),
+			issueTitle: "Replay test",
+			issueUrl: null,
+			handler: async (ctx) => {
+				ctx.emit({
+					kind: "agent:say",
+					stepName: "implement",
+					data: { text: "first" },
+				});
+				ctx.emit({
+					kind: "agent:say",
+					stepName: "implement",
+					data: { text: "second" },
+				});
+				return { status: "completed", durationMs: 0 };
+			},
+		});
+		await done;
+
+		const list = (await (
+			await app.request(`/runs/${runId}/events`)
+		).json()) as Array<{ id: string; kind: string; data: { text?: string } }>;
+		const lastEventId = list[1]?.id;
+		expect(lastEventId).toBeTruthy();
+
+		const res = await app.request("/events", {
+			headers: { "Last-Event-ID": lastEventId as string },
+		});
+		const reader = res.body?.getReader();
+		if (!reader) throw new Error("expected stream");
+		const decoder = new TextDecoder();
+
+		try {
+			let collected = "";
+			for (let i = 0; i < 20; i++) {
+				const { value, done } = await Promise.race([
+					reader.read(),
+					new Promise<never>((_, reject) =>
+						setTimeout(() => reject(new Error("timeout")), 5_000),
+					),
+				]);
+				if (done) break;
+				collected += decoder.decode(value, { stream: true });
+				if (collected.includes("run:completed")) break;
+			}
+			// First "agent:say" was at lastEventId — should NOT be replayed.
+			// Only events strictly after it (the second say + run:completed).
+			expect(collected).not.toContain('"text":"first"');
+			expect(collected).toContain('"text":"second"');
+			expect(collected).toContain("event: run:completed");
+		} finally {
+			await reader.cancel();
 		}
 	});
 });

--- a/server/api/api.ts
+++ b/server/api/api.ts
@@ -45,14 +45,20 @@ export function createApi({
 
 	app.get("/events", (c) => {
 		return streamSSE(c, async (stream) => {
-			const handler = async (event: RunEvent) => {
-				try {
-					await stream.writeSSE({
-						event: event.type,
-						data: JSON.stringify(event),
-					});
-				} catch {
-					// stream aborted; cleanup runs via onAbort
+			const lastEventId =
+				c.req.header("Last-Event-ID") ??
+				c.req.query("lastEventId") ??
+				undefined;
+			const sinceSeq =
+				lastEventId != null ? (repo.getEventSeqById(lastEventId) ?? 0) : 0;
+
+			const buffered: RunEvent[] = [];
+			let live = false;
+			const handler = (event: RunEvent) => {
+				if (live) {
+					void writeFrame(stream, event);
+				} else {
+					buffered.push(event);
 				}
 			};
 
@@ -61,6 +67,17 @@ export function createApi({
 			stream.onAbort(() => {
 				eventBus.off(handler);
 			});
+
+			let replayedSeq = sinceSeq;
+			for (const event of repo.getAllEventsAfterSeq(sinceSeq)) {
+				await writeFrame(stream, event);
+				replayedSeq = event.seq;
+			}
+			// Drain anything that arrived during replay.
+			for (const event of buffered.splice(0)) {
+				if (event.seq > replayedSeq) await writeFrame(stream, event);
+			}
+			live = true;
 
 			while (true) {
 				await stream.writeSSE({ event: "heartbeat", data: "" });
@@ -98,15 +115,40 @@ export function createApi({
 		},
 	);
 
+	app.get(
+		"/runs/:id/events",
+		zValidator("param", runParamSchema, zodProblemHook),
+		zValidator("query", runEventsQuerySchema, zodProblemHook),
+		(c) => {
+			const { id } = c.req.valid("param");
+			const { since } = c.req.valid("query");
+
+			const run = repo.getRunById(id);
+			if (!run) throw new ProblemDetailsError(404, "Not found");
+
+			if (since != null) {
+				const sinceSeq = repo.getEventSeqById(since);
+				if (sinceSeq == null) {
+					throw new ProblemDetailsError(400, "Unknown since cursor");
+				}
+				return c.json(repo.getRunEventsAfterSeq(id, sinceSeq));
+			}
+			return c.json(repo.getRunEvents(id));
+		},
+	);
+
 	app.post(
 		"/runs/:id/kill",
 		zValidator("param", runParamSchema, zodProblemHook),
 		(c) => {
 			const { id } = c.req.valid("param");
+			const run = repo.getRunById(id);
+			if (!run) throw new ProblemDetailsError(404, "Not found");
+			if (run.status !== "running") {
+				throw new ProblemDetailsError(409, `Run already ${run.status}`);
+			}
 			const killed = runner.kill(id);
-			if (!killed)
-				throw new ProblemDetailsError(404, "Run not found or not running");
-			return c.json({ killed: true });
+			return c.json({ killed });
 		},
 	);
 
@@ -132,6 +174,10 @@ const runParamSchema = z.object({
 	id: z.string().min(1).transform(brandRunId),
 });
 
+const runEventsQuerySchema = z.object({
+	since: z.string().min(1).optional(),
+});
+
 type RunWire = {
 	id: string;
 	status: Run["status"];
@@ -152,6 +198,27 @@ type RunWire = {
 };
 
 type StepWire = Omit<RunStepRow, "runId">;
+
+async function writeFrame(
+	stream: {
+		writeSSE: (frame: {
+			id?: string;
+			event: string;
+			data: string;
+		}) => Promise<void>;
+	},
+	event: RunEvent,
+): Promise<void> {
+	try {
+		await stream.writeSSE({
+			id: event.id,
+			event: event.kind,
+			data: JSON.stringify(event),
+		});
+	} catch {
+		// stream aborted; cleanup runs via onAbort
+	}
+}
 
 function runToWire(run: Run): RunWire {
 	const base: Omit<RunWire, "completedAt" | "durationMs" | "error"> = {

--- a/server/api/problem-details.ts
+++ b/server/api/problem-details.ts
@@ -7,6 +7,7 @@ import type { AppEnv } from "./types.ts";
 const STATUS_TITLES = {
 	400: "Bad Request",
 	404: "Not Found",
+	409: "Conflict",
 	422: "Unprocessable Content",
 	500: "Internal Server Error",
 } as const;

--- a/server/api/runs.test.ts
+++ b/server/api/runs.test.ts
@@ -338,7 +338,7 @@ describe("POST /runs/:id/kill", () => {
 		expect(await res.json()).toEqual({ killed: true });
 	});
 
-	it("returns 404 when run is not running", async () => {
+	it("returns 404 when the run does not exist", async () => {
 		const { app } = createTestApi();
 
 		const res = await app.request("/runs/unknown/kill", { method: "POST" });
@@ -348,7 +348,128 @@ describe("POST /runs/:id/kill", () => {
 			type: "about:blank",
 			status: 404,
 			title: "Not Found",
-			detail: "Run not found or not running",
+			detail: "Not found",
+			requestId: expect.any(String),
+		});
+	});
+
+	it("returns 409 when the run is already completed", async () => {
+		const { app, db } = createTestApi();
+		seedRun(db, { id: "done", status: "completed" });
+
+		const res = await app.request("/runs/done/kill", { method: "POST" });
+
+		expect(res.status).toBe(409);
+		expect(await res.json()).toEqual({
+			type: "about:blank",
+			status: 409,
+			title: "Conflict",
+			detail: "Run already completed",
+			requestId: expect.any(String),
+		});
+	});
+
+	it("returns 409 when the run is already failed", async () => {
+		const { app, db } = createTestApi();
+		seedRun(db, { id: "boom", status: "failed", error: "x" });
+
+		const res = await app.request("/runs/boom/kill", { method: "POST" });
+
+		expect(res.status).toBe(409);
+	});
+});
+
+describe("GET /runs/:id/events", () => {
+	it("returns 404 for unknown run", async () => {
+		const { app } = createTestApi();
+		const res = await app.request("/runs/missing/events");
+		expect(res.status).toBe(404);
+	});
+
+	it("returns events ordered oldest → newest with monotonic seq", async () => {
+		const { app, runner } = createTestApi();
+		const { runId, done } = runner.enqueue({
+			repo: repoSlug("test/repo"),
+			issueKey: issueKey("test/repo#1"),
+			issueTitle: "Event ordering",
+			issueUrl: null,
+			handler: async (ctx) => {
+				ctx.emit({
+					kind: "agent:say",
+					stepName: "implement",
+					data: { text: "first" },
+				});
+				ctx.emit({
+					kind: "agent:say",
+					stepName: "implement",
+					data: { text: "second" },
+				});
+				return { status: "completed", durationMs: 0 };
+			},
+		});
+		await done;
+
+		const res = await app.request(`/runs/${runId}/events`);
+		expect(res.status).toBe(200);
+		const events = (await res.json()) as Array<{
+			seq: number;
+			kind: string;
+			data: { text?: string };
+		}>;
+		expect(events.map((e) => e.kind)).toEqual([
+			"run:started",
+			"agent:say",
+			"agent:say",
+			"run:completed",
+		]);
+		const seqs = events.map((e) => e.seq);
+		expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+		expect(new Set(seqs).size).toBe(seqs.length);
+	});
+
+	it("filters events by since cursor (strictly greater seq)", async () => {
+		const { app, runner } = createTestApi();
+		const { runId, done } = runner.enqueue({
+			repo: repoSlug("test/repo"),
+			issueKey: issueKey("test/repo#2"),
+			issueTitle: "Since cursor",
+			issueUrl: null,
+			handler: async (ctx) => {
+				ctx.emit({
+					kind: "agent:say",
+					stepName: "implement",
+					data: { text: "a" },
+				});
+				ctx.emit({
+					kind: "agent:say",
+					stepName: "implement",
+					data: { text: "b" },
+				});
+				return { status: "completed", durationMs: 0 };
+			},
+		});
+		await done;
+
+		const all = (await (
+			await app.request(`/runs/${runId}/events`)
+		).json()) as Array<{ id: string; kind: string }>;
+		const cursor = all[1]?.id;
+		const after = (await (
+			await app.request(`/runs/${runId}/events?since=${cursor}`)
+		).json()) as Array<{ kind: string }>;
+		expect(after.map((e) => e.kind)).toEqual(["agent:say", "run:completed"]);
+	});
+
+	it("returns 400 for unknown since cursor", async () => {
+		const { app, db } = createTestApi();
+		seedRun(db, { id: "live", status: "running" });
+		const res = await app.request("/runs/live/events?since=does-not-exist");
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({
+			type: "about:blank",
+			status: 400,
+			title: "Bad Request",
+			detail: "Unknown since cursor",
 			requestId: expect.any(String),
 		});
 	});

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -49,15 +49,18 @@ export const runSteps = sqliteTable(
 export const runEvents = sqliteTable(
 	"run_events",
 	{
-		id: text("id").primaryKey(),
+		seq: integer("seq").primaryKey({ autoIncrement: true }),
+		id: text("id").notNull().unique(),
 		runId: text("run_id").notNull().$type<RunId>(),
-		type: text("type").notNull().$type<RunEventType>(),
-		data: text("data", { mode: "json" })
-			.notNull()
-			.$type<Record<string, unknown>>(),
+		kind: text("kind").notNull().$type<RunEventKind>(),
+		stepName: text("step_name"),
+		data: text("data", { mode: "json" }).notNull().$type<RunEventData>(),
 		createdAt: text("created_at").notNull(),
 	},
-	(table) => [index("idx_run_events_run_id").on(table.runId)],
+	(table) => [
+		index("idx_run_events_run_id").on(table.runId),
+		index("idx_run_events_seq").on(table.seq),
+	],
 );
 
 export const runStepOutputs = sqliteTable(
@@ -77,25 +80,82 @@ export type RunStatus = "running" | "completed" | "failed";
 export type RunStepState = "pending" | "running" | "completed" | "failed";
 export type PrKind = "opened" | "commented";
 
-export type RunEventType =
+export type RunEventKind =
 	| "run:started"
-	| "run:output"
-	| "run:tool_use"
-	| "step.started"
-	| "step.completed"
-	| "step.failed"
 	| "run:completed"
-	| "run:failed";
+	| "run:failed"
+	| "step:started"
+	| "step:completed"
+	| "step:failed"
+	| "agent:say"
+	| "tool:read"
+	| "tool:edit"
+	| "tool:grep"
+	| "tool:bash"
+	| "tool:other"
+	| "system";
 
-export type RunStartedData = { issueKey: IssueKey; issueTitle: string };
-export type RunOutputData = Record<string, unknown>;
-export type RunToolUseData = { tool: string; target: string };
+export type RunStartedData = {
+	issueKey: string | null;
+	issueTitle: string | null;
+};
+export type RunCompletedData = {
+	durationMs: number;
+	costUsd: number;
+	tokens: { in: number; out: number };
+};
+export type RunFailedData = { error: string; durationMs: number };
+
 export type StepStartedData = { name: string; index: number; total: number };
 export type StepCompletedData = {
 	name: string;
 	index: number;
 	durationMs: number;
 };
-export type StepFailedData = { name: string; index: number; error: string };
-export type RunCompletedData = { durationMs: number };
-export type RunFailedData = { error: string; durationMs: number };
+export type StepFailedData = {
+	name: string;
+	index: number;
+	error: string;
+	durationMs: number;
+};
+
+export type AgentSayData = { text: string };
+
+export type ToolReadData = { path: string; lines: number };
+export type ToolEditData = {
+	path: string;
+	added: number;
+	removed: number;
+	summary: string;
+};
+export type ToolGrepData = { pattern: string; path: string; matches: number };
+export type ToolBashState = "running" | "exited" | "aborted";
+export type ToolBashData = {
+	command: string;
+	cwd: string | null;
+	state: ToolBashState;
+	exitCode: number | null;
+};
+export type ToolOtherData = { tool: string; summary: string };
+
+export type SystemData = {
+	message: string;
+	command: string | null;
+	path: string | null;
+	exitCode: number | null;
+};
+
+export type RunEventData =
+	| RunStartedData
+	| RunCompletedData
+	| RunFailedData
+	| StepStartedData
+	| StepCompletedData
+	| StepFailedData
+	| AgentSayData
+	| ToolReadData
+	| ToolEditData
+	| ToolGrepData
+	| ToolBashData
+	| ToolOtherData
+	| SystemData;

--- a/server/event-bus.ts
+++ b/server/event-bus.ts
@@ -1,33 +1,43 @@
 import { EventEmitter } from "node:events";
 import type {
+	AgentSayData,
 	RunCompletedData,
 	RunFailedData,
-	RunOutputData,
 	RunStartedData,
-	RunToolUseData,
 	StepCompletedData,
 	StepFailedData,
 	StepStartedData,
+	SystemData,
+	ToolBashData,
+	ToolEditData,
+	ToolGrepData,
+	ToolOtherData,
+	ToolReadData,
 } from "./db/schema.ts";
 import type { RunId } from "./types/brands.ts";
 
 type RunEventBase = {
+	id: string;
+	seq: number;
 	runId: RunId;
+	stepName: string | null;
 	createdAt: string;
 };
 
-export type StepEvent =
-	| { type: "step.started"; data: StepStartedData }
-	| { type: "step.completed"; data: StepCompletedData }
-	| { type: "step.failed"; data: StepFailedData };
-
 export type RunEvent =
-	| (RunEventBase & { type: "run:started"; data: RunStartedData })
-	| (RunEventBase & { type: "run:output"; data: RunOutputData })
-	| (RunEventBase & { type: "run:tool_use"; data: RunToolUseData })
-	| (RunEventBase & StepEvent)
-	| (RunEventBase & { type: "run:completed"; data: RunCompletedData })
-	| (RunEventBase & { type: "run:failed"; data: RunFailedData });
+	| (RunEventBase & { kind: "run:started"; data: RunStartedData })
+	| (RunEventBase & { kind: "run:completed"; data: RunCompletedData })
+	| (RunEventBase & { kind: "run:failed"; data: RunFailedData })
+	| (RunEventBase & { kind: "step:started"; data: StepStartedData })
+	| (RunEventBase & { kind: "step:completed"; data: StepCompletedData })
+	| (RunEventBase & { kind: "step:failed"; data: StepFailedData })
+	| (RunEventBase & { kind: "agent:say"; data: AgentSayData })
+	| (RunEventBase & { kind: "tool:read"; data: ToolReadData })
+	| (RunEventBase & { kind: "tool:edit"; data: ToolEditData })
+	| (RunEventBase & { kind: "tool:grep"; data: ToolGrepData })
+	| (RunEventBase & { kind: "tool:bash"; data: ToolBashData })
+	| (RunEventBase & { kind: "tool:other"; data: ToolOtherData })
+	| (RunEventBase & { kind: "system"; data: SystemData });
 
 const emitter = new EventEmitter();
 emitter.setMaxListeners(50);

--- a/server/orchestrator/agent-logging.test.ts
+++ b/server/orchestrator/agent-logging.test.ts
@@ -1,6 +1,26 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import * as canonicalLog from "../canonical-log.ts";
-import { type AgentMessage, logAgentMessage } from "./agent-logging.ts";
+import type { RunEvent } from "../event-bus.ts";
+import type { EmitInput, RunContext } from "../runner/runner.ts";
+import {
+	type AgentMessage,
+	emitAgentMessageEvents,
+	trackAgentToolUseBag,
+} from "./agent-logging.ts";
+
+function captureCtx(): {
+	ctx: Pick<RunContext, "emit">;
+	emitted: EmitInput[];
+} {
+	const emitted: EmitInput[] = [];
+	const ctx: Pick<RunContext, "emit"> = {
+		emit: ((input: EmitInput) => {
+			emitted.push(input);
+			return {} as RunEvent;
+		}) as RunContext["emit"],
+	};
+	return { ctx, emitted };
+}
 
 function capturingLogger(): {
 	logger: { info(obj: Record<string, unknown>, msg: string): void };
@@ -34,50 +54,136 @@ function textMsg(text: string): AgentMessage {
 	};
 }
 
-describe("logAgentMessage", () => {
-	it("does not call emitToolUse for text-only messages", () => {
-		const longText = "a".repeat(300);
-		const emitToolUse = vi.fn();
-
-		logAgentMessage(textMsg(longText), "/workdir", emitToolUse);
-
-		expect(emitToolUse).not.toHaveBeenCalled();
+describe("emitAgentMessageEvents", () => {
+	it("emits agent:say for non-empty text blocks", () => {
+		const { ctx, emitted } = captureCtx();
+		emitAgentMessageEvents(textMsg("reading repo layout"), {
+			ctx,
+			stepName: "implement",
+			cwd: "/work",
+		});
+		expect(emitted).toEqual([
+			{
+				kind: "agent:say",
+				stepName: "implement",
+				data: { text: "reading repo layout" },
+			},
+		]);
 	});
 
-	it("extracts tool_use and calls emitToolUse callback", () => {
-		const emitToolUse = vi.fn();
+	it("skips empty text blocks", () => {
+		const { ctx, emitted } = captureCtx();
+		emitAgentMessageEvents(textMsg("   "), {
+			ctx,
+			stepName: "implement",
+			cwd: "/work",
+		});
+		expect(emitted).toEqual([]);
+	});
 
-		logAgentMessage(
-			toolUseMsg("Bash", { command: "pnpm test" }),
-			"/workdir",
-			emitToolUse,
+	it("emits tool:read for Read with workdir-relative path", () => {
+		const { ctx, emitted } = captureCtx();
+		emitAgentMessageEvents(
+			toolUseMsg("Read", { file_path: "/work/src/app.ts" }),
+			{ ctx, stepName: "implement", cwd: "/work" },
 		);
-
-		expect(emitToolUse).toHaveBeenCalledOnce();
-		expect(emitToolUse).toHaveBeenCalledWith("Bash", "pnpm test");
+		expect(emitted).toEqual([
+			{
+				kind: "tool:read",
+				stepName: "implement",
+				data: { path: "src/app.ts", lines: 0 },
+			},
+		]);
 	});
 
-	it("emits empty detail for tools with no recognisable input keys", () => {
-		const emitToolUse = vi.fn();
+	it("emits tool:edit for Edit / Write / MultiEdit", () => {
+		const { ctx, emitted } = captureCtx();
+		emitAgentMessageEvents(toolUseMsg("Edit", { file_path: "/work/a.ts" }), {
+			ctx,
+			stepName: "implement",
+			cwd: "/work",
+		});
+		emitAgentMessageEvents(toolUseMsg("Write", { file_path: "/work/b.ts" }), {
+			ctx,
+			stepName: "implement",
+			cwd: "/work",
+		});
+		expect(emitted.map((e) => e.kind)).toEqual(["tool:edit", "tool:edit"]);
+	});
 
-		logAgentMessage(
+	it("emits tool:grep with pattern and path", () => {
+		const { ctx, emitted } = captureCtx();
+		emitAgentMessageEvents(
+			toolUseMsg("Grep", { pattern: "TODO", path: "/work/src" }),
+			{ ctx, stepName: "implement", cwd: "/work" },
+		);
+		expect(emitted).toEqual([
+			{
+				kind: "tool:grep",
+				stepName: "implement",
+				data: { pattern: "TODO", path: "src", matches: 0 },
+			},
+		]);
+	});
+
+	it("emits tool:bash with state running and cwd populated", () => {
+		const { ctx, emitted } = captureCtx();
+		emitAgentMessageEvents(toolUseMsg("Bash", { command: "pnpm test" }), {
+			ctx,
+			stepName: "implement",
+			cwd: "/work",
+		});
+		expect(emitted).toEqual([
+			{
+				kind: "tool:bash",
+				stepName: "implement",
+				data: {
+					command: "pnpm test",
+					cwd: "/work",
+					state: "running",
+					exitCode: null,
+				},
+			},
+		]);
+	});
+
+	it("emits tool:other for unrecognised tools", () => {
+		const { ctx, emitted } = captureCtx();
+		emitAgentMessageEvents(
 			toolUseMsg("WebSearch", { query: "vitest coverage" }),
-			"/workdir",
-			emitToolUse,
+			{ ctx, stepName: "implement", cwd: "/work" },
 		);
-
-		expect(emitToolUse).toHaveBeenCalledWith("WebSearch", "");
+		expect(emitted).toEqual([
+			{
+				kind: "tool:other",
+				stepName: "implement",
+				data: { tool: "WebSearch", summary: "" },
+			},
+		]);
 	});
 
 	it("aggregates a tool_use_by_name counter on the canonical bag", async () => {
+		const { ctx } = captureCtx();
 		const { logger, bag } = capturingLogger();
 
 		await canonicalLog.run(
 			{ scope: "run" },
 			async () => {
-				logAgentMessage(toolUseMsg("Read", { file_path: "a.ts" }), "/work");
-				logAgentMessage(toolUseMsg("Read", { file_path: "b.ts" }), "/work");
-				logAgentMessage(toolUseMsg("Edit", { file_path: "c.ts" }), "/work");
+				emitAgentMessageEvents(toolUseMsg("Read", { file_path: "a.ts" }), {
+					ctx,
+					stepName: "implement",
+					cwd: "/work",
+				});
+				emitAgentMessageEvents(toolUseMsg("Read", { file_path: "b.ts" }), {
+					ctx,
+					stepName: "implement",
+					cwd: "/work",
+				});
+				emitAgentMessageEvents(toolUseMsg("Edit", { file_path: "c.ts" }), {
+					ctx,
+					stepName: "implement",
+					cwd: "/work",
+				});
 			},
 			logger,
 		);
@@ -88,30 +194,21 @@ describe("logAgentMessage", () => {
 			}),
 		);
 	});
+});
 
-	it("reads file_path, pattern, or command from tool input", () => {
-		const emitToolUse = vi.fn();
-		const workDir = "/workdir";
-
-		logAgentMessage(
-			toolUseMsg("Read", { file_path: "/workdir/src/app.ts" }),
-			workDir,
-			emitToolUse,
+describe("trackAgentToolUseBag", () => {
+	it("increments tool counters without emitting events", async () => {
+		const { logger, bag } = capturingLogger();
+		await canonicalLog.run(
+			{ scope: "run" },
+			async () => {
+				trackAgentToolUseBag(toolUseMsg("Bash", { command: "ls" }));
+				trackAgentToolUseBag(toolUseMsg("Bash", { command: "pwd" }));
+			},
+			logger,
 		);
-		expect(emitToolUse).toHaveBeenLastCalledWith("Read", "src/app.ts");
-
-		logAgentMessage(
-			toolUseMsg("Grep", { pattern: "TODO" }),
-			workDir,
-			emitToolUse,
+		expect(bag()).toEqual(
+			expect.objectContaining({ tool_use_by_name: { Bash: 2 } }),
 		);
-		expect(emitToolUse).toHaveBeenLastCalledWith("Grep", "TODO");
-
-		logAgentMessage(
-			toolUseMsg("Bash", { command: "ls -la" }),
-			workDir,
-			emitToolUse,
-		);
-		expect(emitToolUse).toHaveBeenLastCalledWith("Bash", "ls -la");
 	});
 });

--- a/server/orchestrator/agent-logging.ts
+++ b/server/orchestrator/agent-logging.ts
@@ -1,43 +1,140 @@
 import * as canonicalLog from "../canonical-log.ts";
+import type { RunContext } from "../runner/runner.ts";
 
 export type AgentMessage = {
 	type: "assistant";
 	message: { content: ContentBlock[] };
 };
 
-/** Log assistant text and tool use activity from an agent message. */
-export function logAgentMessage(
+type EmitContext = {
+	ctx: Pick<RunContext, "emit">;
+	stepName: string;
+	cwd: string;
+};
+
+export function emitAgentMessageEvents(
 	msg: AgentMessage,
-	workDir: string,
-	emitToolUse?: (tool: string, target: string) => void,
+	{ ctx, stepName, cwd }: EmitContext,
 ): void {
 	for (const block of msg.message.content) {
-		if (!isToolUse(block)) continue;
-		const raw = String(
-			block.input["pattern"] ??
-				block.input["file_path"] ??
-				block.input["command"] ??
-				"",
-		);
-		const detail = shortPath(raw, workDir).slice(0, 100);
+		if (isTextBlock(block)) {
+			const text = block.text.trim();
+			if (text.length === 0) continue;
+			ctx.emit({
+				kind: "agent:say",
+				stepName,
+				data: { text },
+			});
+			continue;
+		}
+		if (!isToolUseBlock(block)) continue;
 		canonicalLog.incrementMap("tool_use_by_name", block.name);
-		emitToolUse?.(block.name, detail);
+		emitToolEvent(block, { ctx, stepName, cwd });
+	}
+}
+
+export function trackAgentToolUseBag(msg: AgentMessage): void {
+	for (const block of msg.message.content) {
+		if (!isToolUseBlock(block)) continue;
+		canonicalLog.incrementMap("tool_use_by_name", block.name);
 	}
 }
 
 type TextBlock = { type: "text"; text: string };
 type ToolUseBlock = {
 	type: "tool_use";
+	id?: string;
 	name: string;
 	input: Record<string, unknown>;
 };
 type ContentBlock = TextBlock | ToolUseBlock | { type: string };
 
-function isToolUse(block: ContentBlock): block is ToolUseBlock {
+function isTextBlock(block: ContentBlock): block is TextBlock {
+	return block.type === "text" && typeof (block as TextBlock).text === "string";
+}
+
+function isToolUseBlock(block: ContentBlock): block is ToolUseBlock {
 	return block.type === "tool_use";
 }
 
-/** Strip the workdir prefix from a path for cleaner logging. */
+function emitToolEvent(
+	block: ToolUseBlock,
+	{ ctx, stepName, cwd }: EmitContext,
+): void {
+	const input = block.input;
+	switch (block.name) {
+		case "Read": {
+			ctx.emit({
+				kind: "tool:read",
+				stepName,
+				data: {
+					path: shortPath(stringInput(input["file_path"]), cwd),
+					lines: 0,
+				},
+			});
+			return;
+		}
+		case "Edit":
+		case "Write":
+		case "MultiEdit": {
+			ctx.emit({
+				kind: "tool:edit",
+				stepName,
+				data: {
+					path: shortPath(stringInput(input["file_path"]), cwd),
+					added: 0,
+					removed: 0,
+					summary: "",
+				},
+			});
+			return;
+		}
+		case "Grep": {
+			ctx.emit({
+				kind: "tool:grep",
+				stepName,
+				data: {
+					pattern: stringInput(input["pattern"]),
+					path: shortPath(stringInput(input["path"] ?? ""), cwd),
+					matches: 0,
+				},
+			});
+			return;
+		}
+		case "Bash": {
+			ctx.emit({
+				kind: "tool:bash",
+				stepName,
+				data: {
+					command: stringInput(input["command"]),
+					cwd,
+					state: "running",
+					exitCode: null,
+				},
+			});
+			return;
+		}
+		default: {
+			const summary = stringInput(
+				input["pattern"] ?? input["file_path"] ?? input["command"] ?? "",
+			);
+			ctx.emit({
+				kind: "tool:other",
+				stepName,
+				data: {
+					tool: block.name,
+					summary: shortPath(summary, cwd).slice(0, 100),
+				},
+			});
+		}
+	}
+}
+
+function stringInput(value: unknown): string {
+	if (value == null) return "";
+	return String(value);
+}
+
 function shortPath(fullPath: string, workDir: string): string {
 	const privatePrefixed = `/private${workDir}`;
 	if (fullPath.startsWith(privatePrefixed)) {

--- a/server/orchestrator/branch-resolver.ts
+++ b/server/orchestrator/branch-resolver.ts
@@ -2,7 +2,7 @@ import type { Issue } from "../trackers/types.ts";
 import type { WorkflowBranch } from "../workflow/workflow.ts";
 import { renderPrompt } from "../workflow/workflow.ts";
 import type { AgentInvoker, OutputFormat } from "./agent-invoker.ts";
-import { logAgentMessage } from "./agent-logging.ts";
+import { trackAgentToolUseBag } from "./agent-logging.ts";
 import { recordAgentResult } from "./agent-metrics.ts";
 
 type ResolveBranchParams = {
@@ -40,7 +40,7 @@ export async function resolveBranch({
 		outputFormat,
 	})) {
 		if (msg.type === "assistant") {
-			logAgentMessage(msg, cwd);
+			trackAgentToolUseBag(msg);
 			continue;
 		}
 		if (msg.type !== "result") continue;

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -2,9 +2,14 @@ import * as canonicalLog from "../canonical-log.ts";
 import type { CodeHostAdapter } from "../code-hosts/types.ts";
 import type { Logger } from "../logger.ts";
 import type { RunRepository } from "../run-repository.ts";
-import type { RunHandle, Runner, RunResult } from "../runner/runner.ts";
+import type {
+	RunContext,
+	RunHandle,
+	Runner,
+	RunResult,
+} from "../runner/runner.ts";
 import type { Issue, TrackerAdapter } from "../trackers/types.ts";
-import type { RepoSlug, RunId } from "../types/brands.ts";
+import type { RepoSlug } from "../types/brands.ts";
 import type { RepoWorkflow } from "../workflow/workflow.ts";
 import type { AgentInvoker } from "./agent-invoker.ts";
 import { resolveBranch } from "./branch-resolver.ts";
@@ -101,6 +106,16 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 							ctx.runId,
 							workflow.steps.map((s, i) => ({ index: i + 1, name: s.name })),
 						);
+						ctx.emit({
+							kind: "system",
+							stepName: null,
+							data: {
+								message: "workspace prepared",
+								command: null,
+								path: ws.path,
+								exitCode: null,
+							},
+						});
 
 						try {
 							const branchResolverStart = clock.now();
@@ -118,11 +133,33 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 							branch = resolvedBranch;
 							canonicalLog.set({ branch });
 							runRepo.setRunBranch(ctx.runId, branch);
+							ctx.emit({
+								kind: "system",
+								stepName: null,
+								data: {
+									message: "branch resolved",
+									command: null,
+									path: branch,
+									exitCode: null,
+								},
+							});
 
 							phase = "setup";
 							await ensureBranch(ws.path, branch);
 							const repoSetupRan = await runRepoSetup(ws.path, runShell);
 							canonicalLog.set({ repo_setup_ran: repoSetupRan });
+							if (repoSetupRan) {
+								ctx.emit({
+									kind: "system",
+									stepName: null,
+									data: {
+										message: "repo setup ran",
+										command: ".agent/setup.sh",
+										path: ws.path,
+										exitCode: 0,
+									},
+								});
+							}
 
 							phase = "step";
 							outputs = await runWorkflowSteps({
@@ -157,7 +194,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 							result.status === "completed" &&
 							branch !== undefined &&
 							(await finalizeSuccess(
-								ctx.runId,
+								ctx,
 								repo,
 								issue,
 								workflow,
@@ -183,7 +220,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 	}
 
 	async function finalizeSuccess(
-		runId: RunId,
+		ctx: RunContext,
 		repo: RepoSlug,
 		issue: Issue,
 		workflow: RepoWorkflow,
@@ -214,13 +251,23 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 				title,
 				body,
 			);
-			runRepo.setRunPr(runId, {
+			runRepo.setRunPr(ctx.runId, {
 				repo,
 				number: pr.number,
 				url: pr.url,
 				kind: "opened",
 			});
 			canonicalLog.set({ pr_url: pr.url });
+			ctx.emit({
+				kind: "system",
+				stepName: null,
+				data: {
+					message: "change request opened",
+					command: null,
+					path: pr.url,
+					exitCode: null,
+				},
+			});
 		} catch (err) {
 			recordFailure(
 				"change_request",

--- a/server/orchestrator/step-runner.test.ts
+++ b/server/orchestrator/step-runner.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import * as canonicalLog from "../canonical-log.ts";
-import type { StepEvent } from "../event-bus.ts";
+import type { RunEvent } from "../event-bus.ts";
 import type { RunRepository } from "../run-repository.ts";
-import type { RunContext } from "../runner/runner.ts";
+import type { EmitInput, RunContext } from "../runner/runner.ts";
 import {
 	buildAssistantMessage,
 	buildErrorResult,
@@ -84,17 +84,20 @@ type StepRepoSubset = Pick<
 type ContextRecorder = {
 	ctx: RunContext;
 	runRepo: StepRepoSubset;
-	stepEvents: StepEvent[];
+	emitted: EmitInput[];
 	stepOutputs: { runId: RunId; name: string; value: unknown }[];
 };
 
 function createCtx(): ContextRecorder {
-	const stepEvents: StepEvent[] = [];
+	const emitted: EmitInput[] = [];
 	const stepOutputs: { runId: RunId; name: string; value: unknown }[] = [];
 	const ctx: RunContext = {
 		runId: runId("test-run"),
-		emitToolUse: () => {},
-		emitStepEvent: (event) => stepEvents.push(event),
+		emit: ((input: EmitInput) => {
+			emitted.push(input);
+			return {} as RunEvent;
+		}) as RunContext["emit"],
+		updateToolBashState: () => undefined,
 		signal: new AbortController().signal,
 	};
 	const runRepo: StepRepoSubset = {
@@ -106,7 +109,7 @@ function createCtx(): ContextRecorder {
 		failStep: () => {},
 		addRunUsage: () => {},
 	};
-	return { ctx, runRepo, stepEvents, stepOutputs };
+	return { ctx, runRepo, emitted, stepOutputs };
 }
 
 type ScriptedCall = AgentInvokeOptions;
@@ -211,19 +214,21 @@ describe("runWorkflowSteps", () => {
 			{ runId: recorder.ctx.runId, name: "summarise", value: structured },
 		]);
 		expect(outputs).toEqual({ summarise: structured });
-		expect(recorder.stepEvents).toEqual([
+		expect(recorder.emitted).toEqual([
 			{
-				type: "step.started",
+				kind: "step:started",
+				stepName: "summarise",
 				data: { name: "summarise", index: 1, total: 1 },
 			},
 			{
-				type: "step.completed",
+				kind: "step:completed",
+				stepName: "summarise",
 				data: { name: "summarise", index: 1, durationMs: expect.any(Number) },
 			},
 		]);
 	});
 
-	it("aborts with step.failed when result.subtype is error_max_structured_output_retries", async () => {
+	it("aborts with step:failed when result.subtype is error_max_structured_output_retries", async () => {
 		const recorder = createCtx();
 		const agent = createAgent(async function* () {
 			yield buildErrorResult({
@@ -260,17 +265,20 @@ describe("runWorkflowSteps", () => {
 		).rejects.toThrow(/error_max_structured_output_retries/);
 
 		expect(agent.calls).toHaveLength(1);
-		expect(recorder.stepEvents).toEqual([
+		expect(recorder.emitted).toEqual([
 			{
-				type: "step.started",
+				kind: "step:started",
+				stepName: "summarise",
 				data: { name: "summarise", index: 1, total: 2 },
 			},
 			{
-				type: "step.failed",
+				kind: "step:failed",
+				stepName: "summarise",
 				data: {
 					name: "summarise",
 					index: 1,
 					error: expect.stringMatching(/error_max_structured_output_retries/),
+					durationMs: expect.any(Number),
 				},
 			},
 		]);
@@ -305,13 +313,15 @@ describe("runWorkflowSteps", () => {
 		});
 
 		expect(recorder.stepOutputs).toEqual([]);
-		expect(recorder.stepEvents).toEqual([
+		expect(recorder.emitted).toEqual([
 			{
-				type: "step.started",
+				kind: "step:started",
+				stepName: "implement",
 				data: { name: "implement", index: 1, total: 1 },
 			},
 			{
-				type: "step.completed",
+				kind: "step:completed",
+				stepName: "implement",
 				data: { name: "implement", index: 1, durationMs: expect.any(Number) },
 			},
 		]);

--- a/server/orchestrator/step-runner.ts
+++ b/server/orchestrator/step-runner.ts
@@ -9,7 +9,7 @@ import {
 import type { RepoWorkflow, WorkflowStep } from "../workflow/workflow.ts";
 import { renderPrompt } from "../workflow/workflow.ts";
 import type { AgentInvoker, OutputFormat } from "./agent-invoker.ts";
-import { logAgentMessage } from "./agent-logging.ts";
+import { emitAgentMessageEvents } from "./agent-logging.ts";
 import { recordAgentResult } from "./agent-metrics.ts";
 
 type StepRunRepository = Pick<
@@ -107,8 +107,9 @@ async function runWorkflowStep({
 	const startedAt = new Date(startedAtMs).toISOString();
 	let currentSessionId = resumeSessionId;
 	runRepo.startStep(ctx.runId, stepIndex, { startedAt });
-	ctx.emitStepEvent({
-		type: "step.started",
+	ctx.emit({
+		kind: "step:started",
+		stepName: step.name,
 		data: { name: step.name, index: stepIndex, total: totalSteps },
 	});
 
@@ -138,7 +139,7 @@ async function runWorkflowStep({
 			...(outputFormat && { outputFormat }),
 		})) {
 			if (msg.type === "assistant") {
-				logAgentMessage(msg, cwd, ctx.emitToolUse);
+				emitAgentMessageEvents(msg, { ctx, stepName: step.name, cwd });
 				currentSessionId = msg.session_id;
 				continue;
 			}
@@ -179,17 +180,19 @@ async function runWorkflowStep({
 		});
 		canonicalLog.increment("steps_completed");
 		canonicalLog.incrementMap("step_durations_ms", step.name, durationMs);
-		ctx.emitStepEvent({
-			type: "step.completed",
+		ctx.emit({
+			kind: "step:completed",
+			stepName: step.name,
 			data: { name: step.name, index: stepIndex, durationMs },
 		});
 		return currentSessionId;
 	} catch (err) {
 		const error = err instanceof Error ? err.message : String(err);
 		const completedAtMs = Date.now();
+		const durationMs = completedAtMs - startedAtMs;
 		runRepo.failStep(ctx.runId, stepIndex, {
 			completedAt: new Date(completedAtMs).toISOString(),
-			durationMs: completedAtMs - startedAtMs,
+			durationMs,
 			error,
 		});
 		runRepo.addRunUsage(ctx.runId, {
@@ -200,9 +203,10 @@ async function runWorkflowStep({
 		canonicalLog.set({
 			failed_step: { name: step.name, index: stepIndex, error },
 		});
-		ctx.emitStepEvent({
-			type: "step.failed",
-			data: { name: step.name, index: stepIndex, error },
+		ctx.emit({
+			kind: "step:failed",
+			stepName: step.name,
+			data: { name: step.name, index: stepIndex, error, durationMs },
 		});
 		throw err;
 	}

--- a/server/run-repository.ts
+++ b/server/run-repository.ts
@@ -1,17 +1,20 @@
 import { randomUUID } from "node:crypto";
 
-import { and, asc, desc, eq, isNotNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, isNotNull, sql } from "drizzle-orm";
 
 import type { Db } from "./db/db.ts";
 import {
 	type PrKind,
-	type RunEventType,
+	type RunEventData,
+	type RunEventKind,
 	type RunStatus,
 	runEvents,
 	runStepOutputs,
 	runSteps,
 	runs,
+	type ToolBashData,
 } from "./db/schema.ts";
+import type { RunEvent } from "./event-bus.ts";
 import type { IssueKey, RepoSlug, RunId } from "./types/brands.ts";
 
 export type RunPr = {
@@ -51,14 +54,20 @@ export type FailedRun = RunBase & {
 
 export type Run = RunningRun | CompletedRun | FailedRun;
 
-export type RunEvent = typeof runEvents.$inferSelect;
-
 export type RunStep = typeof runSteps.$inferSelect;
 
 export type StepUsage = {
 	costUsd: number;
 	tokensInput: number;
 	tokensOutput: number;
+};
+
+export type InsertEventInput = {
+	runId: RunId;
+	kind: RunEventKind;
+	stepName: string | null;
+	data: RunEventData;
+	createdAt: string;
 };
 
 export type RunRepository = {
@@ -82,12 +91,11 @@ export type RunRepository = {
 	setRunWorkspaceDir(runId: RunId, workspaceDir: string): void;
 	setRunPr(runId: RunId, pr: RunPr): void;
 	addRunUsage(runId: RunId, usage: StepUsage): void;
-	insertEvent(event: {
-		runId: RunId;
-		type: RunEventType;
-		data: Record<string, unknown>;
-		createdAt: string;
-	}): void;
+	insertEvent(event: InsertEventInput): RunEvent;
+	updateToolBashState(
+		eventId: string,
+		patch: Partial<Pick<ToolBashData, "state" | "exitCode">>,
+	): RunEvent | undefined;
 	getRunningSnapshot(): { id: RunId; issueKey: IssueKey; repo: RepoSlug }[];
 	getRunById(id: RunId): Run | undefined;
 	getRuns(filters: {
@@ -96,6 +104,10 @@ export type RunRepository = {
 		limit: number;
 	}): Run[];
 	getRunEvents(runId: RunId): RunEvent[];
+	getRunEventsAfterSeq(runId: RunId, sinceSeq: number): RunEvent[];
+	getAllEventsAfterSeq(sinceSeq: number): RunEvent[];
+	getEventSeqById(id: string): number | undefined;
+	getInflightToolBash(runId: RunId): RunEvent[];
 	insertSteps(
 		runId: RunId,
 		steps: ReadonlyArray<{ index: number; name: string }>,
@@ -178,9 +190,28 @@ export function createRunRepository(db: Db): RunRepository {
 		},
 
 		insertEvent(event) {
-			db.insert(runEvents)
-				.values({ id: randomUUID(), ...event })
+			const id = randomUUID();
+			const row = db
+				.insert(runEvents)
+				.values({ id, ...event })
+				.returning()
+				.get();
+			return rowToEvent(row);
+		},
+
+		updateToolBashState(eventId, patch) {
+			const row = db
+				.select()
+				.from(runEvents)
+				.where(eq(runEvents.id, eventId))
+				.get();
+			if (!row || row.kind !== "tool:bash") return undefined;
+			const merged: ToolBashData = { ...(row.data as ToolBashData), ...patch };
+			db.update(runEvents)
+				.set({ data: merged })
+				.where(eq(runEvents.id, eventId))
 				.run();
+			return rowToEvent({ ...row, data: merged });
 		},
 
 		getRunningSnapshot() {
@@ -223,8 +254,48 @@ export function createRunRepository(db: Db): RunRepository {
 				.select()
 				.from(runEvents)
 				.where(eq(runEvents.runId, runId))
-				.orderBy(asc(runEvents.createdAt))
-				.all();
+				.orderBy(asc(runEvents.seq))
+				.all()
+				.map(rowToEvent);
+		},
+
+		getRunEventsAfterSeq(runId, sinceSeq) {
+			return db
+				.select()
+				.from(runEvents)
+				.where(and(eq(runEvents.runId, runId), gt(runEvents.seq, sinceSeq)))
+				.orderBy(asc(runEvents.seq))
+				.all()
+				.map(rowToEvent);
+		},
+
+		getAllEventsAfterSeq(sinceSeq) {
+			return db
+				.select()
+				.from(runEvents)
+				.where(gt(runEvents.seq, sinceSeq))
+				.orderBy(asc(runEvents.seq))
+				.all()
+				.map(rowToEvent);
+		},
+
+		getEventSeqById(id) {
+			const row = db
+				.select({ seq: runEvents.seq })
+				.from(runEvents)
+				.where(eq(runEvents.id, id))
+				.get();
+			return row?.seq;
+		},
+
+		getInflightToolBash(runId) {
+			return db
+				.select()
+				.from(runEvents)
+				.where(and(eq(runEvents.runId, runId), eq(runEvents.kind, "tool:bash")))
+				.all()
+				.filter((row) => (row.data as ToolBashData).state === "running")
+				.map(rowToEvent);
 		},
 
 		insertSteps(runId, steps) {
@@ -294,6 +365,7 @@ export function createRunRepository(db: Db): RunRepository {
 }
 
 type RunRow = typeof runs.$inferSelect;
+type RunEventRow = typeof runEvents.$inferSelect;
 
 function rowToRun(row: RunRow): Run {
 	const pr =
@@ -353,4 +425,16 @@ function rowToRun(row: RunRow): Run {
 				error: row.error,
 			};
 	}
+}
+
+function rowToEvent(row: RunEventRow): RunEvent {
+	return {
+		id: row.id,
+		seq: row.seq as number,
+		runId: row.runId,
+		kind: row.kind,
+		stepName: row.stepName,
+		data: row.data,
+		createdAt: row.createdAt,
+	} as RunEvent;
 }

--- a/server/runner/runner.integration.test.ts
+++ b/server/runner/runner.integration.test.ts
@@ -192,17 +192,25 @@ describe("Runner integration", () => {
 		const events = getEvents(db, runId);
 		expect(events).toEqual([
 			{
+				seq: expect.any(Number),
 				id: expect.any(String),
 				runId,
-				type: "run:started",
+				kind: "run:started",
+				stepName: null,
 				data: { issueKey: ik("acme/widgets#4"), issueTitle: "Lifecycle issue" },
 				createdAt: expect.any(String),
 			},
 			{
+				seq: expect.any(Number),
 				id: expect.any(String),
 				runId,
-				type: "run:completed",
-				data: { durationMs: expect.any(Number) },
+				kind: "run:completed",
+				stepName: null,
+				data: {
+					durationMs: expect.any(Number),
+					costUsd: 0,
+					tokens: { in: 0, out: 0 },
+				},
 				createdAt: expect.any(String),
 			},
 		]);
@@ -224,9 +232,11 @@ describe("Runner integration", () => {
 		const events = getEvents(db, runId);
 		expect(events).toEqual([
 			{
+				seq: expect.any(Number),
 				id: expect.any(String),
 				runId,
-				type: "run:started",
+				kind: "run:started",
+				stepName: null,
 				data: {
 					issueKey: ik("acme/widgets#5"),
 					issueTitle: "Fail event issue",
@@ -234,16 +244,18 @@ describe("Runner integration", () => {
 				createdAt: expect.any(String),
 			},
 			{
+				seq: expect.any(Number),
 				id: expect.any(String),
 				runId,
-				type: "run:failed",
+				kind: "run:failed",
+				stepName: null,
 				data: { error: "boom", durationMs: expect.any(Number) },
 				createdAt: expect.any(String),
 			},
 		]);
 	});
 
-	it("records tool_use events when emitToolUse is called", async () => {
+	it("records typed tool events when ctx.emit is called", async () => {
 		const runner = createRunner({ repo, maxConcurrency: 1 });
 
 		const { runId } = runner.enqueue({
@@ -252,8 +264,21 @@ describe("Runner integration", () => {
 			issueTitle: "Tool issue",
 			issueUrl: null,
 			handler: async (ctx) => {
-				ctx.emitToolUse("Read", "/src/index.ts");
-				ctx.emitToolUse("Edit", "/src/index.ts");
+				ctx.emit({
+					kind: "tool:read",
+					stepName: "implement",
+					data: { path: "src/index.ts", lines: 0 },
+				});
+				ctx.emit({
+					kind: "tool:edit",
+					stepName: "implement",
+					data: {
+						path: "src/index.ts",
+						added: 0,
+						removed: 0,
+						summary: "",
+					},
+				});
 				return { status: "completed", durationMs: 0 };
 			},
 		});
@@ -263,34 +288,115 @@ describe("Runner integration", () => {
 		const events = getEvents(db, runId);
 		expect(events).toEqual([
 			{
+				seq: expect.any(Number),
 				id: expect.any(String),
 				runId,
-				type: "run:started",
+				kind: "run:started",
+				stepName: null,
 				data: { issueKey: ik("acme/widgets#6"), issueTitle: "Tool issue" },
 				createdAt: expect.any(String),
 			},
 			{
+				seq: expect.any(Number),
 				id: expect.any(String),
 				runId,
-				type: "run:tool_use",
-				data: { tool: "Read", target: "/src/index.ts" },
+				kind: "tool:read",
+				stepName: "implement",
+				data: { path: "src/index.ts", lines: 0 },
 				createdAt: expect.any(String),
 			},
 			{
+				seq: expect.any(Number),
 				id: expect.any(String),
 				runId,
-				type: "run:tool_use",
-				data: { tool: "Edit", target: "/src/index.ts" },
+				kind: "tool:edit",
+				stepName: "implement",
+				data: { path: "src/index.ts", added: 0, removed: 0, summary: "" },
 				createdAt: expect.any(String),
 			},
 			{
+				seq: expect.any(Number),
 				id: expect.any(String),
 				runId,
-				type: "run:completed",
-				data: { durationMs: expect.any(Number) },
+				kind: "run:completed",
+				stepName: null,
+				data: {
+					durationMs: expect.any(Number),
+					costUsd: 0,
+					tokens: { in: 0, out: 0 },
+				},
 				createdAt: expect.any(String),
 			},
 		]);
+	});
+
+	it("flips in-flight tool:bash events to aborted on kill", async () => {
+		const runner = createRunner({ repo, maxConcurrency: 1 });
+
+		const { runId, done } = runner.enqueue({
+			repo: rs("acme/widgets"),
+			issueKey: ik("acme/widgets#8"),
+			issueTitle: "Killed mid-bash",
+			issueUrl: null,
+			handler: async (ctx) => {
+				ctx.emit({
+					kind: "tool:bash",
+					stepName: "implement",
+					data: {
+						command: "sleep 60",
+						cwd: "/work",
+						state: "running",
+						exitCode: null,
+					},
+				});
+				return new Promise<RunResult>(() => {});
+			},
+		});
+
+		await Promise.resolve();
+		// Give the handler a tick to emit the tool:bash event.
+		await new Promise((r) => setTimeout(r, 5));
+		runner.kill(runId);
+		await done;
+
+		const events = getEvents(db, runId).filter((e) => e.kind === "tool:bash");
+		expect(events).toHaveLength(1);
+		expect(events[0]?.data).toEqual({
+			command: "sleep 60",
+			cwd: "/work",
+			state: "aborted",
+			exitCode: null,
+		});
+	});
+
+	it("flips in-flight tool:bash events to exited on normal completion", async () => {
+		const runner = createRunner({ repo, maxConcurrency: 1 });
+
+		const { runId, done } = runner.enqueue({
+			repo: rs("acme/widgets"),
+			issueKey: ik("acme/widgets#9"),
+			issueTitle: "Bash exits normally",
+			issueUrl: null,
+			handler: async (ctx) => {
+				ctx.emit({
+					kind: "tool:bash",
+					stepName: "implement",
+					data: {
+						command: "ls",
+						cwd: "/work",
+						state: "running",
+						exitCode: null,
+					},
+				});
+				return { status: "completed", durationMs: 0 };
+			},
+		});
+
+		await done;
+
+		const events = getEvents(db, runId).filter((e) => e.kind === "tool:bash");
+		expect(events).toHaveLength(1);
+		expect((events[0]?.data as { state: string }).state).toBe("exited");
 	});
 
 	it("aborts a running job when killed", async () => {

--- a/server/runner/runner.ts
+++ b/server/runner/runner.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { eventBus, type RunEvent, type StepEvent } from "../event-bus.ts";
+import type { RunEventData, RunEventKind, ToolBashData } from "../db/schema.ts";
+import { eventBus, type RunEvent } from "../event-bus.ts";
 import type { RunRepository } from "../run-repository.ts";
 import {
 	type IssueKey,
@@ -11,10 +12,22 @@ import { createJobQueue, type JobQueue } from "./queue.ts";
 
 export const ABORT_ERROR = "Run killed by user";
 
+export type EmitInput<K extends RunEventKind = RunEventKind> = {
+	kind: K;
+	stepName: string | null;
+	data: Extract<RunEvent, { kind: K }>["data"];
+};
+
 export type RunContext = {
 	runId: RunId;
-	emitToolUse: (tool: string, target: string) => void;
-	emitStepEvent: (event: StepEvent) => void;
+	emit<K extends RunEventKind>(
+		input: EmitInput<K>,
+		createdAt?: string,
+	): Extract<RunEvent, { kind: K }>;
+	updateToolBashState(
+		eventId: string,
+		patch: Partial<Pick<ToolBashData, "state" | "exitCode">>,
+	): RunEvent | undefined;
 	signal: AbortSignal;
 };
 
@@ -56,28 +69,29 @@ export function createRunner(config: RunnerConfig): Runner {
 	);
 	const activeRuns = new Map<RunId, AbortController>();
 
-	type EventPayload = {
-		[E in RunEvent as E["type"]]: Pick<E, "type" | "data">;
-	}[RunEvent["type"]];
-
-	function emitEvent(
+	function emitFor<K extends RunEventKind>(
 		id: RunId,
-		event: EventPayload,
+		input: EmitInput<K>,
 		createdAt = new Date().toISOString(),
-	): void {
-		// Post-narrowing: TS doesn't recombine the discriminated union through a spread.
-		const fullEvent = {
-			...event,
+	): Extract<RunEvent, { kind: K }> {
+		const event = repo.insertEvent({
 			runId: id,
+			kind: input.kind,
+			stepName: input.stepName,
+			data: input.data as RunEventData,
 			createdAt,
-		} as RunEvent;
-		repo.insertEvent({
-			runId: id,
-			type: event.type,
-			data: event.data,
-			createdAt,
-		});
-		eventBus.emit(fullEvent);
+		}) as Extract<RunEvent, { kind: K }>;
+		eventBus.emit(event);
+		return event;
+	}
+
+	function flushInflightBash(id: RunId, finalState: "exited" | "aborted") {
+		for (const event of repo.getInflightToolBash(id)) {
+			const updated = repo.updateToolBashState(event.id, {
+				state: finalState,
+			});
+			if (updated) eventBus.emit(updated);
+		}
 	}
 
 	function kill(id: RunId): boolean {
@@ -110,10 +124,11 @@ export function createRunner(config: RunnerConfig): Runner {
 			startedAt,
 		});
 
-		emitEvent(
+		emitFor(
 			id,
 			{
-				type: "run:started",
+				kind: "run:started",
+				stepName: null,
 				data: { issueKey: job.issueKey, issueTitle: job.issueTitle },
 			},
 			startedAt,
@@ -122,15 +137,15 @@ export function createRunner(config: RunnerConfig): Runner {
 		queue.enqueue(async () => {
 			const executionStart = Date.now();
 
-			const emitToolUse = (tool: string, target: string) => {
-				emitEvent(id, {
-					type: "run:tool_use",
-					data: { tool, target },
-				});
-			};
-
-			const emitStepEvent: RunContext["emitStepEvent"] = (event) => {
-				emitEvent(id, event);
+			const ctx: RunContext = {
+				runId: id,
+				emit: (input, createdAt) => emitFor(id, input, createdAt),
+				updateToolBashState: (eventId, patch) => {
+					const updated = repo.updateToolBashState(eventId, patch);
+					if (updated) eventBus.emit(updated);
+					return updated;
+				},
+				signal: controller.signal,
 			};
 
 			const abortPromise = new Promise<RunResult>((resolve) => {
@@ -143,24 +158,30 @@ export function createRunner(config: RunnerConfig): Runner {
 				});
 			});
 
-			const result = await Promise.race([
-				job.handler({
-					runId: id,
-					emitToolUse,
-					emitStepEvent,
-					signal: controller.signal,
-				}),
-				abortPromise,
-			]);
+			const result = await Promise.race([job.handler(ctx), abortPromise]);
 
 			const completedAt = new Date().toISOString();
+			const aborted = controller.signal.aborted;
+			flushInflightBash(id, aborted ? "aborted" : "exited");
 
 			if (result.status === "completed") {
 				repo.completeRun(id, { completedAt, durationMs: result.durationMs });
 
-				emitEvent(
+				const run = repo.getRunById(id);
+				emitFor(
 					id,
-					{ type: "run:completed", data: { durationMs: result.durationMs } },
+					{
+						kind: "run:completed",
+						stepName: null,
+						data: {
+							durationMs: result.durationMs,
+							costUsd: run?.costUsd ?? 0,
+							tokens: {
+								in: run?.tokensInput ?? 0,
+								out: run?.tokensOutput ?? 0,
+							},
+						},
+					},
 					completedAt,
 				);
 			} else {
@@ -170,10 +191,11 @@ export function createRunner(config: RunnerConfig): Runner {
 					durationMs: result.durationMs,
 				});
 
-				emitEvent(
+				emitFor(
 					id,
 					{
-						type: "run:failed",
+						kind: "run:failed",
+						stepName: null,
 						data: { error: result.error, durationMs: result.durationMs },
 					},
 					completedAt,


### PR DESCRIPTION
## Summary

End-to-end vertical slice for the run transcript per #104:

- **Schema:** `runEvents.seq` autoincrement (indexed), reshaped `kind` enum + per-kind `data` shapes; old `run:output` / `run:tool_use` shapes dropped outright.
- **Event bus:** new `RunEvent` discriminated union; typed emit helpers from the orchestrator (no more JSON blob plumbing).
- **Orchestrator:** emits `run:*` / `step:*` / `agent:say` / typed `tool:*` / `system` events; in-flight `tool:bash` flips to `aborted` on kill, `exited` on completion.
- **API:** `GET /runs/:id/events` (with `since` cursor), `GET /events` SSE firehose with 30s heartbeats and `Last-Event-ID` replay, `POST /runs/:id/kill` returning `{ killed }`. RFC 7807 problem details for 400/404/409.
- **Dashboard:** new `useRunEvents(id)` hook (one-shot REST + SSE merge with `Last-Event-ID` seeded from last seen id), `Transcript` component matching `dashboard-prototypes/05-system.html` (step dividers, italic say-text, typed tool rows, blinking cursor for live `tool:bash`, distinct `aborted` marker), kill button wired in `RunBanner`.

## Test plan

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] Manual: start a run, watch transcript stream live, hit kill mid-`bash`, verify `aborted` rendering and 409 on a second kill.
- [ ] Manual: refresh dashboard mid-run, confirm `Last-Event-ID` replay produces no duplicates and no missing events.

Closes #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)