### PR TITLE
feat: dashboard redesign slice 4 — overview stats strip (#106)

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { OverviewStrip } from "./components/overview-strip.tsx";
 import { QueueColumn } from "./components/queue-column.tsx";
 import { RunBanner } from "./components/run-banner.tsx";
 import { Transcript } from "./components/transcript.tsx";
@@ -17,6 +18,7 @@ export function App() {
 					<span>local-agents</span>
 				</div>
 			</header>
+			<OverviewStrip />
 			<main className="shell">
 				<QueueColumn activeRunId={runId} />
 				<section className="center">

--- a/dashboard/src/components/overview-strip.tsx
+++ b/dashboard/src/components/overview-strip.tsx
@@ -1,0 +1,169 @@
+import { useStats } from "../hooks/use-stats.ts";
+import type { Stats } from "../lib/types.ts";
+
+const SPARK_HEIGHT_PX = 14;
+const SPARK_MIN_PX = 2;
+
+export function OverviewStrip() {
+	const { data } = useStats();
+
+	const running = data?.running ?? { active: 0, max: 0 };
+	const queued = data?.queued ?? { count: 0 };
+	const last24h = data?.last24h ?? emptyLast24h();
+	const slotsFree = Math.max(0, running.max - running.active);
+
+	return (
+		<section className="overview" data-testid="overview">
+			<Stat label="Running" labelPip>
+				<Value primary={String(running.active)} dim={` / ${running.max}`} />
+				<Note>{`${slotsFree} slots free`}</Note>
+			</Stat>
+
+			<Stat label="Queued">
+				<Value primary={String(queued.count)} />
+			</Stat>
+
+			<Stat label="Completed · 24h">
+				<Value primary={String(last24h.completed)} />
+				<Note>
+					<Delta value={last24h.completedDelta} kind="more-is-good" />
+					<span> vs yesterday</span>
+				</Note>
+			</Stat>
+
+			<Stat label="Failed · 24h">
+				<Value primary={String(last24h.failed)} />
+				<Note>{`${(last24h.successRate * 100).toFixed(1)}% success`}</Note>
+			</Stat>
+
+			<Stat label="P50 / P95 duration">
+				<div className="value value-small" data-testid="stat-value">
+					{formatCoarseMinutes(last24h.p50DurationMs)}
+					<span className="dim"> · </span>
+					{formatCoarseMinutes(last24h.p95DurationMs)}
+				</div>
+				<Sparkline values={last24h.durationSparkline} />
+			</Stat>
+
+			<Stat label="Spend · 24h">
+				<Value primary={formatSpendUsd(last24h.spendUsd)} />
+				<Note>
+					<Delta
+						value={last24h.spendDeltaUsd}
+						kind="less-is-good"
+						format={formatSignedSpend}
+					/>
+					<span> vs yesterday</span>
+				</Note>
+			</Stat>
+		</section>
+	);
+}
+
+function Stat({
+	label,
+	labelPip,
+	children,
+}: {
+	label: string;
+	labelPip?: boolean;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="stat">
+			<div className="label">
+				{labelPip && <span className="running-pip" />}
+				{label}
+			</div>
+			{children}
+		</div>
+	);
+}
+
+function Value({ primary, dim }: { primary: string; dim?: string }) {
+	return (
+		<div className="value" data-testid="stat-value">
+			{primary}
+			{dim != null && <span className="dim">{dim}</span>}
+		</div>
+	);
+}
+
+function Note({ children }: { children: React.ReactNode }) {
+	return <div className="note">{children}</div>;
+}
+
+function Delta({
+	value,
+	kind,
+	format = formatSignedCount,
+}: {
+	value: number;
+	kind: "more-is-good" | "less-is-good";
+	format?: (n: number) => string;
+}) {
+	const isBad = kind === "more-is-good" ? value < 0 : value > 0;
+	return (
+		<span className={`delta${isBad ? " down" : ""}`} data-testid="stat-delta">
+			{format(value)}
+		</span>
+	);
+}
+
+function Sparkline({ values }: { values: number[] }) {
+	const max = Math.max(0, ...values);
+	return (
+		<div className="spark" data-testid="spark">
+			{values.map((v, i) => {
+				const ratio = max > 0 ? v / max : 0;
+				const height = Math.max(
+					SPARK_MIN_PX,
+					Math.round(ratio * SPARK_HEIGHT_PX),
+				);
+				const isLast = i === values.length - 1;
+				return (
+					<span
+						// biome-ignore lint/suspicious/noArrayIndexKey: sparkline bars have no stable id; index reflects ordinal position
+						key={i}
+						className={isLast ? "live" : undefined}
+						style={{ height: `${height}px` }}
+					/>
+				);
+			})}
+		</div>
+	);
+}
+
+function emptyLast24h(): Stats["last24h"] {
+	return {
+		completed: 0,
+		completedDelta: 0,
+		failed: 0,
+		successRate: 1,
+		spendUsd: 0,
+		spendDeltaUsd: 0,
+		p50DurationMs: 0,
+		p95DurationMs: 0,
+		durationSparkline: [],
+	};
+}
+
+function formatCoarseMinutes(ms: number): string {
+	const minutes = Math.round(ms / 60_000);
+	return `${minutes}m`;
+}
+
+function formatSpendUsd(usd: number): string {
+	return `$${usd.toFixed(2)}`;
+}
+
+function formatSignedCount(n: number): string {
+	if (n > 0) return `+${n}`;
+	return String(n);
+}
+
+function formatSignedSpend(usd: number): string {
+	if (usd === 0) return "$0.00";
+	const sign = usd > 0 ? "+" : "−";
+	return `${sign}$${Math.abs(usd).toFixed(2)}`;
+}

--- a/dashboard/src/dashboard.overview.test.tsx
+++ b/dashboard/src/dashboard.overview.test.tsx
@@ -1,0 +1,137 @@
+import { describe, expect } from "vitest";
+import { createStats } from "./testing/contract.ts";
+import { test } from "./testing/fixture.tsx";
+import { statsHandler } from "./testing/handlers.ts";
+import { browserWorker } from "./testing/msw.ts";
+
+describe("dashboard overview strip", () => {
+	test("renders six stat cells with running, queued, 24h aggregates and sparkline", async ({
+		dashboardPage,
+	}) => {
+		browserWorker.use(
+			statsHandler(
+				createStats({
+					running: { active: 3, max: 5 },
+					queued: { count: 7 },
+					last24h: {
+						completed: 142,
+						completedDelta: 12,
+						failed: 2,
+						successRate: 0.986,
+						spendUsd: 4.82,
+						spendDeltaUsd: 0.42,
+						p50DurationMs: 660_000,
+						p95DurationMs: 2_280_000,
+						durationSparkline: [
+							320_000, 510_000, 380_000, 720_000, 590_000, 860_000, 460_000,
+							920_000, 660_000, 780_000,
+						],
+					},
+				}),
+			),
+		);
+
+		const page = await dashboardPage.mountAt(null);
+
+		const overview = page.getByTestId("overview");
+		await expect.element(overview).toBeInTheDocument();
+
+		await expect.element(overview).toHaveTextContent("Running");
+		await expect.element(overview).toHaveTextContent("3");
+		await expect.element(overview).toHaveTextContent("/ 5");
+		await expect.element(overview).toHaveTextContent("2 slots free");
+
+		await expect.element(overview).toHaveTextContent("Queued");
+		await expect.element(overview).toHaveTextContent("7");
+
+		await expect.element(overview).toHaveTextContent("Completed · 24h");
+		await expect.element(overview).toHaveTextContent("142");
+		await expect.element(overview).toHaveTextContent("+12");
+		await expect.element(overview).toHaveTextContent("vs yesterday");
+
+		await expect.element(overview).toHaveTextContent("Failed · 24h");
+		await expect.element(overview).toHaveTextContent("98.6% success");
+
+		await expect.element(overview).toHaveTextContent("P50 / P95 duration");
+		await expect.element(overview).toHaveTextContent("11m");
+		await expect.element(overview).toHaveTextContent("38m");
+
+		await expect.element(overview).toHaveTextContent("Spend · 24h");
+		await expect.element(overview).toHaveTextContent("$4.82");
+		await expect.element(overview).toHaveTextContent("+$0.42");
+	});
+
+	test("colours deltas: more completed is good, more spend is bad", async ({
+		dashboardPage,
+	}) => {
+		browserWorker.use(
+			statsHandler(
+				createStats({
+					last24h: {
+						completed: 10,
+						completedDelta: 5,
+						failed: 0,
+						successRate: 1,
+						spendUsd: 1.0,
+						spendDeltaUsd: 0.2,
+						p50DurationMs: 0,
+						p95DurationMs: 0,
+						durationSparkline: [],
+					},
+				}),
+			),
+		);
+
+		const page = await dashboardPage.mountAt(null);
+
+		// completedDelta +5 → "delta" (good)
+		const completedDelta = page.getByText("+5");
+		await expect.element(completedDelta).toHaveClass("delta");
+		await expect.element(completedDelta).not.toHaveClass("down");
+
+		// spendDelta +$0.20 → "delta down" (more spend is bad)
+		const spendDelta = page.getByText("+$0.20");
+		await expect.element(spendDelta).toHaveClass("delta");
+		await expect.element(spendDelta).toHaveClass("down");
+	});
+
+	test("draws sparkline bar heights proportional to durationSparkline", async ({
+		dashboardPage,
+	}) => {
+		browserWorker.use(
+			statsHandler(
+				createStats({
+					last24h: {
+						completed: 0,
+						completedDelta: 0,
+						failed: 0,
+						successRate: 1,
+						spendUsd: 0,
+						spendDeltaUsd: 0,
+						p50DurationMs: 0,
+						p95DurationMs: 0,
+						durationSparkline: [10, 20, 40, 80],
+					},
+				}),
+			),
+		);
+
+		const page = await dashboardPage.mountAt(null);
+
+		const spark = page.getByTestId("spark");
+		await expect.poll(() => spark.element().children.length).toBe(4);
+
+		const bars = Array.from(
+			(spark.element() as HTMLElement).querySelectorAll<HTMLSpanElement>(
+				"span",
+			),
+		);
+		// max=80 → ratios 0.125, 0.25, 0.5, 1.0; *14 px rounded; min 2px
+		expect(bars[0]?.style.height).toBe("2px");
+		expect(bars[1]?.style.height).toBe("4px");
+		expect(bars[2]?.style.height).toBe("7px");
+		expect(bars[3]?.style.height).toBe("14px");
+		// last bar gets `live` class
+		expect(bars[3]?.className).toBe("live");
+	});
+});

--- a/dashboard/src/hooks/use-stats.ts
+++ b/dashboard/src/hooks/use-stats.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchStats } from "../lib/api.ts";
+import type { Stats } from "../lib/types.ts";
+
+const POLL_INTERVAL_MS = 5_000;
+
+export function useStats() {
+	return useQuery<Stats>({
+		queryKey: ["stats"],
+		queryFn: fetchStats,
+		refetchInterval: POLL_INTERVAL_MS,
+	});
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -127,6 +127,103 @@ header.app .meta-right {
 	color: var(--fg-3);
 }
 
+/* ───── overview strip ───── */
+
+.overview {
+	border-bottom: var(--b);
+	border-left: var(--b);
+	border-right: var(--b);
+	background: var(--bg);
+	display: grid;
+	grid-template-columns: repeat(6, 1fr);
+	max-width: 1800px;
+	margin: 0 auto;
+	width: 100%;
+}
+
+.stat {
+	padding: 18px 22px 18px;
+	border-right: var(--b);
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	min-width: 0;
+}
+
+.stat:last-child {
+	border-right: none;
+}
+
+.stat .label {
+	font-size: 11.5px;
+	color: var(--fg-3);
+	letter-spacing: 0;
+	font-weight: 450;
+}
+
+.stat .value {
+	font-size: 24px;
+	font-weight: 500;
+	letter-spacing: -0.025em;
+	line-height: 1;
+	color: var(--fg);
+	font-variant-numeric: tabular-nums;
+}
+
+.stat .value-small {
+	font-size: 18px;
+}
+
+.stat .value .dim {
+	color: var(--fg-4);
+	font-weight: 400;
+	font-size: 16px;
+}
+
+.stat .note {
+	font-size: 11.5px;
+	color: var(--fg-3);
+	font-variant-numeric: tabular-nums;
+}
+
+.stat .note .delta {
+	color: var(--completed);
+	font-variant-numeric: tabular-nums;
+}
+
+.stat .note .delta.down {
+	color: var(--failed);
+}
+
+.stat .running-pip {
+	display: inline-block;
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--running);
+	margin-right: 6px;
+	vertical-align: 1px;
+	animation: breathe 1.6s ease-in-out infinite;
+}
+
+.spark {
+	display: flex;
+	align-items: end;
+	gap: 2px;
+	height: 14px;
+	margin-top: 2px;
+}
+
+.spark span {
+	width: 4px;
+	background: var(--fg-5);
+	border-radius: 1px;
+}
+
+.spark span.live {
+	background: var(--running);
+}
+
 /* ───── shell ───── */
 
 .shell {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { QueueSnapshot, RunDetail, RunEvent } from "./types.ts";
+import type { QueueSnapshot, RunDetail, RunEvent, Stats } from "./types.ts";
 
 async function apiFetch(url: string, init?: RequestInit): Promise<Response> {
 	const res = await fetch(url, init);
@@ -23,5 +23,10 @@ export async function killRun(runId: string): Promise<{ killed: boolean }> {
 
 export async function fetchQueueSnapshot(): Promise<QueueSnapshot> {
 	const res = await apiFetch("/queue");
+	return res.json();
+}
+
+export async function fetchStats(): Promise<Stats> {
+	const res = await apiFetch("/stats");
 	return res.json();
 }

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -64,6 +64,23 @@ export type QueueSnapshot = {
 	queued: QueuedItem[];
 };
 
+export type Stats = {
+	asOf: string;
+	running: { active: number; max: number };
+	queued: { count: number };
+	last24h: {
+		completed: number;
+		completedDelta: number;
+		failed: number;
+		successRate: number;
+		spendUsd: number;
+		spendDeltaUsd: number;
+		p50DurationMs: number;
+		p95DurationMs: number;
+		durationSparkline: number[];
+	};
+};
+
 type RunEventBase = {
 	id: string;
 	seq: number;

--- a/dashboard/src/testing/contract.ts
+++ b/dashboard/src/testing/contract.ts
@@ -5,6 +5,7 @@ import type {
 	Run,
 	RunDetail,
 	RunEvent,
+	Stats,
 	Step,
 } from "../lib/types.ts";
 
@@ -91,6 +92,26 @@ export function createQueueSnapshot(
 	return {
 		active: overrides.active ?? [],
 		queued: overrides.queued ?? [],
+	};
+}
+
+export function createStats(overrides: Partial<Stats> = {}): Stats {
+	return {
+		asOf: "2026-05-09T14:32:08.000Z",
+		running: { active: 0, max: 0 },
+		queued: { count: 0 },
+		last24h: {
+			completed: 0,
+			completedDelta: 0,
+			failed: 0,
+			successRate: 1,
+			spendUsd: 0,
+			spendDeltaUsd: 0,
+			p50DurationMs: 0,
+			p95DurationMs: 0,
+			durationSparkline: [],
+		},
+		...overrides,
 	};
 }
 

--- a/dashboard/src/testing/handlers.ts
+++ b/dashboard/src/testing/handlers.ts
@@ -1,5 +1,11 @@
 import { HttpResponse, http } from "msw";
-import type { QueueSnapshot, RunDetail, RunEvent } from "../lib/types.ts";
+import type {
+	QueueSnapshot,
+	RunDetail,
+	RunEvent,
+	Stats,
+} from "../lib/types.ts";
+import { createStats } from "./contract.ts";
 
 export function runDetailHandler(runId: string, detail: RunDetail) {
 	return http.get(`/runs/${runId}`, () => HttpResponse.json(detail));
@@ -35,6 +41,10 @@ export function queueHandler(snapshot: QueueSnapshot) {
 	return http.get("/queue", () => HttpResponse.json(snapshot));
 }
 
+export function statsHandler(stats: Stats) {
+	return http.get("/stats", () => HttpResponse.json(stats));
+}
+
 function eventsStreamHandler() {
 	return http.get(
 		"/events",
@@ -56,5 +66,10 @@ function eventsStreamHandler() {
 }
 
 const defaultQueueHandler = queueHandler({ active: [], queued: [] });
+const defaultStatsHandler = statsHandler(createStats());
 
-export const handlers = [eventsStreamHandler(), defaultQueueHandler];
+export const handlers = [
+	eventsStreamHandler(),
+	defaultQueueHandler,
+	defaultStatsHandler,
+];

--- a/server/api/api.ts
+++ b/server/api/api.ts
@@ -2,6 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { z } from "zod";
+import type { Last24hStats } from "../db/stats-query.ts";
 import { eventBus, type RunEvent } from "../event-bus.ts";
 import type { Logger } from "../logger.ts";
 import type { Orchestrator } from "../orchestrator/orchestrator.ts";
@@ -34,14 +35,18 @@ export function createApi({
 	runner,
 	repo,
 	queue,
+	readStats,
 	checkHealth,
 	logger,
+	clock = () => new Date(),
 }: {
 	runner: Runner;
 	repo: RunRepository;
 	queue: Pick<Orchestrator, "getQueueSnapshot">;
+	readStats: (now: Date) => Last24hStats;
 	checkHealth: HealthCheck;
 	logger: Logger;
+	clock?: () => Date;
 }) {
 	const app = new Hono<AppEnv>();
 	app.onError(problemDetailsHandler);
@@ -155,6 +160,20 @@ export function createApi({
 		},
 	);
 
+	app.get("/stats", (c) => {
+		const now = clock();
+		const stats: StatsWire = {
+			asOf: now.toISOString(),
+			running: {
+				active: repo.countRunning(),
+				max: runner.maxConcurrency,
+			},
+			queued: { count: queue.getQueueSnapshot().length },
+			last24h: readStats(now),
+		};
+		return c.json(stats);
+	});
+
 	app.get("/queue", (c) => {
 		const active: ActiveRunWire[] = repo
 			.getRuns({ status: "running", limit: 200 })
@@ -221,6 +240,13 @@ type CurrentStepWire = { name: string; index: number; total: number };
 type ActiveRunWire = RunWire & {
 	currentStep: CurrentStepWire | null;
 	progressRatio: number;
+};
+
+type StatsWire = {
+	asOf: string;
+	running: { active: number; max: number };
+	queued: { count: number };
+	last24h: Last24hStats;
 };
 
 function currentStepFor(steps: RunStepRow[]): CurrentStepWire | null {

--- a/server/api/stats.test.ts
+++ b/server/api/stats.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import { createTestApi } from "../test-support/test-api.ts";
+import { seedRun } from "../test-support/test-db.ts";
+import { issueKey, repoSlug } from "../types/brands.ts";
+
+const NOW_ISO = "2026-05-09T14:32:08.000Z";
+const NOW = new Date(NOW_ISO);
+const HOUR_MS = 60 * 60 * 1000;
+const fixedClock = () => NOW;
+
+function isoOffset(hoursAgo: number): string {
+	return new Date(NOW.getTime() - hoursAgo * HOUR_MS).toISOString();
+}
+
+describe("GET /stats", () => {
+	it("returns the design-doc shape with asOf set to the server clock", async () => {
+		const { app } = createTestApi({ clock: fixedClock, concurrencyMax: 5 });
+
+		const res = await app.request("/stats");
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			asOf: NOW_ISO,
+			running: { active: 0, max: 5 },
+			queued: { count: 0 },
+			last24h: {
+				completed: 0,
+				completedDelta: 0,
+				failed: 0,
+				successRate: 1,
+				spendUsd: 0,
+				spendDeltaUsd: 0,
+				p50DurationMs: 0,
+				p95DurationMs: 0,
+				durationSparkline: [],
+			},
+		});
+	});
+
+	it("counts completed/failed runs in the trailing 24h window and computes the prior-window delta", async () => {
+		const { app, db } = createTestApi({ clock: fixedClock });
+		seedRun(db, {
+			id: "c1",
+			status: "completed",
+			completedAt: isoOffset(2),
+			durationMs: 60_000,
+			costUsd: 1.0,
+		});
+		seedRun(db, {
+			id: "c2",
+			status: "completed",
+			completedAt: isoOffset(10),
+			durationMs: 120_000,
+			costUsd: 2.0,
+		});
+		seedRun(db, {
+			id: "f1",
+			status: "failed",
+			completedAt: isoOffset(5),
+			error: "boom",
+			costUsd: 0.5,
+		});
+		// Prior window (24h–48h ago)
+		seedRun(db, {
+			id: "p1",
+			status: "completed",
+			completedAt: isoOffset(30),
+			durationMs: 30_000,
+			costUsd: 0.4,
+		});
+		// Outside both windows (>48h ago) — ignored
+		seedRun(db, {
+			id: "old",
+			status: "completed",
+			completedAt: isoOffset(72),
+			durationMs: 90_000,
+			costUsd: 9.0,
+		});
+
+		const body = (await (await app.request("/stats")).json()) as {
+			last24h: {
+				completed: number;
+				completedDelta: number;
+				failed: number;
+				successRate: number;
+				spendUsd: number;
+				spendDeltaUsd: number;
+			};
+		};
+
+		expect(body.last24h.completed).toBe(2);
+		expect(body.last24h.completedDelta).toBe(1);
+		expect(body.last24h.failed).toBe(1);
+		expect(body.last24h.successRate).toBeCloseTo(2 / 3, 10);
+		expect(body.last24h.spendUsd).toBeCloseTo(3.5, 10);
+		expect(body.last24h.spendDeltaUsd).toBeCloseTo(3.1, 10);
+	});
+
+	it("returns successRate=1 when there are zero failures", async () => {
+		const { app, db } = createTestApi({ clock: fixedClock });
+		seedRun(db, {
+			id: "c1",
+			status: "completed",
+			completedAt: isoOffset(2),
+			durationMs: 60_000,
+			costUsd: 0,
+		});
+
+		const body = (await (await app.request("/stats")).json()) as {
+			last24h: { successRate: number };
+		};
+		expect(body.last24h.successRate).toBe(1);
+	});
+
+	it("computes p50 and p95 from completed-run durations in the window", async () => {
+		const { app, db } = createTestApi({ clock: fixedClock });
+		const durations = [
+			100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000, 800_000,
+			900_000, 1_000_000,
+		];
+		durations.forEach((ms, i) => {
+			seedRun(db, {
+				id: `c${i}`,
+				status: "completed",
+				completedAt: isoOffset(1 + i * 0.1),
+				durationMs: ms,
+				costUsd: 0,
+			});
+		});
+
+		const body = (await (await app.request("/stats")).json()) as {
+			last24h: { p50DurationMs: number; p95DurationMs: number };
+		};
+		// linear interpolation across [100000..1000000], n=10
+		// p50 rank = 4.5 → 550000
+		// p95 rank = 8.55 → 955000
+		expect(body.last24h.p50DurationMs).toBe(550_000);
+		expect(body.last24h.p95DurationMs).toBe(955_000);
+	});
+
+	it("returns the last 10 completed-run durations in the window oldest → newest", async () => {
+		const { app, db } = createTestApi({ clock: fixedClock });
+		// Seed 12 completions in the window, oldest first
+		for (let i = 0; i < 12; i++) {
+			seedRun(db, {
+				id: `c${i}`,
+				status: "completed",
+				completedAt: isoOffset(20 - i * 0.5),
+				durationMs: (i + 1) * 1000,
+				costUsd: 0,
+			});
+		}
+
+		const body = (await (await app.request("/stats")).json()) as {
+			last24h: { durationSparkline: number[] };
+		};
+		// Last 10, oldest → newest, are c2..c11 → durations 3000..12000
+		expect(body.last24h.durationSparkline).toEqual([
+			3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 11000, 12000,
+		]);
+	});
+
+	it("reports running.active from in-flight runs and queued.count from the orchestrator queue", async () => {
+		const { app } = createTestApi({
+			clock: fixedClock,
+			concurrencyMax: 5,
+			queued: [
+				{
+					issueKey: issueKey("ACME-1"),
+					issueTitle: "queued",
+					repo: repoSlug("acme/api"),
+					pendingSince: isoOffset(0.1),
+				},
+				{
+					issueKey: issueKey("ACME-2"),
+					issueTitle: "queued",
+					repo: repoSlug("acme/api"),
+					pendingSince: isoOffset(0.05),
+				},
+			],
+		});
+
+		const body = (await (await app.request("/stats")).json()) as {
+			running: { active: number; max: number };
+			queued: { count: number };
+		};
+		expect(body.running).toEqual({ active: 0, max: 5 });
+		expect(body.queued).toEqual({ count: 2 });
+	});
+
+	it("reports running.active including in-flight runs from the repository", async () => {
+		const { app, db } = createTestApi({ clock: fixedClock, concurrencyMax: 3 });
+		seedRun(db, { id: "r1", status: "running", startedAt: isoOffset(0.1) });
+		seedRun(db, { id: "r2", status: "running", startedAt: isoOffset(0.05) });
+
+		const body = (await (await app.request("/stats")).json()) as {
+			running: { active: number; max: number };
+		};
+		expect(body.running).toEqual({ active: 2, max: 3 });
+	});
+});

--- a/server/db/stats-query.ts
+++ b/server/db/stats-query.ts
@@ -1,0 +1,90 @@
+import { and, asc, gte, lt } from "drizzle-orm";
+import type { Db } from "./db.ts";
+import { runs } from "./schema.ts";
+
+export type Last24hStats = {
+	completed: number;
+	completedDelta: number;
+	failed: number;
+	successRate: number;
+	spendUsd: number;
+	spendDeltaUsd: number;
+	p50DurationMs: number;
+	p95DurationMs: number;
+	durationSparkline: number[];
+};
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+const SPARKLINE_LENGTH = 10;
+
+export function readLast24hStats(db: Db, now: Date): Last24hStats {
+	const nowMs = now.getTime();
+	const start24h = new Date(nowMs - TWENTY_FOUR_HOURS_MS).toISOString();
+	const start48h = new Date(nowMs - 2 * TWENTY_FOUR_HOURS_MS).toISOString();
+	const nowIso = now.toISOString();
+
+	const rows = db
+		.select({
+			status: runs.status,
+			completedAt: runs.completedAt,
+			durationMs: runs.durationMs,
+			costUsd: runs.costUsd,
+		})
+		.from(runs)
+		.where(and(gte(runs.completedAt, start48h), lt(runs.completedAt, nowIso)))
+		.orderBy(asc(runs.completedAt))
+		.all();
+
+	let completed = 0;
+	let completedPrior = 0;
+	let failed = 0;
+	let spendUsd = 0;
+	let spendPriorUsd = 0;
+	const completedDurations: number[] = [];
+
+	for (const row of rows) {
+		if (row.completedAt == null) continue;
+		const inCurrent = row.completedAt >= start24h;
+		const cost = row.costUsd ?? 0;
+
+		if (inCurrent) {
+			spendUsd += cost;
+			if (row.status === "completed") {
+				completed += 1;
+				if (row.durationMs != null) completedDurations.push(row.durationMs);
+			} else if (row.status === "failed") {
+				failed += 1;
+			}
+		} else {
+			spendPriorUsd += cost;
+			if (row.status === "completed") completedPrior += 1;
+		}
+	}
+
+	const sortedDurations = [...completedDurations].sort((a, b) => a - b);
+	const sparkline = completedDurations.slice(-SPARKLINE_LENGTH);
+
+	return {
+		completed,
+		completedDelta: completed - completedPrior,
+		failed,
+		successRate: failed === 0 ? 1 : completed / (completed + failed),
+		spendUsd,
+		spendDeltaUsd: spendUsd - spendPriorUsd,
+		p50DurationMs: percentile(sortedDurations, 50),
+		p95DurationMs: percentile(sortedDurations, 95),
+		durationSparkline: sparkline,
+	};
+}
+
+function percentile(sorted: readonly number[], p: number): number {
+	if (sorted.length === 0) return 0;
+	if (sorted.length === 1) return Math.round(sorted[0] ?? 0);
+	const rank = (p / 100) * (sorted.length - 1);
+	const lo = Math.floor(rank);
+	const hi = Math.ceil(rank);
+	const loVal = sorted[lo] ?? 0;
+	if (lo === hi) return Math.round(loVal);
+	const hiVal = sorted[hi] ?? loVal;
+	return Math.round(loVal + (rank - lo) * (hiVal - loVal));
+}

--- a/server/run-repository.ts
+++ b/server/run-repository.ts
@@ -97,6 +97,7 @@ export type RunRepository = {
 		patch: Partial<Pick<ToolBashData, "state" | "exitCode">>,
 	): RunEvent | undefined;
 	getRunningSnapshot(): { id: RunId; issueKey: IssueKey; repo: RepoSlug }[];
+	countRunning(): number;
 	getRunById(id: RunId): Run | undefined;
 	getRuns(filters: {
 		status?: RunStatus | undefined;
@@ -224,6 +225,15 @@ export function createRunRepository(db: Db): RunRepository {
 					(row): row is { id: RunId; issueKey: IssueKey; repo: RepoSlug } =>
 						row.issueKey != null,
 				);
+		},
+
+		countRunning() {
+			const row = db
+				.select({ n: sql<number>`count(*)` })
+				.from(runs)
+				.where(eq(runs.status, "running"))
+				.get();
+			return row?.n ?? 0;
 		},
 
 		getRunById(id) {

--- a/server/runner/runner.ts
+++ b/server/runner/runner.ts
@@ -53,6 +53,7 @@ export type Runner = {
 	enqueue(job: AgentJob): RunHandle;
 	kill(runId: RunId): boolean;
 	readonly queue: JobQueue;
+	readonly maxConcurrency: number;
 };
 
 type RunnerConfig = {
@@ -60,13 +61,12 @@ type RunnerConfig = {
 	maxConcurrency?: number;
 };
 
+const DEFAULT_MAX_CONCURRENCY = 5;
+
 export function createRunner(config: RunnerConfig): Runner {
 	const { repo } = config;
-	const queue = createJobQueue(
-		config.maxConcurrency != null
-			? { maxConcurrency: config.maxConcurrency }
-			: {},
-	);
+	const maxConcurrency = config.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY;
+	const queue = createJobQueue({ maxConcurrency });
 	const activeRuns = new Map<RunId, AbortController>();
 
 	function emitFor<K extends RunEventKind>(
@@ -209,6 +209,6 @@ export function createRunner(config: RunnerConfig): Runner {
 		return { runId: id, done };
 	}
 
-	const runner: Runner = { enqueue, kill, queue };
+	const runner: Runner = { enqueue, kill, queue, maxConcurrency };
 	return runner;
 }

--- a/server/server.ts
+++ b/server/server.ts
@@ -4,6 +4,7 @@ import { createCodeHost } from "./code-hosts/create-code-host.ts";
 import { loadConfig } from "./config.ts";
 import { closeDb, getDb } from "./db/db.ts";
 import { migrate } from "./db/migrate.ts";
+import { readLast24hStats } from "./db/stats-query.ts";
 import { env } from "./env.ts";
 import { createLogger } from "./logger.ts";
 import { createOrchestrator } from "./orchestrator/orchestrator.ts";
@@ -69,6 +70,7 @@ const app = createApi({
 	runner,
 	repo,
 	queue: orchestrator,
+	readStats: (now) => readLast24hStats(db, now),
 	checkHealth,
 	logger,
 });

--- a/server/test-support/test-api.ts
+++ b/server/test-support/test-api.ts
@@ -1,4 +1,5 @@
 import { createApi, type HealthCheck } from "../api/api.ts";
+import { readLast24hStats } from "../db/stats-query.ts";
 import type { QueuedItem } from "../orchestrator/orchestrator.ts";
 import { createRunRepository } from "../run-repository.ts";
 import { createRunner } from "../runner/runner.ts";
@@ -13,17 +14,24 @@ const healthyCheck: HealthCheck = () => ({
 export function createTestApi(opts?: {
 	checkHealth?: HealthCheck;
 	queued?: QueuedItem[];
+	concurrencyMax?: number;
+	clock?: () => Date;
 }) {
 	const db = createTestDb();
 	const repo = createRunRepository(db);
-	const runner = createRunner({ repo, maxConcurrency: 2 });
+	const runner = createRunner({
+		repo,
+		maxConcurrency: opts?.concurrencyMax ?? 2,
+	});
 	const queued = opts?.queued ?? [];
 	const app = createApi({
 		runner,
 		repo,
 		queue: { getQueueSnapshot: () => queued },
+		readStats: (now) => readLast24hStats(db, now),
 		checkHealth: opts?.checkHealth ?? healthyCheck,
 		logger: testLogger,
+		...(opts?.clock && { clock: opts.clock }),
 	});
 	return { app, db, runner };
 }


### PR DESCRIPTION
## Summary
- Adds `GET /stats` backed by `readLast24hStats(db, now)` — single SQL pull over the trailing 48h window producing last-24h counts, prior-window deltas, success rate, spend, p50/p95 durations, and the 10-point duration sparkline.
- New `useStats()` hook polled at 5s feeds the six-cell overview strip (Running, Queued, Completed · 24h, Failed · 24h, P50/P95, Spend · 24h) matching `dashboard-prototypes/05-system.html`.
- `Runner` now exposes `maxConcurrency`; repository gets `countRunning()`. `createApi` takes a `readStats` collaborator instead of raw `db` + a separate concurrency knob.
- Per design alignment: the Queued cell drops the prototype's "oldest waiting Xm Ys" sub-note since the `Stats` type only exposes `queued: { count: number }`.

Closes #106.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (259 tests, including 7 new server-side `/stats` cases and 3 dashboard browser tests)
- [ ] Manual smoke: load dashboard with `pnpm dev`, confirm strip renders and polls

🤖 Generated with [Claude Code](https://claude.com/claude-code)