### PR TITLE
feat: dashboard redesign slice 5 — recent runs right column

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { OverviewStrip } from "./components/overview-strip.tsx";
 import { QueueColumn } from "./components/queue-column.tsx";
+import { RecentRunsColumn } from "./components/recent-runs-column.tsx";
 import { RunBanner } from "./components/run-banner.tsx";
 import { Transcript } from "./components/transcript.tsx";
 import { WorkflowStripe } from "./components/workflow-stripe.tsx";
@@ -24,6 +25,7 @@ export function App() {
 				<section className="center">
 					<CenterContent runId={runId} />
 				</section>
+				<RecentRunsColumn />
 			</main>
 		</>
 	);

--- a/dashboard/src/components/recent-runs-column.tsx
+++ b/dashboard/src/components/recent-runs-column.tsx
@@ -1,0 +1,136 @@
+import { Fragment } from "react";
+import { useRecentRuns } from "../hooks/use-recent-runs.ts";
+import {
+	formatCompactCost,
+	formatHourMinute,
+	formatStepDuration,
+	localDayLabel,
+} from "../lib/format.ts";
+import type { Run, RunPr } from "../lib/types.ts";
+
+export function RecentRunsColumn() {
+	const { data } = useRecentRuns();
+	const runs = (data ?? []).filter((r) => r.status !== "running");
+	const groups = groupByLocalDay(runs, new Date());
+
+	return (
+		<section className="history" data-testid="recent-runs">
+			<div className="col-head">
+				<h2>Recent runs</h2>
+			</div>
+			{groups.map((group) => (
+				<Fragment key={group.label}>
+					<div className="hgroup-head">{group.label}</div>
+					{group.runs.map((run) => (
+						<HistoryRow key={run.id} run={run} />
+					))}
+				</Fragment>
+			))}
+		</section>
+	);
+}
+
+function HistoryRow({ run }: { run: Run }) {
+	const href = `/?runId=${encodeURIComponent(run.id)}`;
+	const navigate = () => {
+		window.location.assign(href);
+	};
+	return (
+		// biome-ignore lint/a11y/useSemanticElements: row contains a nested PR <a>, so the row itself can't be an <a>; role="link" + keyboard handler preserves accessibility.
+		<div
+			className="hrow"
+			data-testid={`recent-run-${run.id}`}
+			role="link"
+			tabIndex={0}
+			onClick={navigate}
+			onKeyDown={(e) => {
+				if (e.key === "Enter" || e.key === " ") {
+					e.preventDefault();
+					navigate();
+				}
+			}}
+		>
+			<div className="hrow-top">
+				<span className={`pip ${run.status}`} />
+				<span className="hrow-name">{run.issueTitle ?? run.id}</span>
+				<span className="hrow-time mono">
+					{formatHourMinute(run.startedAt)}
+				</span>
+			</div>
+			<div className="hrow-issue">
+				{run.issueKey != null && (
+					<span className="key mono">{run.issueKey}</span>
+				)}
+				{run.repo}
+			</div>
+			<div className="hrow-foot">
+				{run.status === "failed" ? (
+					<FailureTag run={run} />
+				) : run.pr != null ? (
+					<PrLink pr={run.pr} />
+				) : (
+					<span />
+				)}
+				<span className="right">
+					<span className="dur">
+						{run.durationMs == null ? "—" : formatStepDuration(run.durationMs)}
+					</span>
+					<span className="cost">{formatCompactCost(run.costUsd)}</span>
+				</span>
+			</div>
+		</div>
+	);
+}
+
+function FailureTag({ run }: { run: Run }) {
+	const error = run.error ?? "failed";
+	const step = run.failedStep;
+	const text =
+		step != null
+			? `step ${step.index} · ${step.name} · ${error}`
+			: `failed · ${error}`;
+	return <span className="err">{text}</span>;
+}
+
+function PrLink({ pr }: { pr: RunPr }) {
+	return (
+		<a
+			href={pr.url}
+			className="pr"
+			onClick={(e) => e.stopPropagation()}
+			target="_blank"
+			rel="noreferrer"
+		>
+			<svg
+				viewBox="0 0 16 16"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.5"
+				aria-hidden="true"
+			>
+				<title>pull request</title>
+				<circle cx="4" cy="4" r="2" />
+				<circle cx="4" cy="12" r="2" />
+				<circle cx="12" cy="12" r="2" />
+				<path d="M4 6v4M12 10V8a4 4 0 0 0-4-4H6" />
+			</svg>
+			{pr.repo} · #{pr.number}
+		</a>
+	);
+}
+
+type DayGroup = { label: string; runs: Run[] };
+
+function groupByLocalDay(runs: Run[], now: Date): DayGroup[] {
+	const groups: DayGroup[] = [];
+	for (const run of runs) {
+		const label = localDayLabel(run.startedAt, now);
+		const last = groups[groups.length - 1];
+		if (last && last.label === label) {
+			last.runs.push(run);
+		} else {
+			groups.push({ label, runs: [run] });
+		}
+	}
+	return groups;
+}

