### PR TITLE
fix: dashboard live ticking + finalize failure surfacing

### DIFF
--- a/bugs.md
+++ b/bugs.md
@@ -1,0 +1,2 @@
+- I noticed that our Run UI appears to only update when a new event comes through that is not nice. Considering we are literally rendering runtime down to seconds so this is literally stopping at like 10secs then jumping to 16secs as another event has come through. This is so bad that actually our left pannel UI showing the active runs the time lapsed doesn't even update unless you refresh the page or click to another run.
+- I noticed that when clicking to another run it seems like our entire UI re-renders.

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from "react";
+import { type ReactNode, Suspense } from "react";
+import { ErrorBoundary } from "./components/error-boundary.tsx";
 import { OverviewStrip } from "./components/overview-strip.tsx";
 import { QueueColumn } from "./components/queue-column.tsx";
 import { RecentRunsColumn } from "./components/recent-runs-column.tsx";
@@ -6,10 +7,14 @@ import { RunBanner } from "./components/run-banner.tsx";
 import { Transcript } from "./components/transcript.tsx";
 import { WorkflowStripe } from "./components/workflow-stripe.tsx";
 import { useRunDetail } from "./hooks/use-run-detail.ts";
+import { useRunEventInvalidator } from "./hooks/use-run-event-invalidator.ts";
 import { useRunEvents } from "./hooks/use-run-events.ts";
