### PR TITLE
feat: dashboard redesign slice 3 — active + queue left column

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { QueueColumn } from "./components/queue-column.tsx";
 import { RunBanner } from "./components/run-banner.tsx";
 import { Transcript } from "./components/transcript.tsx";
 import { WorkflowStripe } from "./components/workflow-stripe.tsx";
@@ -16,11 +17,12 @@ export function App() {
 					<span>local-agents</span>
 				</div>
 			</header>
-			<div className="shell">
+			<main className="shell">
+				<QueueColumn activeRunId={runId} />
 				<section className="center">
 					<CenterContent runId={runId} />
 				</section>
-			</div>
+			</main>
 		</>
 	);
 }

--- a/dashboard/src/components/queue-column.tsx
+++ b/dashboard/src/components/queue-column.tsx
@@ -1,0 +1,78 @@
+import { useQueue } from "../hooks/use-queue.ts";
+import { elapsedSinceMs, formatElapsed, formatTime } from "../lib/format.ts";
+import type { ActiveRun, QueuedItem } from "../lib/types.ts";
+
+export function QueueColumn({ activeRunId }: { activeRunId: string | null }) {
+	const { data } = useQueue();
+	const active = data?.active ?? [];
+	const queued = data?.queued ?? [];
+
+	return (
+		<section className="queue" data-testid="queue">
+			<div className="col-head">
+				<h2>Active</h2>
+			</div>
+			{active.map((run) => (
+				<ActiveRow key={run.id} run={run} selected={run.id === activeRunId} />
+			))}
+			<div className="hgroup-head">Queued</div>
+			{queued.map((item) => (
+				<QueuedRow key={item.issueKey} item={item} />
+			))}
+		</section>
+	);
+}
+
+function ActiveRow({ run, selected }: { run: ActiveRun; selected: boolean }) {
+	const elapsedMs = elapsedSinceMs(run.startedAt);
+	const widthPct = Math.max(0, Math.min(1, run.progressRatio)) * 100;
+
+	return (
+		<a
+			className={`qrow${selected ? " active" : ""}`}
+			href={`/?runId=${encodeURIComponent(run.id)}`}
+			data-testid={`queue-active-${run.id}`}
+		>
+			<div className="qrow-top">
+				<span className="pip running" />
+				<span className="qrow-name">{run.issueTitle ?? run.id}</span>
+				<span className="qrow-time mono">{formatElapsed(elapsedMs)}</span>
+			</div>
+			<div className="qrow-issue">
+				{run.issueKey != null && (
+					<span className="key mono">{run.issueKey}</span>
+				)}
+				{run.repo}
+			</div>
+			<div className="qrow-progress">
+				<div className="fill" style={{ width: `${widthPct}%` }} />
+			</div>
+			<div className="qrow-step">
+				<span className="stepname">
+					{run.currentStep
+						? `step ${run.currentStep.index} / ${run.currentStep.total} · ${run.currentStep.name}`
+						: "—"}
+				</span>
+			</div>
+		</a>
+	);
+}
+
+function QueuedRow({ item }: { item: QueuedItem }) {
+	return (
+		<div
+			className="qrow queued"
+			data-testid={`queue-queued-${item.issueKey}`}
+			title={`pending since ${formatTime(item.pendingSince)}`}
+		>
+			<div className="qrow-top">
+				<span className="pip queued" />
+				<span className="qrow-name">{item.issueTitle}</span>
+			</div>
+			<div className="qrow-issue">
+				<span className="key mono">{item.issueKey}</span>
+				{item.repo}
+			</div>
+		</div>
+	);
+}