--- a/dashboard/src/dashboard.recent-runs.test.tsx
+++ b/dashboard/src/dashboard.recent-runs.test.tsx
@@ -1,0 +1,157 @@
+import { describe, expect } from "vitest";
+import { createRun } from "./testing/contract.ts";
+import { test } from "./testing/fixture.tsx";
+import { recentRunsHandler } from "./testing/handlers.ts";
+import { browserWorker } from "./testing/msw.ts";
+
+describe("dashboard recent runs column", () => {
+	test("renders Today / Yesterday day groups split on local-day boundary", async ({
+		dashboardPage,
+	}) => {
+		const todayBoundary = new Date();
+		todayBoundary.setHours(0, 0, 0, 0);
+		const yesterdayBoundary = new Date(todayBoundary.getTime() - 86_400_000);
+
+		browserWorker.use(
+			recentRunsHandler([
+				createRun({
+					id: "today-1",
+					status: "completed",
+					issueTitle: "auth header dropped on retry",
+					issueKey: "ACME-1283",
+					repo: "acme/api",
+					startedAt: new Date(
+						todayBoundary.getTime() + 14 * 3600_000 + 18 * 60_000,
+					).toISOString(),
+					completedAt: new Date(
+						todayBoundary.getTime() + 14 * 3600_000 + 27 * 60_000 + 12_000,
+					).toISOString(),
+					durationMs: 552_000,
+					costUsd: 0.04,
+					pr: {
+						repo: "acme/api",
+						number: 4419,
+						url: "https://github.com/acme/api/pull/4419",
+						kind: "opened",
+					},
+				}),
+				createRun({
+					id: "yesterday-1",
+					status: "completed",
+					issueTitle: "tidy run-repository tests",
+					issueKey: "ACME-1271",
+					repo: "acme/api",
+					startedAt: new Date(
+						yesterdayBoundary.getTime() + 17 * 3600_000 + 42 * 60_000,
+					).toISOString(),
+					completedAt: new Date(
+						yesterdayBoundary.getTime() + 18 * 3600_000 + 1 * 60_000 + 8_000,
+					).toISOString(),
+					durationMs: 1_148_000,
+					costUsd: 0.1,
+					pr: {
+						repo: "acme/api",
+						number: 4404,
+						url: "https://github.com/acme/api/pull/4404",
+						kind: "opened",
+					},
+				}),
+			]),
+		);
+
+		const page = await dashboardPage.mountAt(null);
+
+		const column = page.getByTestId("recent-runs");
+		await expect.element(column).toHaveTextContent("Recent runs");
+		await expect.element(column).toHaveTextContent("Today");
+		await expect.element(column).toHaveTextContent("Yesterday");
+
+		const todayRow = page.getByTestId("recent-run-today-1");
+		await expect
+			.element(todayRow)
+			.toHaveTextContent("auth header dropped on retry");
+		await expect.element(todayRow).toHaveTextContent("ACME-1283");
+		await expect.element(todayRow).toHaveTextContent("acme/api · #4419");
+		await expect.element(todayRow).toHaveTextContent("9m 12s");
+		await expect.element(todayRow).toHaveTextContent("$0.04");
+
+		const yesterdayRow = page.getByTestId("recent-run-yesterday-1");
+		await expect
+			.element(yesterdayRow)
+			.toHaveTextContent("tidy run-repository tests");
+	});
+
+	test("failed run renders failure tag with step name + error and no PR link", async ({
+		dashboardPage,
+	}) => {
+		const today = new Date();
+		today.setHours(13, 51, 0, 0);
+
+		browserWorker.use(
+			recentRunsHandler([
+				createRun({
+					id: "fail-1",
+					status: "failed",
+					issueTitle: "cover repo-resolver",
+					issueKey: "ACME-1280",
+					repo: "acme/api",
+					startedAt: today.toISOString(),
+					completedAt: new Date(today.getTime() + 401_000).toISOString(),
+					durationMs: 401_000,
+					costUsd: 0.03,
+					error: "no commits made",
+					failedStep: { index: 1, name: "implement" },
+				}),
+			]),
+		);
+
+		const page = await dashboardPage.mountAt(null);
+
+		const row = page.getByTestId("recent-run-fail-1");
+		await expect.element(row).toHaveTextContent("cover repo-resolver");
+		await expect
+			.element(row)
+			.toHaveTextContent("step 1 · implement · no commits made");
+		await expect.element(row).toHaveTextContent("6m 41s");
+		await expect.element(row).toHaveTextContent("$0.03");
+		await expect.element(row).not.toHaveTextContent("#");
+	});
+
+	test("excludes running runs from the recent column", async ({
+		dashboardPage,
+	}) => {
+		const today = new Date();
+		today.setHours(14, 0, 0, 0);
+
+		browserWorker.use(
+			recentRunsHandler([
+				createRun({
+					id: "running-1",
+					status: "running",
+					issueTitle: "should not appear",
+					issueKey: "ACME-RUNNING",
+					startedAt: today.toISOString(),
+				}),
+				createRun({
+					id: "completed-1",
+					status: "completed",
+					issueTitle: "should appear",
+					issueKey: "ACME-DONE",
+					startedAt: today.toISOString(),
+					completedAt: new Date(today.getTime() + 60_000).toISOString(),
+					durationMs: 60_000,
+					costUsd: 0.01,
+				}),
+			]),
+		);
+
+		const page = await dashboardPage.mountAt(null);
+
+		await expect
+			.element(page.getByTestId("recent-run-completed-1"))
+			.toBeInTheDocument();
+		await expect
+			.element(page.getByTestId("recent-runs"))
+			.not.toHaveTextContent("should not appear");
+	});
+});