+import { useRunRoute } from "./hooks/use-run-route.ts";
+import type { Step } from "./lib/types.ts";
 
 export function App() {
-	const runId = readRunIdFromUrl();
+	useRunEventInvalidator();
+	const { runId, navigate } = useRunRoute();
 
 	return (
 		<>
@@ -21,33 +26,46 @@ export function App() {
 			</header>
 			<OverviewStrip />
 			<main className="shell">
-				<QueueColumn activeRunId={runId} />
+				<QueueColumn activeRunId={runId} onSelectRun={navigate} />
 				<section className="center">
 					<CenterContent runId={runId} />
 				</section>
-				<RecentRunsColumn />
+				<RecentRunsColumn onSelectRun={navigate} />
 			</main>
 		</>
 	);
 }
 
 function CenterContent({ runId }: { runId: string | null }) {
-	const detail = useRunDetail(runId);
-	const events = useRunEvents(runId);
-
 	if (runId == null) return <Placeholder>No run selected.</Placeholder>;
-	if (detail.isLoading) return <Placeholder>Loading…</Placeholder>;
-	if (detail.error) return <Placeholder>{detail.error.message}</Placeholder>;
-	if (!detail.data) return null;
+	return (
+		<ErrorBoundary
+			key={runId}
+			fallback={(error) => <Placeholder>{error.message}</Placeholder>}
+		>
+			<Suspense fallback={<Placeholder>Loading…</Placeholder>}>
+				<RunDetailView runId={runId} />
+			</Suspense>
+		</ErrorBoundary>
+	);
+}
 
-	const eventsList = events.status === "ready" ? events.events : [];
+function RunDetailView({ runId }: { runId: string }) {
+	const { data } = useRunDetail(runId);
 	return (
 		<>
-			<RunBanner run={detail.data.run} />
-			<WorkflowStripe steps={detail.data.steps} />
-			<Transcript events={eventsList} steps={detail.data.steps} />
+			<RunBanner run={data.run} />
+			<WorkflowStripe steps={data.steps} />
+			<Suspense fallback={<Placeholder>Loading transcript…</Placeholder>}>
+				<TranscriptView runId={runId} steps={data.steps} />
+			</Suspense>
 		</>
 	);
+}
+
+function TranscriptView({ runId, steps }: { runId: string; steps: Step[] }) {
+	const events = useRunEvents(runId);
+	return <Transcript events={events} steps={steps} />;
 }
 
 function Placeholder({ children }: { children: ReactNode }) {
@@ -56,10 +74,4 @@ function Placeholder({ children }: { children: ReactNode }) {
 			{children}
 		</div>
 	);
-}
-
-function readRunIdFromUrl(): string | null {
-	if (typeof window === "undefined") return null;
-	const params = new URLSearchParams(window.location.search);
-	return params.get("runId");
 }

--- a/dashboard/src/components/error-boundary.tsx
+++ b/dashboard/src/components/error-boundary.tsx
@@ -1,7 +1,8 @@
-import { Component } from "react";
+import { Component, type ReactNode } from "react";
 
 type Props = {
-	children: React.ReactNode;
+	children: ReactNode;
+	fallback?: (error: Error, reset: () => void) => ReactNode;
 };
 
 type State = {
@@ -15,14 +16,27 @@ export class ErrorBoundary extends Component<Props, State> {
 		return { error };
 	}
 
+	private reset = () => {
+		this.setState({ error: null });
+	};
+
 	override render() {
-		if (this.state.error) {
-			return (
-				<div className="placeholder" role="alert">
-					{this.state.error.message}
-				</div>
-			);
-		}
-		return this.props.children;
+		const { error } = this.state;
+		if (error == null) return this.props.children;
+		if (this.props.fallback != null)
+			return this.props.fallback(error, this.reset);
+		return (
+			<div className="placeholder" role="alert">
+				<span>{error.message}</span>
+				<button
+					type="button"
+					className="btn"
+					onClick={this.reset}
+					data-testid="error-retry"
+				>
+					Retry
+				</button>
+			</div>
+		);
 	}
 }

--- a/dashboard/src/components/overview-strip.tsx
+++ b/dashboard/src/components/overview-strip.tsx
@@ -1,10 +1,11 @@
+import { memo } from "react";
 import { useStats } from "../hooks/use-stats.ts";
 import type { Stats } from "../lib/types.ts";
 
 const SPARK_HEIGHT_PX = 14;
 const SPARK_MIN_PX = 2;
 
-export function OverviewStrip() {
+export const OverviewStrip = memo(function OverviewStrip() {
 	const { data } = useStats();
 
 	const running = data?.running ?? { active: 0, max: 0 };
@@ -14,7 +15,14 @@ export function OverviewStrip() {
 
 	return (
 		<section className="overview" data-testid="overview">
-			<Stat label="Running" labelPip>
+			<Stat
+				label={
+					<>
+						<span className="running-pip" />
+						Running
+					</>
+				}
+			>
 				<Value primary={String(running.active)} dim={` / ${running.max}`} />
 				<Note>{`${slotsFree} slots free`}</Note>
 			</Stat>
@@ -58,23 +66,18 @@ export function OverviewStrip() {
 			</Stat>
 		</section>
 	);
-}
+});
 
 function Stat({
 	label,
-	labelPip,
 	children,
 }: {
-	label: string;
-	labelPip?: boolean;
+	label: React.ReactNode;
 	children: React.ReactNode;
 }) {
 	return (
 		<div className="stat">
-			<div className="label">
-				{labelPip && <span className="running-pip" />}
-				{label}
-			</div>
+			<div className="label">{label}</div>
 			{children}
 		</div>
 	);

--- a/dashboard/src/components/queue-column.tsx
+++ b/dashboard/src/components/queue-column.tsx
@@ -1,8 +1,15 @@
+import type { MouseEvent } from "react";
 import { useQueue } from "../hooks/use-queue.ts";
-import { elapsedSinceMs, formatElapsed, formatTime } from "../lib/format.ts";
+import { useNowEverySecond } from "../hooks/use-tick.ts";
+import { formatElapsed, formatTime } from "../lib/format.ts";
 import type { ActiveRun, QueuedItem } from "../lib/types.ts";
 
-export function QueueColumn({ activeRunId }: { activeRunId: string | null }) {
+type Props = {
+	activeRunId: string | null;
+	onSelectRun: (runId: string) => void;
+};
+
+export function QueueColumn({ activeRunId, onSelectRun }: Props) {
 	const { data } = useQueue();
 	const active = data?.active ?? [];
 	const queued = data?.queued ?? [];
@@ -13,7 +20,12 @@ export function QueueColumn({ activeRunId }: { activeRunId: string | null }) {
 				<h2>Active</h2>
 			</div>
 			{active.map((run) => (
-				<ActiveRow key={run.id} run={run} selected={run.id === activeRunId} />
+				<ActiveRow
+					key={run.id}
+					run={run}
+					selected={run.id === activeRunId}
+					onSelect={onSelectRun}
+				/>
 			))}
 			<div className="hgroup-head">Queued</div>
 			{queued.map((item) => (
@@ -23,8 +35,17 @@ export function QueueColumn({ activeRunId }: { activeRunId: string | null }) {
 	);
 }
 
-function ActiveRow({ run, selected }: { run: ActiveRun; selected: boolean }) {
-	const elapsedMs = elapsedSinceMs(run.startedAt);
+function ActiveRow({
+	run,
+	selected,
+	onSelect,
+}: {
+	run: ActiveRun;
+	selected: boolean;
+	onSelect: (runId: string) => void;
+}) {
+	const now = useNowEverySecond(true);
+	const elapsedMs = Math.max(0, now - new Date(run.startedAt).getTime());
 	const widthPct = Math.max(0, Math.min(1, run.progressRatio)) * 100;
 
 	return (
@@ -32,6 +53,12 @@ function ActiveRow({ run, selected }: { run: ActiveRun; selected: boolean }) {
 			className={`qrow${selected ? " active" : ""}`}
 			href={`/?runId=${encodeURIComponent(run.id)}`}
 			data-testid={`queue-active-${run.id}`}
+			onClick={(e) => {
+				if (isPlainLeftClick(e)) {
+					e.preventDefault();
+					onSelect(run.id);
+				}
+			}}
 		>
 			<div className="qrow-top">
 				<span className="pip running" />
@@ -75,4 +102,8 @@ function QueuedRow({ item }: { item: QueuedItem }) {
 			</div>
 		</div>
 	);
+}
+
+function isPlainLeftClick(e: MouseEvent): boolean {
+	return e.button === 0 && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey;
 }

--- a/dashboard/src/components/recent-runs-column.tsx
+++ b/dashboard/src/components/recent-runs-column.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from "react";
+import { Fragment, memo } from "react";
 import { useRecentRuns } from "../hooks/use-recent-runs.ts";
 import {
 	formatCompactCost,
@@ -8,7 +8,13 @@ import {
 } from "../lib/format.ts";
 import type { Run, RunPr } from "../lib/types.ts";
 
-export function RecentRunsColumn() {
+type Props = {
+	onSelectRun: (runId: string) => void;
+};
+
+export const RecentRunsColumn = memo(function RecentRunsColumn({
+	onSelectRun,
+}: Props) {
 	const { data } = useRecentRuns();
 	const runs = (data ?? []).filter((r) => r.status !== "running");
 	const groups = groupByLocalDay(runs, new Date());
@@ -22,18 +28,23 @@ export function RecentRunsColumn() {
 				<Fragment key={group.label}>
 					<div className="hgroup-head">{group.label}</div>
 					{group.runs.map((run) => (
-						<HistoryRow key={run.id} run={run} />
+						<HistoryRow key={run.id} run={run} onSelect={onSelectRun} />
 					))}
 				</Fragment>
 			))}
 		</section>
 	);
-}
+});
 
-function HistoryRow({ run }: { run: Run }) {
-	const href = `/?runId=${encodeURIComponent(run.id)}`;
-	const navigate = () => {
-		window.location.assign(href);
+function HistoryRow({
+	run,
+	onSelect,
+}: {
+	run: Run;
+	onSelect: (runId: string) => void;
+}) {
+	const select = () => {
+		onSelect(run.id);
 	};
 	return (
 		// biome-ignore lint/a11y/useSemanticElements: row contains a nested PR <a>, so the row itself can't be an <a>; role="link" + keyboard handler preserves accessibility.
@@ -42,11 +53,11 @@ function HistoryRow({ run }: { run: Run }) {
 			data-testid={`recent-run-${run.id}`}
 			role="link"
 			tabIndex={0}
-			onClick={navigate}
+			onClick={select}
 			onKeyDown={(e) => {
 				if (e.key === "Enter" || e.key === " ") {
 					e.preventDefault();
-					navigate();
+					select();
 				}
 			}}
 		>
@@ -85,10 +96,13 @@ function HistoryRow({ run }: { run: Run }) {
 function FailureTag({ run }: { run: Run }) {
 	const error = run.error ?? "failed";
 	const step = run.failedStep;
+	const finalize = run.finalizeFailure;
 	const text =
 		step != null
 			? `step ${step.index} · ${step.name} · ${error}`
-			: `failed · ${error}`;
+			: finalize != null
+				? `${finalize.phase} · ${finalize.error}`
+				: `failed · ${error}`;
 	return <span className="err">{text}</span>;
 }
 

--- a/dashboard/src/components/run-banner.tsx
+++ b/dashboard/src/components/run-banner.tsx
@@ -1,6 +1,6 @@
+import { useNowEverySecond } from "../hooks/use-tick.ts";
 import { killRun } from "../lib/api.ts";
 import {
-	elapsedSinceMs,
 	formatCost,
 	formatElapsed,
 	formatTime,
@@ -13,7 +13,9 @@ type Props = {
 };
 
 export function RunBanner({ run }: Props) {
-	const elapsedMs = run.durationMs ?? elapsedSinceMs(run.startedAt);
+	const now = useNowEverySecond(run.status === "running");
+	const elapsedMs =
+		run.durationMs ?? Math.max(0, now - new Date(run.startedAt).getTime());
 	const tokens = (run.tokensInput ?? 0) + (run.tokensOutput ?? 0);
 
 	return (
@@ -22,10 +24,10 @@ export function RunBanner({ run }: Props) {
 				<div>
 					<h1 className="run-title">{run.issueTitle ?? run.id}</h1>
 					<div className="run-meta" data-testid="run-meta">
-						{run.issueKey && (
+						{run.issueKey != null && (
 							<span>
 								<span className="label">Issue</span>
-								{run.issueUrl ? (
+								{run.issueUrl != null ? (
 									<a href={run.issueUrl}>
 										<span className="key">{run.issueKey}</span>
 									</a>
@@ -38,7 +40,7 @@ export function RunBanner({ run }: Props) {
 							<span className="label">Repo</span>
 							{run.repo}
 						</span>
-						{run.branch && (
+						{run.branch != null && (
 							<span>
 								<span className="label">Branch</span>
 								<span className="mono">{run.branch}</span>
@@ -57,7 +59,7 @@ export function RunBanner({ run }: Props) {
 							{formatCost(run.costUsd)}{" "}
 							<span className="dim">· {formatTokens(tokens)}</span>
 						</span>
-						{run.workspaceDir && (
+						{run.workspaceDir != null && (
 							<span>
 								<span className="label">Workspace</span>
 								<span className="id">{run.workspaceDir}</span>

--- a/dashboard/src/components/transcript.tsx
+++ b/dashboard/src/components/transcript.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import {
 	formatStepDuration,
 	formatStepNumber,
@@ -12,7 +13,7 @@ type Props = {
 };
 
 export function Transcript({ events, steps }: Props) {
-	const groups = groupByStep(events, steps);
+	const groups = useMemo(() => groupByStep(events, steps), [events, steps]);
 	return (
 		<div className="transcript" data-testid="transcript">
 			{groups.map((group) => {
@@ -42,6 +43,7 @@ function groupByStep(events: RunEvent[], steps: Step[]): Group[] {
 
 	let lastTouchedBucket: RunEvent[] | null = null;
 	for (const event of events) {
+		if (isLifecycleEvent(event)) continue;
 		if (event.stepName == null) {
 			if (lastTouchedBucket == null) looseLeading.push(event);
 			else lastTouchedBucket.push(event);
@@ -239,5 +241,19 @@ function renderRowBody(event: RunEvent) {
 			const _exhaustive: never = event;
 			return _exhaustive;
 		}
+	}
+}
+
+function isLifecycleEvent(event: RunEvent): boolean {
+	switch (event.kind) {
+		case "step:started":
+		case "step:completed":
+		case "step:failed":
+		case "run:started":
+		case "run:completed":
+		case "run:failed":
+			return true;
+		default:
+			return false;
 	}
 }

--- a/dashboard/src/dashboard.recent-runs.test.tsx
+++ b/dashboard/src/dashboard.recent-runs.test.tsx
@@ -117,6 +117,41 @@ describe("dashboard recent runs column", () => {
 		await expect.element(row).not.toHaveTextContent("#");
 	});
 
+	test("finalize-failed run renders the phase + finalize error and no PR link", async ({
+		dashboardPage,
+	}) => {
+		const today = new Date();
+		today.setHours(14, 9, 0, 0);
+
+		browserWorker.use(
+			recentRunsHandler([
+				createRun({
+					id: "fail-finalize",
+					status: "failed",
+					issueTitle: "duplicate detection on feedback submission",
+					issueKey: "ACME-9",
+					repo: "acme/api",
+					startedAt: today.toISOString(),
+					completedAt: new Date(today.getTime() + 1_033_437).toISOString(),
+					durationMs: 1_033_437,
+					costUsd: 4.57,
+					error: "push: Permission denied",
+					finalizeFailure: {
+						phase: "push",
+						error: "Permission denied",
+					},
+				}),
+			]),
+		);
+
+		const page = await dashboardPage.mountAt(null);
+
+		const row = page.getByTestId("recent-run-fail-finalize");
+		await expect.element(row).toHaveTextContent("push · Permission denied");
+		await expect.element(row).not.toHaveTextContent("step 1");
+		await expect.element(row).not.toHaveTextContent("#");
+	});
+
 	test("excludes running runs from the recent column", async ({
 		dashboardPage,
 	}) => {

--- a/dashboard/src/dashboard.transcript.test.tsx
+++ b/dashboard/src/dashboard.transcript.test.tsx
@@ -87,6 +87,66 @@ describe("dashboard transcript", () => {
 		await expect.element(page.getBashCursor()).toBeInTheDocument();
 	});
 
+	test("lifecycle events (step:*, run:*) do not render as blank rows", async ({
+		dashboardPage,
+	}) => {
+		browserWorker.use(
+			runDetailHandler(RUN_ID, detail),
+			runEventsHandler(RUN_ID, [
+				createEvent({
+					id: "evt_run_started",
+					kind: "run:started",
+					stepName: null,
+					data: { issueKey: null, issueTitle: null },
+				}),
+				createEvent({
+					id: "evt_step_started",
+					kind: "step:started",
+					stepName: "implement",
+					data: { name: "implement", index: 1, total: 2 },
+				}),
+				createEvent({
+					id: "evt_say",
+					kind: "agent:say",
+					stepName: "implement",
+					data: { text: "hello" },
+				}),
+				createEvent({
+					id: "evt_step_completed",
+					kind: "step:completed",
+					stepName: "implement",
+					data: { name: "implement", index: 1, durationMs: 1000 },
+				}),
+				createEvent({
+					id: "evt_run_completed",
+					kind: "run:completed",
+					stepName: null,
+					data: {
+						durationMs: 2000,
+						costUsd: 0,
+						tokens: { in: 0, out: 0 },
+					},
+				}),
+			]),
+		);
+
+		const page = await dashboardPage.mountAt(RUN_ID);
+
+		await expect.element(page.getEvent("evt_say")).toBeInTheDocument();
+		await expect
+			.element(page.getEvent("evt_run_started"))
+			.not.toBeInTheDocument();
+		await expect
+			.element(page.getEvent("evt_step_started"))
+			.not.toBeInTheDocument();
+		await expect
+			.element(page.getEvent("evt_step_completed"))
+			.not.toBeInTheDocument();
+		await expect
+			.element(page.getEvent("evt_run_completed"))
+			.not.toBeInTheDocument();
+	});
+
 	test("tool:bash aborted renders a distinct marker, not a blinking cursor", async ({
 		dashboardPage,
 	}) => {

--- a/dashboard/src/hooks/use-event-stream.tsx
+++ b/dashboard/src/hooks/use-event-stream.tsx
@@ -1,0 +1,74 @@
+import {
+	createContext,
+	type ReactNode,
+	use,
+	useEffect,
+	useMemo,
+	useRef,
+} from "react";
+import { RUN_EVENT_KINDS, type RunEvent } from "../lib/types.ts";
+
+type RunEventListener = (event: RunEvent) => void;
+
+type RunEventStream = {
+	subscribe: (listener: RunEventListener) => () => void;
+	getBuffer: () => readonly RunEvent[];
+};
+
+const BUFFER_LIMIT = 1000;
+
+export function EventStreamProvider({ children }: { children: ReactNode }) {
+	const listenersRef = useRef<Set<RunEventListener>>(new Set());
+	const bufferRef = useRef<RunEvent[]>([]);
+
+	useEffect(() => {
+		const source = new EventSource("/events");
+		const onFrame = (msg: MessageEvent) => {
+			const event = parse(msg.data);
+			if (event == null) return;
+			const buffer = bufferRef.current;
+			buffer.push(event);
+			if (buffer.length > BUFFER_LIMIT) {
+				buffer.splice(0, buffer.length - BUFFER_LIMIT);
+			}
+			for (const listener of listenersRef.current) listener(event);
+		};
+		for (const kind of RUN_EVENT_KINDS) source.addEventListener(kind, onFrame);
+		return () => source.close();
+	}, []);
+
+	const value = useMemo<RunEventStream>(
+		() => ({
+			subscribe(listener) {
+				listenersRef.current.add(listener);
+				return () => {
+					listenersRef.current.delete(listener);
+				};
+			},
+			getBuffer() {
+				return bufferRef.current;
+			},
+		}),
+		[],
+	);
+
+	return <EventStreamContext value={value}>{children}</EventStreamContext>;
+}
+
+export function useEventStream(): RunEventStream {
+	const ctx = use(EventStreamContext);
+	if (ctx == null) {
+		throw new Error("useEventStream must be used within EventStreamProvider");
+	}
+	return ctx;
+}
+
+const EventStreamContext = createContext<RunEventStream | null>(null);
+
+function parse(raw: string): RunEvent | null {
+	try {
+		return JSON.parse(raw) as RunEvent;
+	} catch {
+		return null;
+	}
+}

--- a/dashboard/src/hooks/use-queue.ts
+++ b/dashboard/src/hooks/use-queue.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchQueueSnapshot } from "../lib/api.ts";
 import type { QueueSnapshot } from "../lib/types.ts";
 
-const POLL_INTERVAL_MS = 2_000;
+const POLL_INTERVAL_MS = 30_000;
 
 export function useQueue() {
 	return useQuery<QueueSnapshot>({

--- a/dashboard/src/hooks/use-recent-runs.ts
+++ b/dashboard/src/hooks/use-recent-runs.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchRecentRuns } from "../lib/api.ts";
 import type { Run } from "../lib/types.ts";
 
-const POLL_INTERVAL_MS = 5_000;
+const POLL_INTERVAL_MS = 60_000;
 
 export function useRecentRuns() {
 	return useQuery<Run[]>({

--- a/dashboard/src/hooks/use-run-detail.ts
+++ b/dashboard/src/hooks/use-run-detail.ts
@@ -1,11 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { fetchRunDetail } from "../lib/api.ts";
 import type { RunDetail } from "../lib/types.ts";
 
-export function useRunDetail(runId: string | null) {
-	return useQuery<RunDetail>({
+export function useRunDetail(runId: string) {
+	return useSuspenseQuery<RunDetail>({
 		queryKey: ["runs", runId],
-		queryFn: () => fetchRunDetail(runId as string),
-		enabled: runId !== null,
+		queryFn: () => fetchRunDetail(runId),
 	});
 }

--- a/dashboard/src/hooks/use-run-event-invalidator.ts
+++ b/dashboard/src/hooks/use-run-event-invalidator.ts
@@ -1,0 +1,27 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import {
+	LIFECYCLE_EVENT_KINDS,
+	RUN_TERMINAL_EVENT_KINDS,
+	type RunEvent,
+} from "../lib/types.ts";
+import { useEventStream } from "./use-event-stream.tsx";
+
+export function useRunEventInvalidator(): void {
+	const stream = useEventStream();
+	const queryClient = useQueryClient();
+
+	useEffect(() => {
+		return stream.subscribe((event) => {
+			if (!LIFECYCLE_KINDS.has(event.kind)) return;
+			queryClient.invalidateQueries({ queryKey: ["queue"] });
+			if (TERMINAL_KINDS.has(event.kind)) {
+				queryClient.invalidateQueries({ queryKey: ["stats"] });
+				queryClient.invalidateQueries({ queryKey: ["recent-runs"] });
+			}
+		});
+	}, [stream, queryClient]);
+}
+
+const LIFECYCLE_KINDS = new Set<RunEvent["kind"]>(LIFECYCLE_EVENT_KINDS);
+const TERMINAL_KINDS = new Set<RunEvent["kind"]>(RUN_TERMINAL_EVENT_KINDS);

--- a/dashboard/src/hooks/use-run-events.ts
+++ b/dashboard/src/hooks/use-run-events.ts
@@ -1,93 +1,89 @@
-import { useEffect, useState } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
 import { fetchRunEvents } from "../lib/api.ts";
-import type { RunEvent, RunEventKind } from "../lib/types.ts";
+import type { RunEvent } from "../lib/types.ts";
+import { useEventStream } from "./use-event-stream.tsx";
 
-const ALL_KINDS: RunEventKind[] = [
-	"run:started",
-	"run:completed",
-	"run:failed",
-	"step:started",
-	"step:completed",
-	"step:failed",
-	"agent:say",
-	"tool:read",
-	"tool:edit",
-	"tool:grep",
-	"tool:bash",
-	"tool:other",
-	"system",
-];
+export function useRunEvents(runId: string): RunEvent[] {
+	const stream = useEventStream();
+	const initial = useSuspenseQuery<RunEvent[]>({
+		queryKey: ["run-events", runId],
+		queryFn: () => fetchRunEvents(runId),
+		staleTime: Number.POSITIVE_INFINITY,
+	});
 
-type State =
-	| { status: "loading" }
-	| { status: "error"; error: Error }
-	| { status: "ready"; events: RunEvent[] };
-
-export function useRunEvents(runId: string | null): State {
-	const [state, setState] = useState<State>({ status: "loading" });
+	const [live, setLive] = useState<RunEvent[]>([]);
 
 	useEffect(() => {
-		if (runId == null) return;
+		const seen = new Set(initial.data.map((e) => e.id));
 
-		let cancelled = false;
-		let source: EventSource | undefined;
-		setState({ status: "loading" });
+		const buffered = stream
+			.getBuffer()
+			.filter((e) => e.runId === runId && !seen.has(e.id));
+		for (const e of buffered) seen.add(e.id);
+		setLive(buffered.slice().sort((a, b) => a.seq - b.seq));
 
-		const start = async () => {
-			let initial: RunEvent[];
-			try {
-				initial = await fetchRunEvents(runId);
-			} catch (err) {
-				if (cancelled) return;
-				setState({
-					status: "error",
-					error: err instanceof Error ? err : new Error(String(err)),
-				});
-				return;
-			}
-			if (cancelled) return;
+		return stream.subscribe((event) => {
+			if (event.runId !== runId) return;
+			if (seen.has(event.id)) return;
+			seen.add(event.id);
+			setLive((prev) => insertSorted(prev, event));
+		});
+	}, [runId, stream, initial.data]);
 
-			const seenIds = new Set(initial.map((e) => e.id));
-			let events = [...initial].sort((a, b) => a.seq - b.seq);
-			setState({ status: "ready", events });
-
-			const last = events.at(-1);
-			const url =
-				last != null
-					? `/events?lastEventId=${encodeURIComponent(last.id)}`
-					: "/events";
-			source = new EventSource(url);
-			const onFrame = (msg: MessageEvent) => {
-				if (cancelled) return;
-				const event = parse(msg.data);
-				if (event == null || event.runId !== runId) return;
-				if (seenIds.has(event.id)) return;
-				seenIds.add(event.id);
-				const tail = events.at(-1);
-				events =
-					tail == null || event.seq > tail.seq
-						? [...events, event]
-						: [...events, event].sort((a, b) => a.seq - b.seq);
-				setState({ status: "ready", events });
-			};
-			for (const kind of ALL_KINDS) source.addEventListener(kind, onFrame);
-		};
-
-		void start();
-
-		return () => {
-			cancelled = true;
-			source?.close();
-		};
-	}, [runId]);
-
-	return state;
+	return useMemo(() => {
+		if (live.length === 0) return initial.data;
+		return mergeBySeq(initial.data, live);
+	}, [initial.data, live]);
 }
 
-function parse(raw: string): RunEvent | null {
-	try {
-		return JSON.parse(raw) as RunEvent;
-	} catch {
-		return null;
+function mergeBySeq(
+	a: readonly RunEvent[],
+	b: readonly RunEvent[],
+): RunEvent[] {
+	const out: RunEvent[] = [];
+	let i = 0;
+	let j = 0;
+	while (i < a.length && j < b.length) {
+		const left = a[i];
+		const right = b[j];
+		if (left == null) {
+			i++;
+			continue;
+		}
+		if (right == null) {
+			j++;
+			continue;
+		}
+		if (left.seq <= right.seq) {
+			out.push(left);
+			i++;
+		} else {
+			out.push(right);
+			j++;
+		}
 	}
+	while (i < a.length) {
+		const e = a[i++];
+		if (e != null) out.push(e);
+	}
+	while (j < b.length) {
+		const e = b[j++];
+		if (e != null) out.push(e);
+	}
+	return out;
+}
+
+function insertSorted(events: RunEvent[], event: RunEvent): RunEvent[] {
+	const tail = events.at(-1);
+	if (tail == null || event.seq >= tail.seq) return [...events, event];
+	let lo = 0;
+	let hi = events.length;
+	while (lo < hi) {
+		const mid = (lo + hi) >>> 1;
+		const candidate = events[mid];
+		if (candidate != null && candidate.seq < event.seq) lo = mid + 1;
+		else hi = mid;
+	}
+	return [...events.slice(0, lo), event, ...events.slice(lo)];
 }

--- a/dashboard/src/hooks/use-run-route.ts
+++ b/dashboard/src/hooks/use-run-route.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from "react";
+
+type RunRoute = {
+	runId: string | null;
+	navigate: (runId: string | null) => void;
+};
+
+export function useRunRoute(): RunRoute {
+	const [runId, setRunId] = useState(readRunIdFromUrl);
+
+	useEffect(() => {
+		const onPop = () => setRunId(readRunIdFromUrl());
+		window.addEventListener("popstate", onPop);
+		return () => window.removeEventListener("popstate", onPop);
+	}, []);
+
+	const navigate = useCallback((next: string | null) => {
+		if (next === readRunIdFromUrl()) {
+			setRunId(next);
+			return;
+		}
+		const url = next == null ? "/" : `/?runId=${encodeURIComponent(next)}`;
+		window.history.pushState({}, "", url);
+		setRunId(next);
+	}, []);
+
+	return { runId, navigate };
+}
+
+function readRunIdFromUrl(): string | null {
+	if (typeof window === "undefined") return null;
+	const params = new URLSearchParams(window.location.search);
+	return params.get("runId");
+}

--- a/dashboard/src/hooks/use-stats.ts
+++ b/dashboard/src/hooks/use-stats.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchStats } from "../lib/api.ts";
 import type { Stats } from "../lib/types.ts";
 
-const POLL_INTERVAL_MS = 5_000;
+const POLL_INTERVAL_MS = 60_000;
 
 export function useStats() {
 	return useQuery<Stats>({

--- a/dashboard/src/hooks/use-tick.ts
+++ b/dashboard/src/hooks/use-tick.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from "react";
+
+export function useNowEverySecond(active: boolean): number {
+	const [now, setNow] = useState(() => Date.now());
+
+	useEffect(() => {
+		if (!active) return;
+		const id = window.setInterval(() => setNow(Date.now()), 1000);
+		return () => window.clearInterval(id);
+	}, [active]);
+
+	return now;
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -747,6 +747,8 @@ h1.run-title {
 
 .group {
 	margin-bottom: 4px;
+	content-visibility: auto;
+	contain-intrinsic-size: auto 200px;
 }
 
 .ev {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -8,8 +8,25 @@ import type {
 
 async function apiFetch(url: string, init?: RequestInit): Promise<Response> {
 	const res = await fetch(url, init);
-	if (!res.ok) throw new Error(`API request failed: ${res.status}`);
+	if (!res.ok)
+		throw new Error(`API request failed: ${await readErrorDetail(res)}`);
 	return res;
+}
+
+async function readErrorDetail(res: Response): Promise<string> {
+	try {
+		const body = (await res.clone().json()) as {
+			detail?: unknown;
+			title?: unknown;
+		};
+		if (typeof body.detail === "string" && body.detail.length > 0)
+			return body.detail;
+		if (typeof body.title === "string" && body.title.length > 0)
+			return body.title;
+	} catch {
+		// fall through to status code
+	}
+	return `${res.status}`;
 }
 
 export async function fetchRunDetail(runId: string): Promise<RunDetail> {

--- a/dashboard/src/lib/format.ts
+++ b/dashboard/src/lib/format.ts
@@ -50,10 +50,6 @@ export function formatElapsed(ms: number): string {
 	return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
 }
 
-export function elapsedSinceMs(startedAt: string): number {
-	return Math.max(0, Date.now() - new Date(startedAt).getTime());
-}
-
 export function formatStepDuration(ms: number | null): string {
 	if (ms == null) return "—";
 	const totalSeconds = Math.floor(ms / 1000);

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -13,6 +13,16 @@ export type RunPr = {
 
 export type RunFailedStep = { index: number; name: string };
 
+export type FinalizeFailurePhase =
+	| "push"
+	| "change_request"
+	| "tracker_transition";
+
+export type RunFinalizeFailure = {
+	phase: FinalizeFailurePhase;
+	error: string;
+};
+
 export type Run = {
 	id: string;
 	status: RunStatus;
@@ -31,6 +41,7 @@ export type Run = {
 	pr: RunPr | null;
 	error: string | null;
 	failedStep: RunFailedStep | null;
+	finalizeFailure: RunFinalizeFailure | null;
 };
 
 export type Step = {
@@ -169,4 +180,42 @@ export type RunEvent =
 			};
 	  });
 
-export type RunEventKind = RunEvent["kind"];
+type RunEventKind = RunEvent["kind"];
+
+export const RUN_EVENT_KINDS = [
+	"run:started",
+	"run:completed",
+	"run:failed",
+	"step:started",
+	"step:completed",
+	"step:failed",
+	"agent:say",
+	"tool:read",
+	"tool:edit",
+	"tool:grep",
+	"tool:bash",
+	"tool:other",
+	"system",
+] as const satisfies readonly RunEventKind[];
+
+export const LIFECYCLE_EVENT_KINDS = [
+	"run:started",
+	"run:completed",
+	"run:failed",
+	"step:started",
+	"step:completed",
+	"step:failed",
+] as const satisfies readonly RunEventKind[];
+
+export const RUN_TERMINAL_EVENT_KINDS = [
+	"run:completed",
+	"run:failed",
+] as const satisfies readonly RunEventKind[];
+
+type _RunEventKindsAreExhaustive = [
+	Exclude<RunEventKind, (typeof RUN_EVENT_KINDS)[number]>,
+] extends [never]
+	? true
+	: never;
+const _runEventKindsExhaustive: _RunEventKindsAreExhaustive = true;
+void _runEventKindsExhaustive;

--- a/dashboard/src/providers.tsx
+++ b/dashboard/src/providers.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
+import { EventStreamProvider } from "./hooks/use-event-stream.tsx";
 
 export function Providers({ children }: { children: React.ReactNode }) {
 	const [queryClient] = useState(
@@ -15,6 +16,8 @@ export function Providers({ children }: { children: React.ReactNode }) {
 	);
 
 	return (
-		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		<QueryClientProvider client={queryClient}>
+			<EventStreamProvider>{children}</EventStreamProvider>
+		</QueryClientProvider>
 	);
 }

--- a/dashboard/src/testing/contract.ts
+++ b/dashboard/src/testing/contract.ts
@@ -28,6 +28,7 @@ export function createRun(overrides: Partial<Run> = {}): Run {
 		pr: null,
 		error: null,
 		failedStep: null,
+		finalizeFailure: null,
 		...overrides,
 	};
 }

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
 			"/events": "http://localhost:3000",
 			"/health": "http://localhost:3000",
 			"/runs": "http://localhost:3000",
+			"/stats": "http://localhost:3000",
+			"/queue": "http://localhost:3000",
 		},
 	},
 	build: {

--- a/drizzle/0009_daffy_starjammers.sql
+++ b/drizzle/0009_daffy_starjammers.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `runs` ADD `finalize_failure_phase` text;--> statement-breakpoint
+ALTER TABLE `runs` ADD `finalize_failure_error` text;

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,364 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "dfb9d1a0-b144-44b1-b03c-98f3e8c84996",
+	"prevId": "b9f3a4d2-8c7e-4f1b-ac26-3e7f9d4a8b6c",
+	"tables": {
+		"run_events": {
+			"name": "run_events",
+			"columns": {
+				"seq": {
+					"name": "seq",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"step_name": {
+					"name": "step_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"data": {
+					"name": "data",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"run_events_id_unique": {
+					"name": "run_events_id_unique",
+					"columns": ["id"],
+					"isUnique": true
+				},
+				"idx_run_events_run_id": {
+					"name": "idx_run_events_run_id",
+					"columns": ["run_id"],
+					"isUnique": false
+				},
+				"idx_run_events_seq": {
+					"name": "idx_run_events_seq",
+					"columns": ["seq"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"run_step_outputs": {
+			"name": "run_step_outputs",
+			"columns": {
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"step_name": {
+					"name": "step_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"output_json": {
+					"name": "output_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"run_step_outputs_run_id_step_name_pk": {
+					"columns": ["run_id", "step_name"],
+					"name": "run_step_outputs_run_id_step_name_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"run_steps": {
+			"name": "run_steps",
+			"columns": {
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"index": {
+					"name": "index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"run_steps_run_id_index_pk": {
+					"columns": ["run_id", "index"],
+					"name": "run_steps_run_id_index_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"runs": {
+			"name": "runs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repo": {
+					"name": "repo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"branch": {
+					"name": "branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"workspace_dir": {
+					"name": "workspace_dir",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"issue_key": {
+					"name": "issue_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"issue_title": {
+					"name": "issue_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"issue_url": {
+					"name": "issue_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"cost_usd": {
+					"name": "cost_usd",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_input": {
+					"name": "tokens_input",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_output": {
+					"name": "tokens_output",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_url": {
+					"name": "pr_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_number": {
+					"name": "pr_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_repo": {
+					"name": "pr_repo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_kind": {
+					"name": "pr_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"finalize_failure_phase": {
+					"name": "finalize_failure_phase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"finalize_failure_error": {
+					"name": "finalize_failure_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
 			"when": 1778918400000,
 			"tag": "0008_dashboard_redesign_slice_2",
 			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "6",
+			"when": 1778435816704,
+			"tag": "0009_daffy_starjammers",
+			"breakpoints": true
 		}
 	]
 }

--- a/server/api/api.ts
+++ b/server/api/api.ts
@@ -2,6 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { z } from "zod";
+import type { FinalizeFailurePhase } from "../db/schema.ts";
 import type { Last24hStats } from "../db/stats-query.ts";
 import { eventBus, type RunEvent } from "../event-bus.ts";
 import type { Logger } from "../logger.ts";
@@ -232,6 +233,7 @@ type RunWire = {
 	pr: Run["pr"];
 	error: string | null;
 	failedStep: { index: number; name: string } | null;
+	finalizeFailure: { phase: FinalizeFailurePhase; error: string } | null;
 };
 
 type StepWire = Omit<RunStepRow, "runId">;
@@ -303,6 +305,7 @@ function runToWire(run: Run): RunWire {
 		durationMs: null,
 		error: null,
 		failedStep: null,
+		finalizeFailure: null,
 	};
 	switch (run.status) {
 		case "running":
@@ -320,6 +323,7 @@ function runToWire(run: Run): RunWire {
 				durationMs: run.durationMs,
 				error: run.error,
 				failedStep: run.failedStep,
+				finalizeFailure: run.finalizeFailure,
 			};
 	}
 }

--- a/server/api/queue.test.ts
+++ b/server/api/queue.test.ts
@@ -72,6 +72,7 @@ describe("GET /queue", () => {
 					tokensOutput: 2600,
 					pr: null,
 					failedStep: null,
+					finalizeFailure: null,
 					currentStep: { name: "implement", index: 1, total: 3 },
 					progressRatio: 0.5 / 3,
 				},

--- a/server/api/runs.test.ts
+++ b/server/api/runs.test.ts
@@ -12,6 +12,7 @@ const baseRunWire = {
 	tokensOutput: null,
 	pr: null,
 	failedStep: null,
+	finalizeFailure: null,
 };
 
 describe("GET /runs", () => {
@@ -295,6 +296,7 @@ describe("GET /runs/:id", () => {
 				tokensOutput: 2600,
 				pr: null,
 				failedStep: null,
+				finalizeFailure: null,
 			},
 			steps: [
 				{

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -29,6 +29,10 @@ export const runs = sqliteTable("runs", {
 	prNumber: integer("pr_number"),
 	prRepo: text("pr_repo"),
 	prKind: text("pr_kind").$type<PrKind>(),
+	finalizeFailurePhase: text(
+		"finalize_failure_phase",
+	).$type<FinalizeFailurePhase>(),
+	finalizeFailureError: text("finalize_failure_error"),
 });
 
 export const runSteps = sqliteTable(
@@ -79,6 +83,10 @@ export const runStepOutputs = sqliteTable(
 export type RunStatus = "running" | "completed" | "failed";
 export type RunStepState = "pending" | "running" | "completed" | "failed";
 export type PrKind = "opened" | "commented";
+export type FinalizeFailurePhase =
+	| "push"
+	| "change_request"
+	| "tracker_transition";
 
 export type RunEventKind =
 	| "run:started"

--- a/server/orchestrator/agent-logging.test.ts
+++ b/server/orchestrator/agent-logging.test.ts
@@ -147,7 +147,7 @@ describe("emitAgentMessageEvents", () => {
 		]);
 	});
 
-	it("emits tool:other for unrecognised tools", () => {
+	it("emits tool:other for unrecognised tools, summarising via known input fields", () => {
 		const { ctx, emitted } = captureCtx();
 		emitAgentMessageEvents(
 			toolUseMsg("WebSearch", { query: "vitest coverage" }),
@@ -157,9 +157,37 @@ describe("emitAgentMessageEvents", () => {
 			{
 				kind: "tool:other",
 				stepName: "implement",
-				data: { tool: "WebSearch", summary: "" },
+				data: { tool: "WebSearch", summary: "vitest coverage" },
 			},
 		]);
+	});
+
+	it("uses the Agent tool's description as its tool:other summary", () => {
+		const { ctx, emitted } = captureCtx();
+		emitAgentMessageEvents(
+			toolUseMsg("Agent", {
+				description: "find duplicate detection sites",
+				prompt: "long prompt body that should not surface in the transcript",
+				subagent_type: "general-purpose",
+			}),
+			{ ctx, stepName: "implement", cwd: "/work" },
+		);
+		expect(emitted).toEqual([
+			{
+				kind: "tool:other",
+				stepName: "implement",
+				data: { tool: "Agent", summary: "find duplicate detection sites" },
+			},
+		]);
+	});
+
+	it("does not emit a transcript event for StructuredOutput", () => {
+		const { ctx, emitted } = captureCtx();
+		emitAgentMessageEvents(
+			toolUseMsg("StructuredOutput", { value: { title: "summary" } }),
+			{ ctx, stepName: "summarise", cwd: "/work" },
+		);
+		expect(emitted).toEqual([]);
 	});
 
 	it("aggregates a tool_use_by_name counter on the canonical bag", async () => {

--- a/server/orchestrator/agent-logging.ts
+++ b/server/orchestrator/agent-logging.ts
@@ -114,9 +114,17 @@ function emitToolEvent(
 			});
 			return;
 		}
+		case "StructuredOutput":
+			return;
 		default: {
 			const summary = stringInput(
-				input["pattern"] ?? input["file_path"] ?? input["command"] ?? "",
+				input["description"] ??
+					input["pattern"] ??
+					input["query"] ??
+					input["url"] ??
+					input["file_path"] ??
+					input["command"] ??
+					"",
 			);
 			ctx.emit({
 				kind: "tool:other",

--- a/server/orchestrator/orchestrator.finalize.integration.test.ts
+++ b/server/orchestrator/orchestrator.finalize.integration.test.ts
@@ -59,4 +59,29 @@ describe("Orchestrator success-path finalization", () => {
 		]);
 		expect(tracker.markedFailed).toEqual([{ repo: REPO, number: 12 }]);
 	});
+
+	it("marks the run failed with finalizeFailure when push fails", async () => {
+		await using ctx = await createTestOrchestrator({ runAgent: noopAgent });
+		const { orchestrator, runner, workspace, repo: runRepo } = ctx;
+		ctx.tracker.addIssue("pending", { number: 13, repo: REPO });
+		const issueKey = jiraIssueKey(13);
+		await workspace.preCreateWorkspace(issueKey, { brokenRemote: true });
+
+		await orchestrator.tick();
+		await runner.queue.waitForIdle();
+		await orchestrator.settled();
+
+		const [run] = runRepo.getRuns({ limit: 1 });
+		if (run?.status !== "failed") throw new Error("expected failed run");
+		expect(run.finalizeFailure?.phase).toBe("push");
+		expect(run.finalizeFailure?.error).toMatch(/git push/);
+		expect(run.error).toMatch(/^push: /);
+
+		const systemEvents = runRepo
+			.getRunEvents(run.id)
+			.filter((e) => e.kind === "system");
+		expect(
+			systemEvents.some((e) => e.data.message === "finalize failed: push"),
+		).toBe(true);
+	});
 });

--- a/server/orchestrator/orchestrator.recovery.integration.test.ts
+++ b/server/orchestrator/orchestrator.recovery.integration.test.ts
@@ -26,6 +26,8 @@ const baseRunRow = {
 	prNumber: null,
 	prRepo: null,
 	prKind: null,
+	finalizeFailurePhase: null,
+	finalizeFailureError: null,
 };
 
 describe("Orchestrator startup recovery", () => {

--- a/server/orchestrator/orchestrator.scheduling.integration.test.ts
+++ b/server/orchestrator/orchestrator.scheduling.integration.test.ts
@@ -15,6 +15,8 @@ const baseRunRow = {
 	prNumber: null,
 	prRepo: null,
 	prKind: null,
+	finalizeFailurePhase: null,
+	finalizeFailureError: null,
 };
 
 function dispatchedRunRow(issueNum: number) {

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -1,5 +1,6 @@
 import * as canonicalLog from "../canonical-log.ts";
 import type { CodeHostAdapter } from "../code-hosts/types.ts";
+import type { FinalizeFailurePhase } from "../db/schema.ts";
 import type { Logger } from "../logger.ts";
 import type { RunRepository } from "../run-repository.ts";
 import type {
@@ -48,13 +49,11 @@ type RunLifecycleDeps = {
 	model: string;
 };
 
-type FailurePhase =
-	| "branch_resolver"
-	| "setup"
-	| "step"
-	| "push"
-	| "change_request"
-	| "tracker_transition";
+type FailurePhase = "branch_resolver" | "setup" | "step" | FinalizeFailurePhase;
+
+type FinalizeOutcome =
+	| { ok: true }
+	| { ok: false; phase: FinalizeFailurePhase; error: string };
 
 function recordFailure(phase: FailurePhase, error: string): void {
 	canonicalLog.set({ failure_phase: phase, failure_error: error });
@@ -188,12 +187,8 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 							};
 						}
 
-						canonicalLog.set({ status: result.status });
-
-						const succeeded =
-							result.status === "completed" &&
-							branch !== undefined &&
-							(await finalizeSuccess(
+						if (result.status === "completed" && branch !== undefined) {
+							const finalize = await finalizeSuccess(
 								ctx,
 								repo,
 								issue,
@@ -202,11 +197,35 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 								branch,
 								baseBranch,
 								outputs,
-							));
+							);
+							if (!finalize.ok) {
+								ctx.emit({
+									kind: "system",
+									stepName: null,
+									data: {
+										message: `finalize failed: ${finalize.phase}`,
+										command: null,
+										path: null,
+										exitCode: null,
+									},
+								});
+								result = {
+									status: "failed",
+									error: `${finalize.phase}: ${finalize.error}`,
+									durationMs: result.durationMs,
+									finalizeFailure: {
+										phase: finalize.phase,
+										error: finalize.error,
+									},
+								};
+							}
+						}
+
+						canonicalLog.set({ status: result.status });
 
 						// Keep the workspace on any failure so the run can be inspected;
 						// only fully successful runs (agent + push + change-request) clean up.
-						if (succeeded) {
+						if (result.status === "completed") {
 							await removeWorkspace(ws.path);
 						} else if (!ctx.signal.aborted) {
 							await markIssueFailed(repo, issue);
@@ -228,13 +247,12 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 		branch: string,
 		baseBranch: string,
 		outputs: Record<string, unknown>,
-	): Promise<boolean> {
+	): Promise<FinalizeOutcome> {
 		// Pinned order per ADR 0001: push → change-request → tracker.
 		try {
 			await pushBranch(wsPath, branch);
 		} catch (err) {
-			recordFailure("push", err instanceof Error ? err.message : String(err));
-			return false;
+			return finalizeFailure("push", err);
 		}
 
 		const { title, body } = renderChangeRequest({
@@ -269,11 +287,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 				},
 			});
 		} catch (err) {
-			recordFailure(
-				"change_request",
-				err instanceof Error ? err.message : String(err),
-			);
-			return false;
+			return finalizeFailure("change_request", err);
 		}
 
 		try {
@@ -284,13 +298,18 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 				"awaiting_review",
 			);
 		} catch (err) {
-			recordFailure(
-				"tracker_transition",
-				err instanceof Error ? err.message : String(err),
-			);
-			return false;
+			return finalizeFailure("tracker_transition", err);
 		}
-		return true;
+		return { ok: true };
+	}
+
+	function finalizeFailure(
+		phase: FinalizeFailurePhase,
+		err: unknown,
+	): FinalizeOutcome {
+		const error = err instanceof Error ? err.message : String(err);
+		recordFailure(phase, error);
+		return { ok: false, phase, error };
 	}
 
 	async function markIssueFailed(repo: RepoSlug, issue: Issue): Promise<void> {

--- a/server/run-repository.test.ts
+++ b/server/run-repository.test.ts
@@ -41,6 +41,7 @@ describe("run repository row projection", () => {
 			tokensOutput: null,
 			pr: null,
 			failedStep: null,
+			finalizeFailure: null,
 		});
 	});
 

--- a/server/run-repository.ts
+++ b/server/run-repository.ts
@@ -4,6 +4,7 @@ import { and, asc, desc, eq, gt, inArray, isNotNull, sql } from "drizzle-orm";
 
 import type { Db } from "./db/db.ts";
 import {
+	type FinalizeFailurePhase,
 	type PrKind,
 	type RunEventData,
 	type RunEventKind,
@@ -41,6 +42,11 @@ type RunBase = {
 
 export type RunFailedStep = { index: number; name: string };
 
+export type RunFinalizeFailure = {
+	phase: FinalizeFailurePhase;
+	error: string;
+};
+
 export type RunningRun = RunBase & { status: "running" };
 export type CompletedRun = RunBase & {
 	status: "completed";
@@ -53,6 +59,7 @@ export type FailedRun = RunBase & {
 	durationMs: number | null;
 	error: string;
 	failedStep: RunFailedStep | null;
+	finalizeFailure: RunFinalizeFailure | null;
 };
 
 export type Run = RunningRun | CompletedRun | FailedRun;
@@ -88,7 +95,12 @@ export type RunRepository = {
 	): void;
 	failRun(
 		runId: RunId,
-		params: { error: string; completedAt: string; durationMs?: number },
+		params: {
+			error: string;
+			completedAt: string;
+			durationMs?: number;
+			finalizeFailure?: RunFinalizeFailure;
+		},
 	): void;
 	setRunBranch(runId: RunId, branch: string): void;
 	setRunWorkspaceDir(runId: RunId, workspaceDir: string): void;
@@ -151,12 +163,16 @@ export function createRunRepository(db: Db): RunRepository {
 		},
 
 		failRun(runId, params) {
-			const { durationMs, ...rest } = params;
+			const { durationMs, finalizeFailure, ...rest } = params;
 			db.update(runs)
 				.set({
 					status: "failed",
 					...rest,
 					...(durationMs != null && { durationMs }),
+					...(finalizeFailure != null && {
+						finalizeFailurePhase: finalizeFailure.phase,
+						finalizeFailureError: finalizeFailure.error,
+					}),
 				})
 				.where(eq(runs.id, runId))
 				.run();
@@ -466,6 +482,13 @@ function rowToRun(row: RunRow, failedStep: RunFailedStep | null): Run {
 				durationMs: row.durationMs,
 				error: row.error,
 				failedStep,
+				finalizeFailure:
+					row.finalizeFailurePhase != null && row.finalizeFailureError != null
+						? {
+								phase: row.finalizeFailurePhase,
+								error: row.finalizeFailureError,
+							}
+						: null,
 			};
 	}
 }

--- a/server/runner/runner.integration.test.ts
+++ b/server/runner/runner.integration.test.ts
@@ -33,6 +33,8 @@ const baseRunRow = {
 	prNumber: null,
 	prRepo: null,
 	prKind: null,
+	finalizeFailurePhase: null,
+	finalizeFailureError: null,
 };
 
 describe("Runner integration", () => {

--- a/server/runner/runner.ts
+++ b/server/runner/runner.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { RunEventData, RunEventKind, ToolBashData } from "../db/schema.ts";
 import { eventBus, type RunEvent } from "../event-bus.ts";
-import type { RunRepository } from "../run-repository.ts";
+import type { RunFinalizeFailure, RunRepository } from "../run-repository.ts";
 import {
 	type IssueKey,
 	type RepoSlug,
@@ -41,7 +41,12 @@ export type AgentJob = {
 
 export type RunResult =
 	| { status: "completed"; durationMs: number }
-	| { status: "failed"; error: string; durationMs: number };
+	| {
+			status: "failed";
+			error: string;
+			durationMs: number;
+			finalizeFailure?: RunFinalizeFailure;
+	  };
 
 export type RunHandle = {
 	runId: RunId;
@@ -189,6 +194,9 @@ export function createRunner(config: RunnerConfig): Runner {
 					error: result.error,
 					completedAt,
 					durationMs: result.durationMs,
+					...(result.finalizeFailure != null && {
+						finalizeFailure: result.finalizeFailure,
+					}),
 				});
 
 				emitFor(


### PR DESCRIPTION
## Summary
- Fixes the dashboard's stuttering live durations (10s → 16s jumps) and the full re-render on run selection by introducing a shared SSE provider (`EventStreamProvider`), a 1Hz `useNowEverySecond` tick, lifecycle-gated query invalidation, and `memo`-wrapped sibling columns. Prefetch effect in `CenterContent` was redundant alongside `useSuspenseQuery` and is gone.
- Consolidates kind enumerations into `RUN_EVENT_KINDS` / `LIFECYCLE_EVENT_KINDS` / `RUN_TERMINAL_EVENT_KINDS` in `lib/types.ts` with a compile-time exhaustiveness check, replacing the duplicated literal lists.
- Surfaces structured finalize-failure data on the run: new `finalize_failure_phase` / `finalize_failure_error` columns (migration 0009), a `FinalizeOutcome` return from `finalizeSuccess`, a `system` event emitted on failure, and the phase + message rendered in the recent-runs failure tag. Tracker + agent-logging pick up `StructuredOutput` and richer `tool:other` description fallbacks along the way.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 269/269 pass
- [ ] Smoke a running run in the browser: live elapsed in the active queue row + run banner ticks every second without an event arriving
- [ ] Click between two active runs; confirm `OverviewStrip` and `RecentRunsColumn` don't unmount/refetch
- [ ] Trigger a finalize failure (push or change-request) and confirm the recent-runs row renders `<phase> · <error>`
- [ ] Confirm `/queue` only refetches on lifecycle events (network panel) — not on every `agent:say` / `tool:bash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)