--- a/dashboard/src/components/run-banner.tsx
+++ b/dashboard/src/components/run-banner.tsx
@@ -1,5 +1,6 @@
 import { killRun } from "../lib/api.ts";
 import {
+	elapsedSinceMs,
 	formatCost,
 	formatElapsed,
 	formatTime,
@@ -12,9 +13,7 @@ type Props = {
 };
 
 export function RunBanner({ run }: Props) {
-	const elapsedMs =
-		run.durationMs ??
-		Math.max(0, Date.now() - new Date(run.startedAt).getTime());
+	const elapsedMs = run.durationMs ?? elapsedSinceMs(run.startedAt);
 	const tokens = (run.tokensInput ?? 0) + (run.tokensOutput ?? 0);
 
 	return (

--- a/dashboard/src/dashboard.queue.test.tsx
+++ b/dashboard/src/dashboard.queue.test.tsx
@@ -1,0 +1,104 @@
+import { describe, expect } from "vitest";
+import {
+	createActiveRun,
+	createQueuedItem,
+	createQueueSnapshot,
+	createRun,
+	createRunDetail,
+} from "./testing/contract.ts";
+import { test } from "./testing/fixture.tsx";
+import {
+	queueHandler,
+	runDetailHandler,
+	runEventsHandler,
+} from "./testing/handlers.ts";
+import { browserWorker } from "./testing/msw.ts";
+
+describe("dashboard queue column", () => {
+	test("renders Active rows with progress bar + step label and Queued rows", async ({
+		dashboardPage,
+	}) => {
+		browserWorker.use(
+			runEventsHandler("run_9f3b2e1c"),
+			runDetailHandler(
+				"run_9f3b2e1c",
+				createRunDetail({
+					run: createRun({
+						id: "run_9f3b2e1c",
+						issueTitle: "npm install hangs on linux runners",
+					}),
+				}),
+			),
+			queueHandler(
+				createQueueSnapshot({
+					active: [
+						createActiveRun({
+							id: "run_9f3b2e1c",
+							repo: "acme/api",
+							issueKey: "ACME-1284",
+							issueTitle: "npm install hangs on linux runners",
+							currentStep: { name: "implement", index: 1, total: 3 },
+							progressRatio: 0.17,
+						}),
+					],
+					queued: [
+						createQueuedItem({
+							issueKey: "ACME-1285",
+							issueTitle: "500 on /api/runs?limit=0",
+							repo: "acme/api",
+							pendingSince: "2026-05-09T14:31:42Z",
+						}),
+						createQueuedItem({
+							issueKey: "WIDGETS-911",
+							issueTitle: "cover branch-resolver edges",
+							repo: "widgets/dashboard",
+							pendingSince: "2026-05-09T14:31:55Z",
+						}),
+					],
+				}),
+			),
+		);
+
+		const page = await dashboardPage.mountAt("run_9f3b2e1c");
+
+		const activeRow = page.getByTestId("queue-active-run_9f3b2e1c");
+		await expect
+			.element(activeRow)
+			.toHaveTextContent("npm install hangs on linux runners");
+		await expect.element(activeRow).toHaveTextContent("ACME-1284");
+		await expect.element(activeRow).toHaveTextContent("acme/api");
+		await expect.element(activeRow).toHaveTextContent("step 1 / 3 · implement");
+		await expect.element(activeRow).toHaveClass(/\bactive\b/);
+
+		const queuedFirst = page.getByTestId("queue-queued-ACME-1285");
+		await expect
+			.element(queuedFirst)
+			.toHaveTextContent("500 on /api/runs?limit=0");
+		await expect.element(queuedFirst).toHaveTextContent("ACME-1285");
+
+		const queuedSecond = page.getByTestId("queue-queued-WIDGETS-911");
+		await expect
+			.element(queuedSecond)
+			.toHaveTextContent("cover branch-resolver edges");
+	});
+
+	test("queued rows have no progress bar or step label", async ({
+		dashboardPage,
+	}) => {
+		browserWorker.use(
+			queueHandler(
+				createQueueSnapshot({
+					queued: [
+						createQueuedItem({ issueKey: "ACME-9", issueTitle: "waiting" }),
+					],
+				}),
+			),
+		);
+
+		const page = await dashboardPage.mountAt(null);
+
+		const row = page.getByTestId("queue-queued-ACME-9");
+		await expect.element(row).toHaveClass(/\bqueued\b/);
+		await expect.element(row).not.toHaveTextContent(/step \d+ \/ \d+/);
+	});
+});

--- a/dashboard/src/hooks/use-queue.ts
+++ b/dashboard/src/hooks/use-queue.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchQueueSnapshot } from "../lib/api.ts";
+import type { QueueSnapshot } from "../lib/types.ts";
+
+const POLL_INTERVAL_MS = 2_000;
+
+export function useQueue() {
+	return useQuery<QueueSnapshot>({
+		queryKey: ["queue"],
+		queryFn: fetchQueueSnapshot,
+		refetchInterval: POLL_INTERVAL_MS,
+	});
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -130,20 +130,209 @@ header.app .meta-right {
 /* ───── shell ───── */
 
 .shell {
-	display: flex;
+	display: grid;
+	grid-template-columns: 320px 1fr;
 	flex: 1;
 	max-width: 1800px;
 	margin: 0 auto;
 	width: 100%;
+	background: var(--bg);
 	border-left: var(--b);
 	border-right: var(--b);
+	min-height: 0;
+}
+
+.shell > section {
+	border-right: var(--b);
+	min-height: 0;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+}
+
+.shell > section:last-child {
+	border-right: none;
 }
 
 .center {
 	background: var(--bg);
-	flex: 1;
+}
+
+.col-head {
+	height: 38px;
+	padding: 0 16px;
+	border-bottom: var(--b);
 	display: flex;
-	flex-direction: column;
+	align-items: center;
+	justify-content: space-between;
+	background: var(--running-bg);
+	position: sticky;
+	top: 0;
+	z-index: 10;
+}
+
+.col-head h2 {
+	margin: 0;
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--fg);
+}
+
+/* ───── queue column ───── */
+
+.queue {
+	overflow-y: auto;
+}
+
+.qrow {
+	display: block;
+	padding: 12px 16px;
+	border-bottom: 1px solid var(--line);
+	cursor: pointer;
+	position: relative;
+	transition: background 0.12s;
+	color: inherit;
+	text-decoration: none;
+}
+
+.qrow:hover {
+	background: var(--bg-1);
+}
+
+.qrow.active {
+	background: var(--bg-1);
+}
+
+.qrow.active::before {
+	content: "";
+	position: absolute;
+	left: 0;
+	top: 0;
+	bottom: 0;
+	width: 2px;
+	background: var(--running);
+}
+
+.qrow-top {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 4px;
+}
+
+.pip {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.pip.running {
+	background: var(--running);
+	animation: breathe 1.6s ease-in-out infinite;
+}
+
+.pip.queued {
+	background: transparent;
+	border: 1px solid var(--fg-4);
+}
+
+.qrow-name {
+	font-size: 13px;
+	font-weight: 500;
+	color: var(--fg);
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.qrow-time {
+	font-size: 11.5px;
+	color: var(--fg-3);
+	font-variant-numeric: tabular-nums;
+}
+
+.qrow.active .qrow-time {
+	color: var(--running);
+}
+
+.qrow-issue {
+	font-size: 12px;
+	color: var(--fg-3);
+	margin: 0 0 0 14px;
+	line-height: 1.4;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.qrow-issue .key {
+	color: var(--link);
+	margin-right: 4px;
+}
+
+.qrow-progress {
+	margin: 8px 0 0 14px;
+	height: 2px;
+	background: var(--bg-3);
+	border-radius: 1px;
+	overflow: hidden;
+	position: relative;
+}
+
+.qrow-progress .fill {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	background: var(--running);
+	border-radius: 1px;
+}
+
+.qrow.queued .qrow-progress {
+	display: none;
+}
+
+.qrow-step {
+	margin: 6px 0 0 14px;
+	font-size: 11.5px;
+	color: var(--fg-3);
+	display: flex;
+	justify-content: space-between;
+	gap: 8px;
+	font-variant-numeric: tabular-nums;
+}
+
+.qrow-step .stepname {
+	color: var(--fg-2);
+}
+
+.qrow.queued .qrow-step {
+	display: none;
+}
+
+.hgroup-head {
+	padding: 18px 16px 6px;
+	font-size: 10.5px;
+	color: var(--fg-4);
+	font-weight: 500;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.queue .hgroup-head {
+	height: 38px;
+	padding: 0 16px;
+	display: flex;
+	align-items: center;
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--fg);
+	letter-spacing: 0;
+	text-transform: none;
+	background: var(--running-bg);
 }
 
 /* ───── run banner ───── */

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { RunDetail, RunEvent } from "./types.ts";
+import type { QueueSnapshot, RunDetail, RunEvent } from "./types.ts";
 
 async function apiFetch(url: string, init?: RequestInit): Promise<Response> {
 	const res = await fetch(url, init);
@@ -18,5 +18,10 @@ export async function fetchRunEvents(runId: string): Promise<RunEvent[]> {
 
 export async function killRun(runId: string): Promise<{ killed: boolean }> {
 	const res = await apiFetch(`/runs/${runId}/kill`, { method: "POST" });
+	return res.json();
+}
+
+export async function fetchQueueSnapshot(): Promise<QueueSnapshot> {
+	const res = await apiFetch("/queue");
 	return res.json();
 }

--- a/dashboard/src/lib/format.ts
+++ b/dashboard/src/lib/format.ts
@@ -15,6 +15,10 @@ export function formatElapsed(ms: number): string {
 	return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
 }
 
+export function elapsedSinceMs(startedAt: string): number {
+	return Math.max(0, Date.now() - new Date(startedAt).getTime());
+}
+
 export function formatStepDuration(ms: number | null): string {
 	if (ms == null) return "—";
 	const totalSeconds = Math.floor(ms / 1000);

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -45,6 +45,25 @@ export type RunDetail = {
 	steps: Step[];
 };
 
+export type CurrentStep = { name: string; index: number; total: number };
+
+export type ActiveRun = Run & {
+	currentStep: CurrentStep | null;
+	progressRatio: number;
+};
+
+export type QueuedItem = {
+	issueKey: string;
+	issueTitle: string;
+	repo: string;
+	pendingSince: string;
+};
+
+export type QueueSnapshot = {
+	active: ActiveRun[];
+	queued: QueuedItem[];
+};
+
 type RunEventBase = {
 	id: string;
 	seq: number;

--- a/dashboard/src/testing/contract.ts
+++ b/dashboard/src/testing/contract.ts
@@ -1,4 +1,12 @@
-import type { Run, RunDetail, RunEvent, Step } from "../lib/types.ts";
+import type {
+	ActiveRun,
+	QueuedItem,
+	QueueSnapshot,
+	Run,
+	RunDetail,
+	RunEvent,
+	Step,
+} from "../lib/types.ts";
 
 export function createRun(overrides: Partial<Run> = {}): Run {
 	return {
@@ -56,6 +64,35 @@ type EventInput = {
 		createdAt?: string;
 	};
 }[RunEvent["kind"]];
+
+export function createActiveRun(overrides: Partial<ActiveRun> = {}): ActiveRun {
+	return {
+		...createRun(overrides),
+		currentStep: overrides.currentStep ?? null,
+		progressRatio: overrides.progressRatio ?? 0,
+	};
+}
+
+export function createQueuedItem(
+	overrides: Partial<QueuedItem> = {},
+): QueuedItem {
+	return {
+		issueKey: "ACME-1285",
+		issueTitle: "queued issue",
+		repo: "acme/api",
+		pendingSince: "2026-05-09T14:31:42Z",
+		...overrides,
+	};
+}
+
+export function createQueueSnapshot(
+	overrides: Partial<QueueSnapshot> = {},
+): QueueSnapshot {
+	return {
+		active: overrides.active ?? [],
+		queued: overrides.queued ?? [],
+	};
+}
 
 export function createEvent(event: EventInput): RunEvent {
 	const seq = event.seq ?? nextSeq++;

--- a/dashboard/src/testing/handlers.ts
+++ b/dashboard/src/testing/handlers.ts
@@ -1,5 +1,5 @@
 import { HttpResponse, http } from "msw";
-import type { RunDetail, RunEvent } from "../lib/types.ts";
+import type { QueueSnapshot, RunDetail, RunEvent } from "../lib/types.ts";
 
 export function runDetailHandler(runId: string, detail: RunDetail) {
 	return http.get(`/runs/${runId}`, () => HttpResponse.json(detail));
@@ -31,6 +31,10 @@ export function killRunHandler(
 	return http.post(`/runs/${runId}/kill`, () => HttpResponse.json(body));
 }
 
+export function queueHandler(snapshot: QueueSnapshot) {
+	return http.get("/queue", () => HttpResponse.json(snapshot));
+}
+
 function eventsStreamHandler() {
 	return http.get(
 		"/events",
@@ -51,4 +55,6 @@ function eventsStreamHandler() {
 	);
 }
 
-export const handlers = [eventsStreamHandler()];
+const defaultQueueHandler = queueHandler({ active: [], queued: [] });
+
+export const handlers = [eventsStreamHandler(), defaultQueueHandler];

--- a/server/api/api.ts
+++ b/server/api/api.ts
@@ -4,6 +4,7 @@ import { streamSSE } from "hono/streaming";
 import { z } from "zod";
 import { eventBus, type RunEvent } from "../event-bus.ts";
 import type { Logger } from "../logger.ts";
+import type { Orchestrator } from "../orchestrator/orchestrator.ts";
 import type {
 	Run,
 	RunRepository,
@@ -32,11 +33,13 @@ export type HealthCheck = () => HealthCheckResult;
 export function createApi({
 	runner,
 	repo,
+	queue,
 	checkHealth,
 	logger,
 }: {
 	runner: Runner;
 	repo: RunRepository;
+	queue: Pick<Orchestrator, "getQueueSnapshot">;
 	checkHealth: HealthCheck;
 	logger: Logger;
 }) {
@@ -152,6 +155,20 @@ export function createApi({
 		},
 	);
 
+	app.get("/queue", (c) => {
+		const active: ActiveRunWire[] = repo
+			.getRuns({ status: "running", limit: 200 })
+			.map((run) => {
+				const steps = repo.getRunSteps(run.id);
+				return {
+					...runToWire(run),
+					currentStep: currentStepFor(steps),
+					progressRatio: progressRatioFor(steps),
+				};
+			});
+		return c.json({ active, queued: queue.getQueueSnapshot() });
+	});
+
 	app.get("/health", (c) => {
 		const result = checkHealth();
 		return c.json(result, result.status === "healthy" ? 200 : 503);
@@ -198,6 +215,26 @@ type RunWire = {
 };
 
 type StepWire = Omit<RunStepRow, "runId">;
+
+type CurrentStepWire = { name: string; index: number; total: number };
+
+type ActiveRunWire = RunWire & {
+	currentStep: CurrentStepWire | null;
+	progressRatio: number;
+};
+
+function currentStepFor(steps: RunStepRow[]): CurrentStepWire | null {
+	const running = steps.find((s) => s.state === "running");
+	if (!running) return null;
+	return { name: running.name, index: running.index, total: steps.length };
+}
+
+function progressRatioFor(steps: RunStepRow[]): number {
+	if (steps.length === 0) return 0;
+	const completed = steps.filter((s) => s.state === "completed").length;
+	const inFlight = steps.some((s) => s.state === "running") ? 0.5 : 0;
+	return (completed + inFlight) / steps.length;
+}
 
 async function writeFrame(
 	stream: {

--- a/server/api/queue.test.ts
+++ b/server/api/queue.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { createTestApi } from "../test-support/test-api.ts";
+import { seedRun, seedStep } from "../test-support/test-db.ts";
+import { issueKey, repoSlug } from "../types/brands.ts";
+
+describe("GET /queue", () => {
+	it("returns empty active and queued lists when nothing is running or queued", async () => {
+		const { app } = createTestApi();
+
+		const res = await app.request("/queue");
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ active: [], queued: [] });
+	});
+
+	it("returns running runs as ActiveRun with currentStep + progressRatio", async () => {
+		const { app, db } = createTestApi();
+		seedRun(db, {
+			id: "run_9f3b2e1c",
+			status: "running",
+			repo: "acme/api",
+			issueKey: "ACME-1284",
+			issueTitle: "npm install hangs on linux runners",
+			issueUrl: null,
+			branch: "fix/ACME-1284-npm-install-hang",
+			workspaceDir: "/tmp/lag/9f3b2e1",
+			costUsd: 0.034,
+			tokensInput: 9800,
+			tokensOutput: 2600,
+			startedAt: "2026-05-09T14:27:56Z",
+		});
+		seedStep(db, {
+			runId: "run_9f3b2e1c",
+			index: 1,
+			name: "implement",
+			state: "running",
+			startedAt: "2026-05-09T14:28:19Z",
+		});
+		seedStep(db, {
+			runId: "run_9f3b2e1c",
+			index: 2,
+			name: "review",
+			state: "pending",
+		});
+		seedStep(db, {
+			runId: "run_9f3b2e1c",
+			index: 3,
+			name: "summarise",
+			state: "pending",
+		});
+
+		const res = await app.request("/queue");
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			active: [
+				{
+					id: "run_9f3b2e1c",
+					status: "running",
+					error: null,
+					repo: "acme/api",
+					branch: "fix/ACME-1284-npm-install-hang",
+					workspaceDir: "/tmp/lag/9f3b2e1",
+					issueKey: "ACME-1284",
+					issueTitle: "npm install hangs on linux runners",
+					issueUrl: null,
+					startedAt: "2026-05-09T14:27:56Z",
+					completedAt: null,
+					durationMs: null,
+					costUsd: 0.034,
+					tokensInput: 9800,
+					tokensOutput: 2600,
+					pr: null,
+					currentStep: { name: "implement", index: 1, total: 3 },
+					progressRatio: 0.5 / 3,
+				},
+			],
+			queued: [],
+		});
+	});
+
+	it("computes progressRatio as (completed + 0.5 if any running) / total", async () => {
+		const { app, db } = createTestApi();
+		seedRun(db, {
+			id: "r1",
+			status: "running",
+			startedAt: "2026-01-01T00:00:00Z",
+		});
+		seedStep(db, { runId: "r1", index: 1, name: "a", state: "completed" });
+		seedStep(db, { runId: "r1", index: 2, name: "b", state: "running" });
+		seedStep(db, { runId: "r1", index: 3, name: "c", state: "pending" });
+
+		const body = (await (await app.request("/queue")).json()) as {
+			active: Array<{ progressRatio: number }>;
+		};
+		expect(body.active[0]?.progressRatio).toBeCloseTo(1.5 / 3, 10);
+	});
+
+	it("reports currentStep null when between steps", async () => {
+		const { app, db } = createTestApi();
+		seedRun(db, {
+			id: "r2",
+			status: "running",
+			startedAt: "2026-01-01T00:00:00Z",
+		});
+		seedStep(db, { runId: "r2", index: 1, name: "a", state: "completed" });
+		seedStep(db, { runId: "r2", index: 2, name: "b", state: "pending" });
+
+		const body = (await (await app.request("/queue")).json()) as {
+			active: Array<{ currentStep: unknown; progressRatio: number }>;
+		};
+		expect(body.active[0]?.currentStep).toBeNull();
+		expect(body.active[0]?.progressRatio).toBe(1 / 2);
+	});
+
+	it("returns queued items from the orchestrator's holding queue", async () => {
+		const { app } = createTestApi({
+			queued: [
+				{
+					issueKey: issueKey("ACME-1285"),
+					issueTitle: "500 on /api/runs?limit=0",
+					repo: repoSlug("acme/api"),
+					pendingSince: "2026-05-09T14:31:42Z",
+				},
+				{
+					issueKey: issueKey("WIDGETS-911"),
+					issueTitle: "cover branch-resolver edges",
+					repo: repoSlug("widgets/dashboard"),
+					pendingSince: "2026-05-09T14:31:55Z",
+				},
+			],
+		});
+
+		const res = await app.request("/queue");
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			active: [],
+			queued: [
+				{
+					issueKey: "ACME-1285",
+					issueTitle: "500 on /api/runs?limit=0",
+					repo: "acme/api",
+					pendingSince: "2026-05-09T14:31:42Z",
+				},
+				{
+					issueKey: "WIDGETS-911",
+					issueTitle: "cover branch-resolver edges",
+					repo: "widgets/dashboard",
+					pendingSince: "2026-05-09T14:31:55Z",
+				},
+			],
+		});
+	});
+});

--- a/server/orchestrator/orchestrator.queue.integration.test.ts
+++ b/server/orchestrator/orchestrator.queue.integration.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { hangingAgent, jiraIssueKey, REPO } from "../test-support/fixtures.ts";
+import { createTestOrchestrator } from "../test-support/test-orchestrator.ts";
+
+describe("Orchestrator holding queue", () => {
+	it("captures pending issues with first-seen pendingSince and clears them on dispatch", async () => {
+		await using ctx = await createTestOrchestrator({
+			configOverrides: { max_concurrent: 1 },
+			runAgent: hangingAgent,
+		});
+		const { orchestrator, workspace, tracker } = ctx;
+
+		tracker.addIssue("pending", {
+			number: 1,
+			repo: REPO,
+			title: "issue one",
+			createdAt: "2025-01-01T00:00:00.000+0000",
+		});
+		tracker.addIssue("pending", {
+			number: 2,
+			repo: REPO,
+			title: "issue two",
+			createdAt: "2025-01-02T00:00:00.000+0000",
+		});
+		await workspace.preCreateWorkspace(jiraIssueKey(1));
+		await workspace.preCreateWorkspace(jiraIssueKey(2));
+
+		await orchestrator.tick();
+
+		expect(orchestrator.getQueueSnapshot()).toEqual([
+			{
+				issueKey: jiraIssueKey(2),
+				issueTitle: "issue two",
+				repo: REPO,
+				pendingSince: expect.any(String),
+			},
+		]);
+	});
+
+	it("preserves pendingSince across ticks for issues that stay pending", async () => {
+		await using ctx = await createTestOrchestrator({
+			configOverrides: { max_concurrent: 0 },
+		});
+		const { orchestrator, tracker } = ctx;
+
+		tracker.addIssue("pending", {
+			number: 7,
+			repo: REPO,
+			title: "stays pending",
+		});
+
+		await orchestrator.tick();
+		const first = orchestrator.getQueueSnapshot();
+		expect(first).toEqual([
+			{
+				issueKey: jiraIssueKey(7),
+				issueTitle: "stays pending",
+				repo: REPO,
+				pendingSince: expect.any(String),
+			},
+		]);
+
+		// A later tick must not bump pendingSince forward.
+		await new Promise((r) => setTimeout(r, 5));
+		await orchestrator.tick();
+		const second = orchestrator.getQueueSnapshot();
+		expect(second[0]?.pendingSince).toBe(first[0]?.pendingSince);
+	});
+
+	it("removes issues from the queue when the tracker stops reporting them as pending", async () => {
+		await using ctx = await createTestOrchestrator({
+			configOverrides: { max_concurrent: 0 },
+		});
+		const { orchestrator, tracker } = ctx;
+
+		tracker.addIssue("pending", { number: 11, repo: REPO });
+		tracker.addIssue("pending", { number: 12, repo: REPO });
+		await orchestrator.tick();
+		expect(orchestrator.getQueueSnapshot()).toHaveLength(2);
+
+		tracker.removeIssue("pending", 11);
+		await orchestrator.tick();
+		expect(orchestrator.getQueueSnapshot()).toEqual([
+			expect.objectContaining({ issueKey: jiraIssueKey(12) }),
+		]);
+	});
+
+	it("does not write DB rows for queued items", async () => {
+		await using ctx = await createTestOrchestrator({
+			configOverrides: { max_concurrent: 0 },
+		});
+		const { orchestrator, db, tracker } = ctx;
+		const { runs } = await import("../db/schema.ts");
+
+		tracker.addIssue("pending", { number: 21, repo: REPO });
+		tracker.addIssue("pending", { number: 22, repo: REPO });
+		await orchestrator.tick();
+
+		expect(orchestrator.getQueueSnapshot()).toHaveLength(2);
+		expect(db.select().from(runs).all()).toEqual([]);
+	});
+});

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -25,7 +25,14 @@ type OrchestratorConfig = {
 	runShell?: RunShell;
 };
 
-type Orchestrator = {
+export type QueuedItem = {
+	issueKey: IssueKey;
+	issueTitle: string;
+	repo: Issue["repo"];
+	pendingSince: string;
+};
+
+export type Orchestrator = {
 	tick(): Promise<void>;
 	/** Reconcile DB and tracker state left over from a previous process. */
 	recover(): Promise<void>;
@@ -33,6 +40,13 @@ type Orchestrator = {
 	settled(): Promise<void>;
 	start(): void;
 	stop(): void;
+	/** Snapshot of the in-memory holding queue, ordered by `pendingSince` ascending. */
+	getQueueSnapshot(): QueuedItem[];
+};
+
+type QueueEntry = {
+	issue: Issue;
+	pendingSince: string;
 };
 
 type TickState = {
@@ -49,6 +63,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 	let timer: ReturnType<typeof setInterval>;
 	let ticking = false;
 	const pendingPostRuns = new Set<Promise<unknown>>();
+	const holdingQueue = new Map<IssueKey, QueueEntry>();
 
 	const {
 		runRepo,
@@ -185,14 +200,34 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		);
 	}
 
-	async function dispatchPendingIssues(
-		state: TickState,
-	): Promise<DispatchTally> {
+	function reconcileQueue(state: TickState): void {
+		const pendingByKey = new Map(state.pending.map((i) => [i.key, i]));
+
+		for (const key of holdingQueue.keys()) {
+			if (!pendingByKey.has(key) || state.runningIssueKeys.has(key)) {
+				holdingQueue.delete(key);
+			}
+		}
+
+		const nowIso = new Date(clock.now()).toISOString();
+		for (const issue of state.pending) {
+			if (state.runningIssueKeys.has(issue.key)) continue;
+			const existing = holdingQueue.get(issue.key);
+			if (existing) {
+				existing.issue = issue;
+			} else {
+				holdingQueue.set(issue.key, { issue, pendingSince: nowIso });
+			}
+		}
+	}
+
+	async function dispatchFromQueue(state: TickState): Promise<DispatchTally> {
 		const tally: DispatchTally = {
 			dispatched: 0,
 			skippedAtCapacity: 0,
 		};
-		for (const issue of state.pending) {
+		for (const entry of [...holdingQueue.values()]) {
+			const { issue } = entry;
 			if (state.runningIssueKeys.has(issue.key)) continue;
 			if (state.runningIssueKeys.size >= defaults.max_concurrent) {
 				tally.skippedAtCapacity += 1;
@@ -230,6 +265,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 				continue;
 			}
 
+			holdingQueue.delete(issue.key);
 			state.runningIssueKeys.add(issue.key);
 			tally.dispatched += 1;
 		}
@@ -249,7 +285,9 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 						pending_count: state.pending.length,
 						running_count: state.runningIssueKeys.size,
 					});
-					const tally = await dispatchPendingIssues(state);
+					reconcileQueue(state);
+					canonicalLog.set({ queued_count: holdingQueue.size });
+					const tally = await dispatchFromQueue(state);
 					canonicalLog.set({
 						dispatched_count: tally.dispatched,
 						skipped_at_capacity: tally.skippedAtCapacity,
@@ -291,6 +329,14 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		},
 		stop() {
 			clearInterval(timer);
+		},
+		getQueueSnapshot() {
+			return [...holdingQueue.values()].map((entry) => ({
+				issueKey: entry.issue.key,
+				issueTitle: entry.issue.title,
+				repo: entry.issue.repo,
+				pendingSince: entry.pendingSince,
+			}));
 		},
 	};
 }

--- a/server/server.ts
+++ b/server/server.ts
@@ -68,6 +68,7 @@ const checkHealth: HealthCheck = () => {
 const app = createApi({
 	runner,
 	repo,
+	queue: orchestrator,
 	checkHealth,
 	logger,
 });

--- a/server/test-support/test-api.ts
+++ b/server/test-support/test-api.ts
@@ -1,4 +1,5 @@
 import { createApi, type HealthCheck } from "../api/api.ts";
+import type { QueuedItem } from "../orchestrator/orchestrator.ts";
 import { createRunRepository } from "../run-repository.ts";
 import { createRunner } from "../runner/runner.ts";
 import { createTestDb } from "./test-db.ts";
@@ -9,13 +10,18 @@ const healthyCheck: HealthCheck = () => ({
 	checks: { database: { status: "pass" } },
 });
 
-export function createTestApi(opts?: { checkHealth?: HealthCheck }) {
+export function createTestApi(opts?: {
+	checkHealth?: HealthCheck;
+	queued?: QueuedItem[];
+}) {
 	const db = createTestDb();
 	const repo = createRunRepository(db);
 	const runner = createRunner({ repo, maxConcurrency: 2 });
+	const queued = opts?.queued ?? [];
 	const app = createApi({
 		runner,
 		repo,
+		queue: { getQueueSnapshot: () => queued },
 		checkHealth: opts?.checkHealth ?? healthyCheck,
 		logger: testLogger,
 	});

--- a/server/test-support/tracker-stub.ts
+++ b/server/test-support/tracker-stub.ts
@@ -30,6 +30,7 @@ type FailedRecord = {
 
 type TrackerStub = TrackerAdapter & {
 	addIssue(state: TrackerState, input: AddIssueInput): Issue;
+	removeIssue(state: TrackerState, number: number): void;
 	readonly transitions: readonly TransitionRecord[];
 	readonly markedFailed: readonly FailedRecord[];
 	readonly fetchCalls: readonly TrackerState[];
@@ -71,6 +72,10 @@ export function createTrackerStub(
 			const issue = buildIssue(input);
 			active[state].push(issue);
 			return issue;
+		},
+
+		removeIssue(state, number) {
+			active[state] = active[state].filter((i) => i.number !== number);
 		},
 
 		get transitions() {


### PR DESCRIPTION
Closes #105.

## Summary

- **Orchestrator**: introduces an in-memory holding queue between the tracker fetch and runner dispatch (`reconcileQueue` + `dispatchFromQueue`). `pendingSince` is captured at first observation and preserved across ticks; entries are evicted when the tracker stops reporting them or once they start running. No DB rows for queued items.
- **API**: `GET /queue` returns `QueueSnapshot` per `docs/dashboard-api-design.md` — `active[]` carries the full `Run` shape plus `currentStep` (`{name, index, total}` or `null` between steps) and `progressRatio` `(completed + 0.5 if any running) / total`; `queued[]` carries `{issueKey, issueTitle, repo, pendingSince}`.
- **Dashboard**: new `QueueColumn` component, `useQueue()` hook polling at 2s, and CSS for the left column matching `dashboard-prototypes/05-system.html`.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (249 tests across 34 files)
- [ ] Manual: spin up dev server, confirm active rows show progress bar + step label and queued rows appear without progress/step
- [ ] Manual: kill the server while an issue is queued, restart — `pendingSince` resets (acceptable per design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)