--- a/dashboard/src/hooks/use-recent-runs.ts
+++ b/dashboard/src/hooks/use-recent-runs.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchRecentRuns } from "../lib/api.ts";
+import type { Run } from "../lib/types.ts";
+
+const POLL_INTERVAL_MS = 5_000;
+
+export function useRecentRuns() {
+	return useQuery<Run[]>({
+		queryKey: ["recent-runs"],
+		queryFn: fetchRecentRuns,
+		refetchInterval: POLL_INTERVAL_MS,
+		refetchIntervalInBackground: false,
+	});
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -228,7 +228,7 @@ header.app .meta-right {
 
 .shell {
 	display: grid;
-	grid-template-columns: 320px 1fr;
+	grid-template-columns: 320px 1fr 360px;
 	flex: 1;
 	max-width: 1800px;
 	margin: 0 auto;
@@ -332,6 +332,14 @@ header.app .meta-right {
 .pip.queued {
 	background: transparent;
 	border: 1px solid var(--fg-4);
+}
+
+.pip.completed {
+	background: var(--completed);
+}
+
+.pip.failed {
+	background: var(--failed);
 }
 
 .qrow-name {
@@ -906,6 +914,114 @@ h1.run-title {
 	50% {
 		opacity: 0;
 	}
+}
+
+/* ───── recent runs (right column) ───── */
+
+.history {
+	overflow-y: auto;
+}
+
+.hrow {
+	display: block;
+	padding: 12px 16px;
+	border-bottom: 1px solid var(--line);
+	cursor: pointer;
+	transition: background 0.12s;
+	color: inherit;
+	text-decoration: none;
+}
+
+.hrow:hover {
+	background: var(--bg-1);
+}
+
+.hrow-top {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 4px;
+}
+
+.hrow-name {
+	font-size: 13px;
+	font-weight: 500;
+	color: var(--fg);
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.hrow-time {
+	font-size: 11.5px;
+	color: var(--fg-4);
+	font-variant-numeric: tabular-nums;
+}
+
+.hrow-issue {
+	font-size: 12px;
+	color: var(--fg-3);
+	margin: 0 0 6px 14px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.hrow-issue .key {
+	color: var(--link);
+	margin-right: 4px;
+}
+
+.hrow-foot {
+	margin-left: 14px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 8px;
+	font-size: 11.5px;
+}
+
+.hrow-foot .pr {
+	color: var(--link);
+	text-decoration: none;
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+}
+
+.hrow-foot .pr svg {
+	width: 11px;
+	height: 11px;
+}
+
+.hrow-foot .pr:hover {
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+
+.hrow-foot > .right {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.hrow-foot .dur {
+	color: var(--fg-4);
+	font-family: "Geist Mono", monospace;
+	font-variant-numeric: tabular-nums;
+}
+
+.hrow-foot .cost {
+	color: var(--fg-3);
+	font-family: "Geist Mono", monospace;
+	font-variant-numeric: tabular-nums;
+}
+
+.hrow-foot .err {
+	color: var(--failed);
+	font-size: 11.5px;
 }
 
 /* ───── empty / loading ───── */

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,4 +1,10 @@
-import type { QueueSnapshot, RunDetail, RunEvent, Stats } from "./types.ts";
+import type {
+	QueueSnapshot,
+	Run,
+	RunDetail,
+	RunEvent,
+	Stats,
+} from "./types.ts";
 
 async function apiFetch(url: string, init?: RequestInit): Promise<Response> {
 	const res = await fetch(url, init);
@@ -28,5 +34,10 @@ export async function fetchQueueSnapshot(): Promise<QueueSnapshot> {
 
 export async function fetchStats(): Promise<Stats> {
 	const res = await apiFetch("/stats");
+	return res.json();
+}
+
+export async function fetchRecentRuns(): Promise<Run[]> {
+	const res = await apiFetch("/runs");
 	return res.json();
 }

--- a/dashboard/src/lib/format.ts
+++ b/dashboard/src/lib/format.ts
@@ -8,6 +8,41 @@ export function formatTime(iso: string): string {
 	return `${hh}:${mm}:${ss}`;
 }
 
+export function formatHourMinute(iso: string): string {
+	const d = new Date(iso);
+	const hh = String(d.getHours()).padStart(2, "0");
+	const mm = String(d.getMinutes()).padStart(2, "0");
+	return `${hh}:${mm}`;
+}
+
+export function formatCompactCost(usd: number | null): string {
+	if (usd == null) return "$0.00";
+	return `$${usd.toFixed(2)}`;
+}
+
+const DAY_FORMATTER = new Intl.DateTimeFormat(undefined, {
+	month: "short",
+	day: "numeric",
+});
+
+export function localDayLabel(iso: string, now: Date): string {
+	const d = new Date(iso);
+	const startOfToday = new Date(
+		now.getFullYear(),
+		now.getMonth(),
+		now.getDate(),
+	).getTime();
+	const startOfRunDay = new Date(
+		d.getFullYear(),
+		d.getMonth(),
+		d.getDate(),
+	).getTime();
+
+	if (startOfRunDay >= startOfToday) return "Today";
+	if (startOfRunDay >= startOfToday - 86_400_000) return "Yesterday";
+	return DAY_FORMATTER.format(d);
+}
+
 export function formatElapsed(ms: number): string {
 	const totalSeconds = Math.floor(ms / 1000);
 	const minutes = Math.floor(totalSeconds / 60);

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -11,6 +11,8 @@ export type RunPr = {
 	kind: PrKind;
 };
 
+export type RunFailedStep = { index: number; name: string };
+
 export type Run = {
 	id: string;
 	status: RunStatus;
@@ -28,6 +30,7 @@ export type Run = {
 	tokensOutput: number | null;
 	pr: RunPr | null;
 	error: string | null;
+	failedStep: RunFailedStep | null;
 };
 
 export type Step = {

--- a/dashboard/src/testing/contract.ts
+++ b/dashboard/src/testing/contract.ts
@@ -27,6 +27,7 @@ export function createRun(overrides: Partial<Run> = {}): Run {
 		tokensOutput: null,
 		pr: null,
 		error: null,
+		failedStep: null,
 		...overrides,
 	};
 }

--- a/dashboard/src/testing/handlers.ts
+++ b/dashboard/src/testing/handlers.ts
@@ -1,6 +1,7 @@
 import { HttpResponse, http } from "msw";
 import type {
 	QueueSnapshot,
+	Run,
 	RunDetail,
 	RunEvent,
 	Stats,
@@ -45,6 +46,10 @@ export function statsHandler(stats: Stats) {
 	return http.get("/stats", () => HttpResponse.json(stats));
 }
 
+export function recentRunsHandler(runs: Run[]) {
+	return http.get("/runs", () => HttpResponse.json(runs));
+}
+
 function eventsStreamHandler() {
 	return http.get(
 		"/events",
@@ -67,9 +72,11 @@ function eventsStreamHandler() {
 
 const defaultQueueHandler = queueHandler({ active: [], queued: [] });
 const defaultStatsHandler = statsHandler(createStats());
+const defaultRecentRunsHandler = recentRunsHandler([]);
 
 export const handlers = [
 	eventsStreamHandler(),
 	defaultQueueHandler,
 	defaultStatsHandler,
+	defaultRecentRunsHandler,
 ];

--- a/docs/dashboard-api-design.md
+++ b/docs/dashboard-api-design.md
@@ -66,6 +66,7 @@ type Run = {
   pr: { repo: string; number: number; url: string; kind: "opened" | "commented" } | null;
 
   error: string | null;              // failure summary for `failed`
+  failedStep: { index: number; name: string } | null;   // the failed step's metadata for `failed`
 };
 ```
 
@@ -228,7 +229,7 @@ All endpoints use RFC 7807 problem-details (already in `server/api/problem-detai
 
 | Endpoint | Status | When |
 |---|---|---|
-| `GET /runs` | 400 | Invalid filter value (e.g. unknown `status`). |
+| `GET /runs` | 422 | Invalid filter value (e.g. unknown `status`). Validation failures use the project-wide 422 convention; field errors are returned in the `errors` extension. |
 | `GET /runs/:id` | 404 | Run id not found. |
 | `GET /runs/:id/events` | 404 | Run id not found. |
 | `GET /runs/:id/events` | 400 | `since` cursor refers to an unknown event id. |
@@ -262,7 +263,8 @@ All endpoints use RFC 7807 problem-details (already in `server/api/problem-detai
     "tokensInput": 9800,
     "tokensOutput": 2600,
     "pr": null,
-    "error": null
+    "error": null,
+    "failedStep": null
   },
   "steps": [
     { "index": 1, "name": "implement", "state": "running", "startedAt": "2026-05-09T14:28:19Z", "completedAt": null,                   "durationMs": null, "error": null },
@@ -317,7 +319,7 @@ When the run is live, the FE seeds the SSE `Last-Event-ID` from the most recent 
       "issueKey": "ACME-1284", "issueTitle": "npm install hangs on linux runners", "issueUrl": null,
       "startedAt": "2026-05-09T14:27:56Z", "completedAt": null, "durationMs": null,
       "costUsd": 0.034, "tokensInput": 9800, "tokensOutput": 2600,
-      "pr": null, "error": null,
+      "pr": null, "error": null, "failedStep": null,
       "currentStep": { "name": "implement", "index": 1, "total": 3 },
       "progressRatio": 0.17
     }

--- a/server/api/api.ts
+++ b/server/api/api.ts
@@ -231,6 +231,7 @@ type RunWire = {
 	tokensOutput: number | null;
 	pr: Run["pr"];
 	error: string | null;
+	failedStep: { index: number; name: string } | null;
 };
 
 type StepWire = Omit<RunStepRow, "runId">;
@@ -284,7 +285,7 @@ async function writeFrame(
 }
 
 function runToWire(run: Run): RunWire {
-	const base: Omit<RunWire, "completedAt" | "durationMs" | "error"> = {
+	const base: RunWire = {
 		id: run.id,
 		status: run.status,
 		repo: run.repo,
@@ -298,16 +299,19 @@ function runToWire(run: Run): RunWire {
 		tokensInput: run.tokensInput,
 		tokensOutput: run.tokensOutput,
 		pr: run.pr,
+		completedAt: null,
+		durationMs: null,
+		error: null,
+		failedStep: null,
 	};
 	switch (run.status) {
 		case "running":
-			return { ...base, completedAt: null, durationMs: null, error: null };
+			return base;
 		case "completed":
 			return {
 				...base,
 				completedAt: run.completedAt,
 				durationMs: run.durationMs,
-				error: null,
 			};
 		case "failed":
 			return {
@@ -315,6 +319,7 @@ function runToWire(run: Run): RunWire {
 				completedAt: run.completedAt,
 				durationMs: run.durationMs,
 				error: run.error,
+				failedStep: run.failedStep,
 			};
 	}
 }

--- a/server/api/queue.test.ts
+++ b/server/api/queue.test.ts
@@ -71,6 +71,7 @@ describe("GET /queue", () => {
 					tokensInput: 9800,
 					tokensOutput: 2600,
 					pr: null,
+					failedStep: null,
 					currentStep: { name: "implement", index: 1, total: 3 },
 					progressRatio: 0.5 / 3,
 				},

--- a/server/api/runs.test.ts
+++ b/server/api/runs.test.ts
@@ -11,6 +11,7 @@ const baseRunWire = {
 	tokensInput: null,
 	tokensOutput: null,
 	pr: null,
+	failedStep: null,
 };
 
 describe("GET /runs", () => {
@@ -175,6 +176,38 @@ describe("GET /runs", () => {
 		]);
 	});
 
+	it("populates failedStep with the failed step name + index", async () => {
+		const { app, db } = createTestApi();
+		seedRun(db, {
+			id: "fail-step-1",
+			status: "failed",
+			startedAt: "2025-01-03T00:00:00Z",
+			completedAt: "2025-01-03T00:00:02Z",
+			durationMs: 1500,
+			error: "no commits made",
+		});
+		seedStep(db, {
+			runId: "fail-step-1",
+			index: 1,
+			name: "implement",
+			state: "failed",
+			error: "no commits made",
+		});
+		seedStep(db, {
+			runId: "fail-step-1",
+			index: 2,
+			name: "review",
+			state: "pending",
+		});
+
+		const res = await app.request("/runs?status=failed");
+		const body = (await res.json()) as Array<{
+			failedStep: { index: number; name: string } | null;
+		}>;
+
+		expect(body[0]?.failedStep).toEqual({ index: 1, name: "implement" });
+	});
+
 	it("respects limit parameter", async () => {
 		const { app, db } = createTestApi();
 		seedRun(db, { id: "r1", startedAt: "2025-01-01T00:00:00Z" });
@@ -261,6 +294,7 @@ describe("GET /runs/:id", () => {
 				tokensInput: 9800,
 				tokensOutput: 2600,
 				pr: null,
+				failedStep: null,
 			},
 			steps: [
 				{

--- a/server/run-repository.test.ts
+++ b/server/run-repository.test.ts
@@ -40,7 +40,46 @@ describe("run repository row projection", () => {
 			tokensInput: null,
 			tokensOutput: null,
 			pr: null,
+			failedStep: null,
 		});
+	});
+
+	it("populates failedStep from the runSteps row marked failed", () => {
+		const db = createTestDb();
+		const repo = createRunRepository(db);
+		db.insert(runs)
+			.values({
+				id: runId("failed-2"),
+				status: "failed",
+				repo: repoSlug("acme/widgets"),
+				issueKey: issueKey("acme/widgets#2"),
+				issueTitle: "boom",
+				startedAt: "2025-01-01T00:00:00Z",
+				completedAt: "2025-01-01T00:00:02Z",
+				durationMs: 2000,
+				error: "no commits made",
+			})
+			.run();
+		repo.insertSteps(runId("failed-2"), [
+			{ index: 1, name: "implement" },
+			{ index: 2, name: "review" },
+		]);
+		repo.failStep(runId("failed-2"), 1, {
+			completedAt: "2025-01-01T00:00:02Z",
+			durationMs: 2000,
+			error: "no commits made",
+		});
+
+		const run = repo.getRunById(runId("failed-2"));
+		expect(run?.status).toBe("failed");
+		if (run?.status !== "failed") throw new Error("expected failed run");
+		expect(run.failedStep).toEqual({ index: 1, name: "implement" });
+
+		const list = repo.getRuns({ limit: 10 });
+		const fromList = list.find((r) => r.id === "failed-2");
+		expect(fromList?.status).toBe("failed");
+		if (fromList?.status !== "failed") throw new Error("expected failed run");
+		expect(fromList.failedStep).toEqual({ index: 1, name: "implement" });
 	});
 });
 

--- a/server/run-repository.ts
+++ b/server/run-repository.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { and, asc, desc, eq, gt, isNotNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNotNull, sql } from "drizzle-orm";
 
 import type { Db } from "./db/db.ts";
 import {
@@ -39,6 +39,8 @@ type RunBase = {
 	pr: RunPr | null;
 };
 
+export type RunFailedStep = { index: number; name: string };
+
 export type RunningRun = RunBase & { status: "running" };
 export type CompletedRun = RunBase & {
 	status: "completed";
@@ -50,6 +52,7 @@ export type FailedRun = RunBase & {
 	completedAt: string;
 	durationMs: number | null;
 	error: string;
+	failedStep: RunFailedStep | null;
 };
 
 export type Run = RunningRun | CompletedRun | FailedRun;
@@ -238,7 +241,12 @@ export function createRunRepository(db: Db): RunRepository {
 
 		getRunById(id) {
 			const row = db.select().from(runs).where(eq(runs.id, id)).get();
-			return row ? rowToRun(row) : undefined;
+			if (!row) return undefined;
+			const failedStep =
+				row.status === "failed"
+					? (findFailedSteps(db, [row.id]).get(row.id) ?? null)
+					: null;
+			return rowToRun(row, failedStep);
 		},
 
 		getRuns(filters) {
@@ -256,7 +264,18 @@ export function createRunRepository(db: Db): RunRepository {
 				conditions.length > 0
 					? query.where(and(...conditions)).all()
 					: query.all();
-			return rows.map(rowToRun);
+
+			const failedIds = rows
+				.filter((r) => r.status === "failed")
+				.map((r) => r.id);
+			const failedSteps =
+				failedIds.length === 0 ? new Map() : findFailedSteps(db, failedIds);
+			return rows.map((row) =>
+				rowToRun(
+					row,
+					row.status === "failed" ? (failedSteps.get(row.id) ?? null) : null,
+				),
+			);
 		},
 
 		getRunEvents(runId) {
@@ -377,7 +396,20 @@ export function createRunRepository(db: Db): RunRepository {
 type RunRow = typeof runs.$inferSelect;
 type RunEventRow = typeof runEvents.$inferSelect;
 
-function rowToRun(row: RunRow): Run {
+function findFailedSteps(db: Db, ids: RunId[]): Map<RunId, RunFailedStep> {
+	const rows = db
+		.select({
+			runId: runSteps.runId,
+			index: runSteps.index,
+			name: runSteps.name,
+		})
+		.from(runSteps)
+		.where(and(inArray(runSteps.runId, ids), eq(runSteps.state, "failed")))
+		.all();
+	return new Map(rows.map((r) => [r.runId, { index: r.index, name: r.name }]));
+}
+
+function rowToRun(row: RunRow, failedStep: RunFailedStep | null): Run {
 	const pr =
 		row.prRepo != null &&
 		row.prNumber != null &&
@@ -433,6 +465,7 @@ function rowToRun(row: RunRow): Run {
 				completedAt: row.completedAt,
 				durationMs: row.durationMs,
 				error: row.error,
+				failedStep,
 			};
 	}
 }


### PR DESCRIPTION
## Summary
- `GET /runs` now returns the new `Run[]` shape ordered by `startedAt desc`, with `status`/`repo`/`limit` filters (default 50, max 200) and a new `failedStep: { index, name } | null` field populated for failed runs from the matching `runSteps` row. The `agent` filter is gone.
- New `useRecentRuns()` hook (5s poll, paused when tab hidden) feeds the `.history` right column: Today / Yesterday / older day-group headers split on the local-day boundary, one `.hrow` per non-running run with status pip, title, time, issue key, PR link with branch icon (or failure tag formatted as `step N · name · error`), duration, cost.
- Repository batches the failed-step lookup in `getRuns` via a single `IN (...)` query, with `getRunById` reusing the same helper for the n=1 case.

Closes #107.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (264 tests; 3 new dashboard browser tests, 1 new server `/runs` case, 1 new repository projection case)
- [ ] Manual smoke: `pnpm dev`, confirm column renders, polls, day grouping, PR/failure footers

🤖 Generated with [Claude Code](https://claude.com/claude-code)