### PR TITLE
feat: surface repo url on runs + dashboard polish

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -10,7 +10,11 @@ import { useRunDetail } from "./hooks/use-run-detail.ts";
 import { useRunEventInvalidator } from "./hooks/use-run-event-invalidator.ts";
 import { useRunEvents } from "./hooks/use-run-events.ts";
 import { useRunRoute } from "./hooks/use-run-route.ts";
+import { useNowEverySecond } from "./hooks/use-tick.ts";
+import { formatTime } from "./lib/format.ts";
 import type { Step } from "./lib/types.ts";
+
+const APP_VERSION = "v0.4.2";
 
 export function App() {
 	useRunEventInvalidator();
@@ -20,8 +24,12 @@ export function App() {
 		<>
 			<header className="app">
 				<div className="brand">
-					<span className="mark">l</span>
+					<span className="mark">L</span>
 					<span>local-agents</span>
+					<span className="v mono">{APP_VERSION}</span>
+				</div>
+				<div className="meta-right">
+					<LiveClock />
 				</div>
 			</header>
 			<OverviewStrip />
@@ -66,6 +74,11 @@ function RunDetailView({ runId }: { runId: string }) {
 function TranscriptView({ runId, steps }: { runId: string; steps: Step[] }) {
 	const events = useRunEvents(runId);
 	return <Transcript events={events} steps={steps} />;
+}
+
+function LiveClock() {
+	const now = useNowEverySecond(true);
+	return <span className="mono">{formatTime(now)}</span>;
 }
 
 function Placeholder({ children }: { children: ReactNode }) {

--- a/dashboard/src/components/run-banner.tsx
+++ b/dashboard/src/components/run-banner.tsx
@@ -17,6 +17,7 @@ export function RunBanner({ run }: Props) {
 	const elapsedMs =
 		run.durationMs ?? Math.max(0, now - new Date(run.startedAt).getTime());
 	const tokens = (run.tokensInput ?? 0) + (run.tokensOutput ?? 0);
+	const hasUsage = (run.costUsd ?? 0) > 0 || tokens > 0;
 
 	return (
 		<div className="run-banner" data-testid="run-banner">
@@ -38,7 +39,11 @@ export function RunBanner({ run }: Props) {
 						)}
 						<span>
 							<span className="label">Repo</span>
-							{run.repo}
+							{run.repoUrl != null ? (
+								<a href={run.repoUrl}>{run.repo}</a>
+							) : (
+								run.repo
+							)}
 						</span>
 						{run.branch != null && (
 							<span>
@@ -54,11 +59,13 @@ export function RunBanner({ run }: Props) {
 							<span className="label">Elapsed</span>
 							<span className="mono">{formatElapsed(elapsedMs)}</span>
 						</span>
-						<span>
-							<span className="label">Cost</span>
-							{formatCost(run.costUsd)}{" "}
-							<span className="dim">· {formatTokens(tokens)}</span>
-						</span>
+						{hasUsage && (
+							<span>
+								<span className="label">Cost</span>
+								{formatCost(run.costUsd)}{" "}
+								<span className="dim">· {formatTokens(tokens)}</span>
+							</span>
+						)}
 						{run.workspaceDir != null && (
 							<span>
 								<span className="label">Workspace</span>

--- a/dashboard/src/hooks/use-run-event-invalidator.ts
+++ b/dashboard/src/hooks/use-run-event-invalidator.ts
@@ -15,8 +15,8 @@ export function useRunEventInvalidator(): void {
 		return stream.subscribe((event) => {
 			if (!LIFECYCLE_KINDS.has(event.kind)) return;
 			queryClient.invalidateQueries({ queryKey: ["queue"] });
+			queryClient.invalidateQueries({ queryKey: ["stats"] });
 			if (TERMINAL_KINDS.has(event.kind)) {
-				queryClient.invalidateQueries({ queryKey: ["stats"] });
 				queryClient.invalidateQueries({ queryKey: ["recent-runs"] });
 			}
 		});

--- a/dashboard/src/hooks/use-tick.ts
+++ b/dashboard/src/hooks/use-tick.ts
@@ -1,13 +1,46 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+let now = Date.now();
+let timeoutId: number | null = null;
+
+function emit() {
+	now = Date.now();
+	for (const listener of listeners) listener();
+	scheduleNextTick();
+}
+
+function scheduleNextTick() {
+	if (listeners.size === 0) {
+		timeoutId = null;
+		return;
+	}
+	const delay = 1000 - (Date.now() % 1000);
+	timeoutId = window.setTimeout(emit, delay);
+}
+
+function subscribe(listener: Listener): () => void {
+	listeners.add(listener);
+	if (timeoutId == null) scheduleNextTick();
+	return () => {
+		listeners.delete(listener);
+		if (listeners.size === 0 && timeoutId != null) {
+			window.clearTimeout(timeoutId);
+			timeoutId = null;
+		}
+	};
+}
+
+function getNow(): number {
+	return now;
+}
 
 export function useNowEverySecond(active: boolean): number {
-	const [now, setNow] = useState(() => Date.now());
+	return useSyncExternalStore(active ? subscribe : noopSubscribe, getNow);
+}
 
-	useEffect(() => {
-		if (!active) return;
-		const id = window.setInterval(() => setNow(Date.now()), 1000);
-		return () => window.clearInterval(id);
-	}, [active]);
-
-	return now;
+function noopSubscribe(): () => void {
+	return () => {};
 }

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -63,6 +63,13 @@ body {
 	flex-direction: column;
 }
 
+#root {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+}
+
 ::selection {
 	background: #dbeafe;
 }
@@ -116,6 +123,16 @@ header.app .meta-right {
 	place-items: center;
 	font-size: 11px;
 	font-weight: 600;
+}
+
+.brand .v {
+	font-size: 11px;
+	color: var(--fg-3);
+	font-weight: 400;
+	padding: 2px 6px;
+	background: var(--bg-1);
+	border-radius: 3px;
+	margin-left: 4px;
 }
 
 .meta-right {

--- a/dashboard/src/lib/format.ts
+++ b/dashboard/src/lib/format.ts
@@ -1,7 +1,7 @@
 import type { RunStepState } from "./types.ts";
 
-export function formatTime(iso: string): string {
-	const d = new Date(iso);
+export function formatTime(input: string | number | Date): string {
+	const d = input instanceof Date ? input : new Date(input);
 	const hh = String(d.getHours()).padStart(2, "0");
 	const mm = String(d.getMinutes()).padStart(2, "0");
 	const ss = String(d.getSeconds()).padStart(2, "0");

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -27,6 +27,7 @@ export type Run = {
 	id: string;
 	status: RunStatus;
 	repo: string;
+	repoUrl: string | null;
 	branch: string | null;
 	workspaceDir: string | null;
 	issueKey: string | null;

--- a/dashboard/src/testing/contract.ts
+++ b/dashboard/src/testing/contract.ts
@@ -14,6 +14,7 @@ export function createRun(overrides: Partial<Run> = {}): Run {
 		id: "run-1",
 		status: "running",
 		repo: "acme/api",
+		repoUrl: null,
 		branch: null,
 		workspaceDir: null,
 		issueKey: null,

--- a/drizzle/0010_parched_professor_monster.sql
+++ b/drizzle/0010_parched_professor_monster.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `runs` ADD `repo_url` text;

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,371 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "4c0d7ed9-c3b5-47b6-a390-a94e10bcc629",
+	"prevId": "dfb9d1a0-b144-44b1-b03c-98f3e8c84996",
+	"tables": {
+		"run_events": {
+			"name": "run_events",
+			"columns": {
+				"seq": {
+					"name": "seq",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"step_name": {
+					"name": "step_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"data": {
+					"name": "data",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"run_events_id_unique": {
+					"name": "run_events_id_unique",
+					"columns": ["id"],
+					"isUnique": true
+				},
+				"idx_run_events_run_id": {
+					"name": "idx_run_events_run_id",
+					"columns": ["run_id"],
+					"isUnique": false
+				},
+				"idx_run_events_seq": {
+					"name": "idx_run_events_seq",
+					"columns": ["seq"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"run_step_outputs": {
+			"name": "run_step_outputs",
+			"columns": {
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"step_name": {
+					"name": "step_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"output_json": {
+					"name": "output_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"run_step_outputs_run_id_step_name_pk": {
+					"columns": ["run_id", "step_name"],
+					"name": "run_step_outputs_run_id_step_name_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"run_steps": {
+			"name": "run_steps",
+			"columns": {
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"index": {
+					"name": "index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"run_steps_run_id_index_pk": {
+					"columns": ["run_id", "index"],
+					"name": "run_steps_run_id_index_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"runs": {
+			"name": "runs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repo": {
+					"name": "repo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"repo_url": {
+					"name": "repo_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"branch": {
+					"name": "branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"workspace_dir": {
+					"name": "workspace_dir",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"issue_key": {
+					"name": "issue_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"issue_title": {
+					"name": "issue_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"issue_url": {
+					"name": "issue_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"cost_usd": {
+					"name": "cost_usd",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_input": {
+					"name": "tokens_input",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_output": {
+					"name": "tokens_output",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_url": {
+					"name": "pr_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_number": {
+					"name": "pr_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_repo": {
+					"name": "pr_repo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_kind": {
+					"name": "pr_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"finalize_failure_phase": {
+					"name": "finalize_failure_phase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"finalize_failure_error": {
+					"name": "finalize_failure_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
 			"when": 1778435816704,
 			"tag": "0009_daffy_starjammers",
 			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "6",
+			"when": 1778443339865,
+			"tag": "0010_parched_professor_monster",
+			"breakpoints": true
 		}
 	]
 }

--- a/server/api/api.test.ts
+++ b/server/api/api.test.ts
@@ -64,6 +64,7 @@ describe("GET /events", () => {
 				issueKey: issueKey("test/repo#42"),
 				issueTitle: "SSE test issue",
 				issueUrl: null,
+				repoUrl: "https://code-host.example.test/test/repo",
 				handler: async () => ({ status: "completed" as const, durationMs: 0 }),
 			});
 
@@ -98,6 +99,7 @@ describe("GET /events", () => {
 			issueKey: issueKey("test/repo#100"),
 			issueTitle: "Replay test",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/test/repo",
 			handler: async (ctx) => {
 				ctx.emit({
 					kind: "agent:say",

--- a/server/api/api.ts
+++ b/server/api/api.ts
@@ -219,6 +219,7 @@ type RunWire = {
 	id: string;
 	status: Run["status"];
 	repo: string;
+	repoUrl: string | null;
 	branch: string | null;
 	workspaceDir: string | null;
 	issueKey: string | null;
@@ -291,6 +292,7 @@ function runToWire(run: Run): RunWire {
 		id: run.id,
 		status: run.status,
 		repo: run.repo,
+		repoUrl: run.repoUrl,
 		branch: run.branch,
 		workspaceDir: run.workspaceDir,
 		issueKey: run.issueKey,

--- a/server/api/queue.test.ts
+++ b/server/api/queue.test.ts
@@ -59,6 +59,7 @@ describe("GET /queue", () => {
 					status: "running",
 					error: null,
 					repo: "acme/api",
+					repoUrl: null,
 					branch: "fix/ACME-1284-npm-install-hang",
 					workspaceDir: "/tmp/lag/9f3b2e1",
 					issueKey: "ACME-1284",

--- a/server/api/runs.test.ts
+++ b/server/api/runs.test.ts
@@ -7,6 +7,7 @@ const baseRunWire = {
 	branch: null,
 	workspaceDir: null,
 	issueUrl: null,
+	repoUrl: null,
 	costUsd: null,
 	tokensInput: null,
 	tokensOutput: null,
@@ -283,6 +284,7 @@ describe("GET /runs/:id", () => {
 				status: "running",
 				error: null,
 				repo: "acme/api",
+				repoUrl: null,
 				branch: "fix/ACME-1284-npm-install-hang",
 				workspaceDir: "/tmp/lag/9f3b2e1",
 				issueKey: "acme/api#1284",
@@ -365,6 +367,7 @@ describe("POST /runs/:id/kill", () => {
 			issueKey: issueKey("test/repo#1"),
 			issueTitle: "Long running job",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/test/repo",
 			handler: () => new Promise(() => {}),
 		});
 
@@ -429,6 +432,7 @@ describe("GET /runs/:id/events", () => {
 			issueKey: issueKey("test/repo#1"),
 			issueTitle: "Event ordering",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/test/repo",
 			handler: async (ctx) => {
 				ctx.emit({
 					kind: "agent:say",
@@ -470,6 +474,7 @@ describe("GET /runs/:id/events", () => {
 			issueKey: issueKey("test/repo#2"),
 			issueTitle: "Since cursor",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/test/repo",
 			handler: async (ctx) => {
 				ctx.emit({
 					kind: "agent:say",

--- a/server/code-hosts/github.ts
+++ b/server/code-hosts/github.ts
@@ -13,6 +13,10 @@ export function githubCodeHostAdapter(
 			return `https://x-access-token:${encodeURIComponent(cloneToken)}@github.com/${repo}.git`;
 		},
 
+		repoUrl(repo): string {
+			return `https://github.com/${repo}`;
+		},
+
 		async defaultBranch(repo) {
 			const project = await client.getRepo(repo);
 			return project.default_branch;

--- a/server/code-hosts/gitlab.ts
+++ b/server/code-hosts/gitlab.ts
@@ -17,6 +17,10 @@ export function gitlabCodeHostAdapter(
 			);
 		},
 
+		repoUrl(repo): string {
+			return `${client.baseUrl}/${repo}`;
+		},
+
 		async defaultBranch(repo) {
 			const project = await client.getProject(repo);
 			return project.default_branch;

--- a/server/code-hosts/types.ts
+++ b/server/code-hosts/types.ts
@@ -7,6 +7,7 @@ export type ChangeRequest = {
 
 export type CodeHostAdapter = {
 	cloneUrl(repo: RepoSlug): string;
+	repoUrl(repo: RepoSlug): string;
 	defaultBranch(repo: RepoSlug): Promise<string>;
 	createChangeRequest(
 		repo: RepoSlug,

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -14,6 +14,7 @@ export const runs = sqliteTable("runs", {
 	status: text("status").notNull().$type<RunStatus>(),
 	error: text("error"),
 	repo: text("repo").notNull().$type<RepoSlug>(),
+	repoUrl: text("repo_url"),
 	branch: text("branch"),
 	workspaceDir: text("workspace_dir"),
 	issueKey: text("issue_key").$type<IssueKey>(),

--- a/server/orchestrator/orchestrator.recovery.integration.test.ts
+++ b/server/orchestrator/orchestrator.recovery.integration.test.ts
@@ -19,6 +19,7 @@ const baseRunRow = {
 	branch: null,
 	workspaceDir: null,
 	issueUrl: null,
+	repoUrl: null,
 	costUsd: null,
 	tokensInput: null,
 	tokensOutput: null,

--- a/server/orchestrator/orchestrator.scheduling.integration.test.ts
+++ b/server/orchestrator/orchestrator.scheduling.integration.test.ts
@@ -8,6 +8,7 @@ const baseRunRow = {
 	branch: null,
 	workspaceDir: null,
 	issueUrl: null,
+	repoUrl: null,
 	costUsd: null,
 	tokensInput: null,
 	tokensOutput: null,
@@ -25,6 +26,7 @@ function dispatchedRunRow(issueNum: number) {
 		branch: `agent/issue-${issueNum}`,
 		workspaceDir: expect.any(String),
 		issueUrl: `https://tracker.example.test/browse/${jiraIssueKey(issueNum)}`,
+		repoUrl: `https://code-host.example.test/${REPO}`,
 	};
 }
 

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -82,6 +82,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 
 		return runner.enqueue({
 			repo,
+			repoUrl: codeHost.repoUrl(repo),
 			issueKey: issue.key,
 			issueTitle: issue.title,
 			issueUrl: issue.url,

--- a/server/run-repository.test.ts
+++ b/server/run-repository.test.ts
@@ -27,6 +27,7 @@ describe("run repository row projection", () => {
 			id: "failed-1",
 			status: "failed",
 			repo: "acme/widgets",
+			repoUrl: null,
 			branch: null,
 			workspaceDir: null,
 			issueKey: "acme/widgets#1",

--- a/server/run-repository.ts
+++ b/server/run-repository.ts
@@ -28,6 +28,7 @@ export type RunPr = {
 type RunBase = {
 	id: RunId;
 	repo: RepoSlug;
+	repoUrl: string | null;
 	branch: string | null;
 	workspaceDir: string | null;
 	issueKey: IssueKey | null;
@@ -84,6 +85,7 @@ export type RunRepository = {
 	insertRun(run: {
 		id: RunId;
 		repo: RepoSlug;
+		repoUrl: string;
 		issueKey: IssueKey;
 		issueTitle: string;
 		issueUrl: string | null;
@@ -442,6 +444,7 @@ function rowToRun(row: RunRow, failedStep: RunFailedStep | null): Run {
 	const base: RunBase = {
 		id: row.id,
 		repo: row.repo,
+		repoUrl: row.repoUrl,
 		branch: row.branch,
 		workspaceDir: row.workspaceDir,
 		issueKey: row.issueKey,

--- a/server/runner/runner.integration.test.ts
+++ b/server/runner/runner.integration.test.ts
@@ -26,6 +26,7 @@ const baseRunRow = {
 	branch: null,
 	workspaceDir: null,
 	issueUrl: null,
+	repoUrl: "https://code-host.example.test/acme/widgets",
 	costUsd: null,
 	tokensInput: null,
 	tokensOutput: null,
@@ -55,6 +56,7 @@ describe("Runner integration", () => {
 			issueKey: ik("acme/widgets#1"),
 			issueTitle: "Test issue",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/acme/widgets",
 			handler: () =>
 				new Promise((r) => {
 					resolveHandler = r;
@@ -90,6 +92,7 @@ describe("Runner integration", () => {
 			issueKey: ik("acme/widgets#1"),
 			issueTitle: "Blocker",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/acme/widgets",
 			handler: () =>
 				new Promise((r) => {
 					resolveBlocker = r;
@@ -102,6 +105,7 @@ describe("Runner integration", () => {
 			issueKey: ik("acme/widgets#2"),
 			issueTitle: "Queued issue",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/acme/widgets",
 			handler: async () => ({ status: "completed" as const, durationMs: 0 }),
 		});
 
@@ -134,6 +138,7 @@ describe("Runner integration", () => {
 			issueKey: ik("acme/widgets#2"),
 			issueTitle: "Fast issue",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/acme/widgets",
 			handler: completedHandler,
 		});
 
@@ -166,6 +171,7 @@ describe("Runner integration", () => {
 			issueKey: ik("acme/widgets#99"),
 			issueTitle: "Crash issue",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/acme/widgets",
 			handler: failedHandler("catastrophic failure"),
 		});
 
@@ -186,6 +192,7 @@ describe("Runner integration", () => {
 			issueKey: ik("acme/widgets#4"),
 			issueTitle: "Lifecycle issue",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/acme/widgets",
 			handler: completedHandler,
 		});
 
@@ -226,6 +233,7 @@ describe("Runner integration", () => {
 			issueKey: ik("acme/widgets#5"),
 			issueTitle: "Fail event issue",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/acme/widgets",
 			handler: failedHandler("boom"),
 		});
 
@@ -265,6 +273,7 @@ describe("Runner integration", () => {
 			issueKey: ik("acme/widgets#6"),
 			issueTitle: "Tool issue",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/acme/widgets",
 			handler: async (ctx) => {
 				ctx.emit({
 					kind: "tool:read",
@@ -340,6 +349,7 @@ describe("Runner integration", () => {
 			issueKey: ik("acme/widgets#8"),
 			issueTitle: "Killed mid-bash",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/acme/widgets",
 			handler: async (ctx) => {
 				ctx.emit({
 					kind: "tool:bash",
@@ -379,6 +389,7 @@ describe("Runner integration", () => {
 			issueKey: ik("acme/widgets#9"),
 			issueTitle: "Bash exits normally",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/acme/widgets",
 			handler: async (ctx) => {
 				ctx.emit({
 					kind: "tool:bash",
@@ -409,6 +420,7 @@ describe("Runner integration", () => {
 			issueKey: ik("acme/widgets#7"),
 			issueTitle: "Killable issue",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/acme/widgets",
 			handler: () => new Promise(() => {}), // never resolves naturally
 		});
 
@@ -451,6 +463,7 @@ describe("Runner integration", () => {
 			issueKey: ik("acme/widgets#10"),
 			issueTitle: "Default concurrency",
 			issueUrl: null,
+			repoUrl: "https://code-host.example.test/acme/widgets",
 			handler: completedHandler,
 		});
 

--- a/server/runner/runner.ts
+++ b/server/runner/runner.ts
@@ -33,6 +33,7 @@ export type RunContext = {
 
 export type AgentJob = {
 	repo: RepoSlug;
+	repoUrl: string;
 	issueKey: IssueKey;
 	issueTitle: string;
 	issueUrl: string | null;
@@ -123,6 +124,7 @@ export function createRunner(config: RunnerConfig): Runner {
 		repo.insertRun({
 			id,
 			repo: job.repo,
+			repoUrl: job.repoUrl,
 			issueKey: job.issueKey,
 			issueTitle: job.issueTitle,
 			issueUrl: job.issueUrl,

--- a/server/test-support/code-host-stub.ts
+++ b/server/test-support/code-host-stub.ts
@@ -45,6 +45,10 @@ export function createCodeHostStub(): CodeHostStub {
 			);
 		},
 
+		repoUrl(repo) {
+			return `https://code-host.example.test/${repo}`;
+		},
+
 		async defaultBranch(repo) {
 			return defaultBranches.get(repo) ?? "main";
 		},


### PR DESCRIPTION
## Summary
- Plumbs a `repoUrl` from each code-host adapter through the runs schema (new migration `0010`), repository, runner, lifecycle, and wire layer so the run banner can render the repo slug as a link.
- Run banner: hides the Cost/tokens row until the run has actual usage so brand-new runs aren't littered with `$0.000 · 0 tok`.
- App header: live clock, version chip (`v0.4.2`), tweaked brand mark.
- `use-tick`: replaces the per-component `setInterval` with a shared global store via `useSyncExternalStore`. One second-aligned timer drives every subscriber; cleans up when the last unsubscribes.
- Stats invalidate on every lifecycle event (not just terminal) so the overview strip stays current mid-run.
- `formatTime` now accepts `string | number | Date` so the live clock can pass the tick value directly.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (269 passing)
- [ ] Manual: restart `pnpm dev` so migration `0010` applies, then verify the run banner repo slug links out and the live clock ticks in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)