### PR TITLE
refactor: per-run workspace with TTL sweep + richer exec failures

### DIFF
--- a/bugs.md
+++ b/bugs.md
@@ -1,2 +1,0 @@
-- I noticed that our Run UI appears to only update when a new event comes through that is not nice. Considering we are literally rendering runtime down to seconds so this is literally stopping at like 10secs then jumping to 16secs as another event has come through. This is so bad that actually our left pannel UI showing the active runs the time lapsed doesn't even update unless you refresh the page or click to another run.
-- I noticed that when clicking to another run it seems like our entire UI re-renders.

--- a/dashboard/src/components/recent-runs-column.tsx
+++ b/dashboard/src/components/recent-runs-column.tsx
@@ -103,7 +103,11 @@ function FailureTag({ run }: { run: Run }) {
 			: finalize != null
 				? `${finalize.phase} · ${finalize.error}`
 				: `failed · ${error}`;
-	return <span className="err">{text}</span>;
+	return (
+		<span className="err" title={text}>
+			{text}
+		</span>
+	);
 }
 
 function PrLink({ pr }: { pr: RunPr }) {

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -1000,6 +1000,7 @@ h1.run-title {
 	align-items: center;
 	gap: 8px;
 	font-size: 11.5px;
+	min-width: 0;
 }
 
 .hrow-foot .pr {
@@ -1024,6 +1025,7 @@ h1.run-title {
 	display: flex;
 	align-items: center;
 	gap: 10px;
+	flex-shrink: 0;
 }
 
 .hrow-foot .dur {
@@ -1041,6 +1043,11 @@ h1.run-title {
 .hrow-foot .err {
 	color: var(--failed);
 	font-size: 11.5px;
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 /* ───── empty / loading ───── */

--- a/server/orchestrator/orchestrator.dispatch-multi-repo.integration.test.ts
+++ b/server/orchestrator/orchestrator.dispatch-multi-repo.integration.test.ts
@@ -10,9 +10,8 @@ describe("Orchestrator multi-repo scheduling", () => {
 			maxConcurrency: 5,
 			runAgent: hangingAgent,
 		});
-		const { orchestrator, workspace, tracker } = ctx;
+		const { orchestrator, tracker } = ctx;
 		tracker.addIssue("pending", { number: 1, repo: REPO });
-		await workspace.preCreateWorkspace(jiraIssueKey(1));
 
 		await Promise.all([orchestrator.tick(), orchestrator.tick()]);
 
@@ -27,7 +26,8 @@ describe("Orchestrator multi-repo scheduling", () => {
 			maxConcurrency: 5,
 			configOverrides: { max_concurrent: 5 },
 		});
-		const { orchestrator, db, runner, workspace, tracker } = ctx;
+		const { orchestrator, db, runner, workspace, codeHost, tracker } = ctx;
+		codeHost.setCloneUrl(REPO2, await workspace.setupRepoRemote(REPO2));
 		tracker.addIssue("pending", {
 			number: 1,
 			repo: REPO,
@@ -38,8 +38,6 @@ describe("Orchestrator multi-repo scheduling", () => {
 			repo: REPO2,
 			createdAt: "2025-01-02T00:00:00.000+0000",
 		});
-		await workspace.preCreateWorkspace(jiraIssueKey(1));
-		await workspace.preCreateWorkspace(jiraIssueKey(2));
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();

--- a/server/orchestrator/orchestrator.finalize.integration.test.ts
+++ b/server/orchestrator/orchestrator.finalize.integration.test.ts
@@ -2,7 +2,11 @@ import { execFile } from "node:child_process";
 import { access } from "node:fs/promises";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
-import { jiraIssueKey, noopAgent, REPO } from "../test-support/fixtures.ts";
+import {
+	noopAgent,
+	REPO,
+	type TestRunAgent,
+} from "../test-support/fixtures.ts";
 import { createTestOrchestrator } from "../test-support/test-orchestrator.ts";
 
 const exec = promisify(execFile);
@@ -15,20 +19,42 @@ async function listRemoteBranches(barePath: string): Promise<string[]> {
 		.filter(Boolean);
 }
 
+// Simulates push failure by breaking origin from inside the agent step, after
+// the orchestrator has already cloned a fresh workspace. The generator never
+// yields a message — it only performs the setup side effect.
+// biome-ignore lint/correctness/useYield: intentional side-effect-only agent
+async function* breakRemoteAgent({
+	options,
+}: Parameters<TestRunAgent>[0]): ReturnType<TestRunAgent> {
+	const cwd = options?.cwd;
+	if (typeof cwd === "string") {
+		await exec(
+			"git",
+			["remote", "set-url", "origin", "/nonexistent/path.git"],
+			{ cwd },
+		);
+	}
+}
+
 describe("Orchestrator success-path finalization", () => {
 	it("pushes the agent's branch to the remote before opening the change request", async () => {
 		await using ctx = await createTestOrchestrator({ runAgent: noopAgent });
-		const { orchestrator, runner, workspace, tracker, codeHost } = ctx;
+		const {
+			orchestrator,
+			runner,
+			workspace,
+			tracker,
+			codeHost,
+			repo: runRepo,
+		} = ctx;
 		tracker.addIssue("pending", { number: 11, repo: REPO });
-		const issueKey = jiraIssueKey(11);
-		const wsPath = await workspace.preCreateWorkspace(issueKey);
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
 		await orchestrator.settled();
 
 		const remoteBranches = await listRemoteBranches(
-			workspace.bareRemotePath(issueKey),
+			workspace.bareRemotePath(REPO),
 		);
 		expect(remoteBranches).toContain("agent/issue-11");
 		expect(codeHost.changeRequests.map((c) => c.repo)).toEqual([REPO]);
@@ -36,24 +62,23 @@ describe("Orchestrator success-path finalization", () => {
 			{ repo: REPO, number: 11, from: "pending", to: "running" },
 			{ repo: REPO, number: 11, from: "running", to: "awaiting_review" },
 		]);
-		await expect(access(wsPath)).rejects.toThrow();
+		const [run] = runRepo.getRuns({ limit: 1 });
+		if (run?.workspaceDir == null) throw new Error("expected workspaceDir");
+		await expect(access(run.workspaceDir)).rejects.toThrow();
 	});
 
 	it("skips MR creation and tracker transition when the push fails, and marks the issue failed", async () => {
-		await using ctx = await createTestOrchestrator({ runAgent: noopAgent });
-		const { orchestrator, runner, workspace, tracker, codeHost } = ctx;
-		tracker.addIssue("pending", { number: 12, repo: REPO });
-		const issueKey = jiraIssueKey(12);
-		const wsPath = await workspace.preCreateWorkspace(issueKey, {
-			brokenRemote: true,
+		await using ctx = await createTestOrchestrator({
+			runAgent: breakRemoteAgent,
 		});
+		const { orchestrator, runner, tracker, codeHost } = ctx;
+		tracker.addIssue("pending", { number: 12, repo: REPO });
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
 		await orchestrator.settled();
 
 		expect(codeHost.changeRequests).toEqual([]);
-		await expect(access(wsPath)).resolves.toBeUndefined();
 		expect(tracker.transitions).toEqual([
 			{ repo: REPO, number: 12, from: "pending", to: "running" },
 		]);
@@ -61,11 +86,11 @@ describe("Orchestrator success-path finalization", () => {
 	});
 
 	it("marks the run failed with finalizeFailure when push fails", async () => {
-		await using ctx = await createTestOrchestrator({ runAgent: noopAgent });
-		const { orchestrator, runner, workspace, repo: runRepo } = ctx;
+		await using ctx = await createTestOrchestrator({
+			runAgent: breakRemoteAgent,
+		});
+		const { orchestrator, runner, repo: runRepo } = ctx;
 		ctx.tracker.addIssue("pending", { number: 13, repo: REPO });
-		const issueKey = jiraIssueKey(13);
-		await workspace.preCreateWorkspace(issueKey, { brokenRemote: true });
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
@@ -75,6 +100,14 @@ describe("Orchestrator success-path finalization", () => {
 		if (run?.status !== "failed") throw new Error("expected failed run");
 		expect(run.finalizeFailure?.phase).toBe("push");
 		expect(run.finalizeFailure?.error).toMatch(/git push/);
+		// stderr must survive the round-trip through finalizeFailure — Node's
+		// execFile errors carry the diagnostic detail on `err.stderr`, not in
+		// `err.message`. The broken origin URL makes git emit a "does not appear
+		// to be a git repository" / "Could not read from remote" line on stderr.
+		expect(run.finalizeFailure?.error).toMatch(/stderr:/);
+		expect(run.finalizeFailure?.error).toMatch(
+			/does not appear to be a git repository|Could not read from remote/,
+		);
 		expect(run.error).toMatch(/^push: /);
 
 		const systemEvents = runRepo

--- a/server/orchestrator/orchestrator.queue.integration.test.ts
+++ b/server/orchestrator/orchestrator.queue.integration.test.ts
@@ -8,7 +8,7 @@ describe("Orchestrator holding queue", () => {
 			configOverrides: { max_concurrent: 1 },
 			runAgent: hangingAgent,
 		});
-		const { orchestrator, workspace, tracker } = ctx;
+		const { orchestrator, tracker } = ctx;
 
 		tracker.addIssue("pending", {
 			number: 1,
@@ -22,8 +22,6 @@ describe("Orchestrator holding queue", () => {
 			title: "issue two",
 			createdAt: "2025-01-02T00:00:00.000+0000",
 		});
-		await workspace.preCreateWorkspace(jiraIssueKey(1));
-		await workspace.preCreateWorkspace(jiraIssueKey(2));
 
 		await orchestrator.tick();
 

--- a/server/orchestrator/orchestrator.scheduling.integration.test.ts
+++ b/server/orchestrator/orchestrator.scheduling.integration.test.ts
@@ -23,8 +23,6 @@ const baseRunRow = {
 function dispatchedRunRow(issueNum: number) {
 	return {
 		...baseRunRow,
-		branch: `agent/issue-${issueNum}`,
-		workspaceDir: expect.any(String),
 		issueUrl: `https://tracker.example.test/browse/${jiraIssueKey(issueNum)}`,
 		repoUrl: `https://code-host.example.test/${REPO}`,
 	};
@@ -35,9 +33,8 @@ describe("Orchestrator scheduling", () => {
 		await using ctx = await createTestOrchestrator({
 			runAgent: hangingAgent,
 		});
-		const { orchestrator, db, workspace, tracker } = ctx;
+		const { orchestrator, db, tracker } = ctx;
 		tracker.addIssue("pending", { number: 1, repo: REPO });
-		await workspace.preCreateWorkspace(jiraIssueKey(1));
 
 		await orchestrator.tick();
 
@@ -67,14 +64,13 @@ describe("Orchestrator scheduling", () => {
 			configOverrides: { max_concurrent: 1 },
 			runAgent: hangingAgent,
 		});
-		const { orchestrator, db, workspace, tracker } = ctx;
+		const { orchestrator, db, tracker } = ctx;
 		for (const num of [1, 2, 3]) {
 			tracker.addIssue("pending", {
 				number: num,
 				repo: REPO,
 				createdAt: `2025-01-0${num}T00:00:00.000+0000`,
 			});
-			await workspace.preCreateWorkspace(jiraIssueKey(num));
 		}
 
 		await orchestrator.tick();
@@ -102,7 +98,7 @@ describe("Orchestrator scheduling", () => {
 			configOverrides: { max_concurrent: 2 },
 			runAgent: hangingAgent,
 		});
-		const { orchestrator, db, workspace, tracker } = ctx;
+		const { orchestrator, db, tracker } = ctx;
 		tracker.addIssue("pending", {
 			number: 99,
 			repo: REPO,
@@ -118,9 +114,6 @@ describe("Orchestrator scheduling", () => {
 			repo: REPO,
 			createdAt: "2025-01-02T00:00:00.000+0000",
 		});
-		for (const num of [42, 77, 99]) {
-			await workspace.preCreateWorkspace(jiraIssueKey(num));
-		}
 
 		await orchestrator.tick();
 
@@ -136,9 +129,8 @@ describe("Orchestrator scheduling", () => {
 			maxConcurrency: 5,
 			runAgent: hangingAgent,
 		});
-		const { orchestrator, db, workspace, tracker } = ctx;
+		const { orchestrator, db, tracker } = ctx;
 		tracker.addIssue("pending", { number: 1, repo: REPO });
-		await workspace.preCreateWorkspace(jiraIssueKey(1));
 
 		await orchestrator.tick();
 		const before = db.select().from(runs).all();
@@ -149,22 +141,25 @@ describe("Orchestrator scheduling", () => {
 		expect(after).toEqual(before);
 	});
 
-	it("rolls back tracker (running → pending) when lifecycle.dispatch throws (workspace clone fails)", async () => {
+	it("records a failed run and marks the issue failed when clone fails inside the lifecycle", async () => {
 		await using ctx = await createTestOrchestrator();
-		const { orchestrator, db, runner, tracker, codeHost } = ctx;
+		const { orchestrator, db, runner, tracker, codeHost, repo: runRepo } = ctx;
 		tracker.addIssue("pending", { number: 1, repo: REPO });
-		// No preCreateWorkspace + bad cloneUrl ⇒ ensureWorkspace's `git clone` fails.
 		codeHost.setCloneUrl(REPO, "/nonexistent/repo.git");
 
 		await orchestrator.tick();
 		await runner.queue.waitForIdle();
 		await orchestrator.settled();
 
-		expect(db.select().from(runs).all()).toHaveLength(0);
+		const allRuns = db.select().from(runs).all();
+		expect(allRuns).toHaveLength(1);
+		const [run] = runRepo.getRuns({ limit: 1 });
+		if (run?.status !== "failed") throw new Error("expected failed run");
+		expect(run.error).toMatch(/git clone|does not appear to be a git/);
 		expect(tracker.transitions).toEqual([
 			{ repo: REPO, number: 1, from: "pending", to: "running" },
-			{ repo: REPO, number: 1, from: "running", to: "pending" },
 		]);
+		expect(tracker.markedFailed).toEqual([{ repo: REPO, number: 1 }]);
 	});
 
 	it("start() polls on the configured interval and stop() halts it", async () => {
@@ -191,14 +186,14 @@ describe("Orchestrator scheduling", () => {
 	});
 
 	it("start() runs recovery before the first tick dispatches pending issues", async () => {
-		// Real timers because dispatch awaits real fs I/O in ensureWorkspace; fake
+		// Real timers because dispatch awaits real fs I/O in createWorkspace; fake
 		// timers don't drain the libuv thread pool. Polling interval is set very
 		// long so the first-tick assertion observes only the startup sequence.
 		await using ctx = await createTestOrchestrator({
 			configOverrides: { polling_interval_ms: 60_000 },
 			runAgent: hangingAgent,
 		});
-		const { orchestrator, db, workspace, tracker } = ctx;
+		const { orchestrator, db, tracker } = ctx;
 
 		seedRun(db, {
 			id: "stale-run",
@@ -209,11 +204,14 @@ describe("Orchestrator scheduling", () => {
 			startedAt: "2025-01-01T00:00:00Z",
 		});
 		tracker.addIssue("pending", { number: 1, repo: REPO });
-		await workspace.preCreateWorkspace(jiraIssueKey(1));
 
 		orchestrator.start();
 		await vi.waitFor(() => {
-			expect(db.select().from(runs).all()).toHaveLength(2);
+			const rows = db.select().from(runs).all();
+			expect(rows).toHaveLength(2);
+			const dispatched = rows.find((r) => r.id !== "stale-run");
+			expect(dispatched?.workspaceDir).toEqual(expect.any(String));
+			expect(dispatched?.branch).toEqual(expect.any(String));
 		});
 
 		// Recovery happened first: stale run failed and tracker fetched "running".
@@ -236,6 +234,8 @@ describe("Orchestrator scheduling", () => {
 			{
 				id: expect.any(String),
 				...dispatchedRunRow(1),
+				workspaceDir: expect.any(String),
+				branch: `agent/issue-1`,
 				status: "running",
 				error: null,
 				repo: REPO,
@@ -256,7 +256,7 @@ describe("Orchestrator scheduling", () => {
 		await using ctx = await createTestOrchestrator({
 			configOverrides: { polling_interval_ms: 1000 },
 		});
-		const { orchestrator, db, tracker } = ctx;
+		const { orchestrator, tracker } = ctx;
 		tracker.addIssue("pending", { number: 1, repo: REPO });
 		tracker.failNextTransition();
 
@@ -264,11 +264,11 @@ describe("Orchestrator scheduling", () => {
 		await vi.advanceTimersByTimeAsync(0);
 		await vi.advanceTimersByTimeAsync(1000);
 
-		// Recovery + at least two ticks fired despite the dispatch-time throw.
+		// First tick's pending→running transition is rejected; the loop keeps
+		// polling so a subsequent tick retries.
 		expect(
 			tracker.fetchCalls.filter((s) => s === "pending").length,
 		).toBeGreaterThanOrEqual(2);
-		expect(db.select().from(runs).all()).toHaveLength(0);
 
 		orchestrator.stop();
 		vi.useRealTimers();

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -10,7 +10,9 @@ import type { RepoWorkflow } from "../workflow/workflow.ts";
 import { type AgentInvoker, claudeSdkAgentInvoker } from "./agent-invoker.ts";
 import { type Clock, systemClock } from "./clock.ts";
 import { createRunLifecycle } from "./run-lifecycle.ts";
-import { type RunShell, realRunShell } from "./workspace.ts";
+import { type RunShell, realRunShell, sweepWorkspaces } from "./workspace.ts";
+
+const WORKSPACE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 type OrchestratorConfig = {
 	runRepo: RunRepository;
@@ -310,6 +312,17 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 			logger.info(
 				{ interval: defaults.polling_interval_ms },
 				"orchestrator.starting",
+			);
+			sweepWorkspaces(defaults.workspace_root, WORKSPACE_TTL_MS).then(
+				(swept) => {
+					if (swept.removed.length > 0) {
+						logger.info(
+							{ count: swept.removed.length },
+							"orchestrator.workspaces_swept",
+						);
+					}
+				},
+				(err) => logger.warn({ err }, "orchestrator.workspace_sweep_failed"),
 			);
 			void (async () => {
 				try {

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -18,8 +18,8 @@ import { renderChangeRequest } from "./change-request-renderer.ts";
 import type { Clock } from "./clock.ts";
 import { runWorkflowSteps } from "./step-runner.ts";
 import {
+	createWorkspace,
 	ensureBranch,
-	ensureWorkspace,
 	pushBranch,
 	type RunShell,
 	removeWorkspace,
@@ -49,7 +49,12 @@ type RunLifecycleDeps = {
 	model: string;
 };
 
-type FailurePhase = "branch_resolver" | "setup" | "step" | FinalizeFailurePhase;
+type FailurePhase =
+	| "workspace"
+	| "branch_resolver"
+	| "setup"
+	| "step"
+	| FinalizeFailurePhase;
 
 type FinalizeOutcome =
 	| { ok: true }
@@ -78,7 +83,6 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 
 		const cloneUrl = codeHost.cloneUrl(repo);
 		const baseBranch = await codeHost.defaultBranch(repo);
-		const ws = await ensureWorkspace(issue, workspaceRoot, cloneUrl);
 
 		return runner.enqueue({
 			repo,
@@ -92,7 +96,6 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 						scope: "run",
 						run_id: ctx.runId,
 						issue_key: issue.key,
-						workspace_reused: !ws.created,
 					},
 					async () => {
 						const startTime = clock.now();
@@ -101,18 +104,39 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 						let outputs: Record<string, unknown> = {};
 						let phase: FailurePhase = "branch_resolver";
 
-						runRepo.setRunWorkspaceDir(ctx.runId, ws.path);
 						runRepo.insertSteps(
 							ctx.runId,
 							workflow.steps.map((s, i) => ({ index: i + 1, name: s.name })),
 						);
+
+						let wsPath: string;
+						try {
+							wsPath = await createWorkspace(
+								issue,
+								workspaceRoot,
+								cloneUrl,
+								ctx.runId,
+							);
+						} catch (err) {
+							const error = err instanceof Error ? err.message : String(err);
+							recordFailure("workspace", error);
+							canonicalLog.set({ status: "failed" });
+							if (!ctx.signal.aborted) await markIssueFailed(repo, issue);
+							return {
+								status: "failed",
+								error,
+								durationMs: clock.now() - startTime,
+							};
+						}
+
+						runRepo.setRunWorkspaceDir(ctx.runId, wsPath);
 						ctx.emit({
 							kind: "system",
 							stepName: null,
 							data: {
 								message: "workspace prepared",
 								command: null,
-								path: ws.path,
+								path: wsPath,
 								exitCode: null,
 							},
 						});
@@ -123,7 +147,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 								workflowBranch: workflow.branch,
 								issue,
 								agent,
-								cwd: ws.path,
+								cwd: wsPath,
 								model,
 								signal: ctx.signal,
 							});
@@ -145,8 +169,8 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 							});
 
 							phase = "setup";
-							await ensureBranch(ws.path, branch);
-							const repoSetupRan = await runRepoSetup(ws.path, runShell);
+							await ensureBranch(wsPath, branch);
+							const repoSetupRan = await runRepoSetup(wsPath, runShell);
 							canonicalLog.set({ repo_setup_ran: repoSetupRan });
 							if (repoSetupRan) {
 								ctx.emit({
@@ -155,7 +179,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 									data: {
 										message: "repo setup ran",
 										command: ".agent/setup.sh",
-										path: ws.path,
+										path: wsPath,
 										exitCode: 0,
 									},
 								});
@@ -170,7 +194,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 								issue,
 								branch,
 								baseBranch,
-								cwd: ws.path,
+								cwd: wsPath,
 								model,
 							});
 
@@ -194,7 +218,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 								repo,
 								issue,
 								workflow,
-								ws.path,
+								wsPath,
 								branch,
 								baseBranch,
 								outputs,
@@ -227,7 +251,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 						// Keep the workspace on any failure so the run can be inspected;
 						// only fully successful runs (agent + push + change-request) clean up.
 						if (result.status === "completed") {
-							await removeWorkspace(ws.path);
+							await removeWorkspace(wsPath);
 						} else if (!ctx.signal.aborted) {
 							await markIssueFailed(repo, issue);
 						}
@@ -308,7 +332,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 		phase: FinalizeFailurePhase,
 		err: unknown,
 	): FinalizeOutcome {
-		const error = err instanceof Error ? err.message : String(err);
+		const error = formatExecError(err);
 		recordFailure(phase, error);
 		return { ok: false, phase, error };
 	}
@@ -318,10 +342,24 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 			canonicalLog.append("warnings", {
 				kind: "mark_failed_failed",
 				issue: `${repo}#${issue.number}`,
-				error: err instanceof Error ? err.message : String(err),
+				error: formatExecError(err),
 			});
 		});
 	}
 
 	return { dispatch };
+}
+
+// Node's child_process errors keep the rich detail (stderr/stdout) on the error
+// object rather than in `err.message` — message is just "Command failed: …".
+// Surface stderr/stdout so failure diagnostics survive logging.
+function formatExecError(err: unknown): string {
+	if (!(err instanceof Error)) return String(err);
+	const e = err as Error & { stderr?: unknown; stdout?: unknown };
+	const stderr = typeof e.stderr === "string" ? e.stderr.trim() : "";
+	const stdout = typeof e.stdout === "string" ? e.stdout.trim() : "";
+	const parts = [e.message];
+	if (stderr) parts.push(`stderr:\n${stderr}`);
+	if (stdout) parts.push(`stdout:\n${stdout}`);
+	return parts.join("\n");
 }

--- a/server/orchestrator/workspace.test.ts
+++ b/server/orchestrator/workspace.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { access, chmod, mkdir, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -8,11 +8,12 @@ import { seedBareRepoMain } from "../test-support/test-workspace.ts";
 import type { Issue } from "../trackers/types.ts";
 import { issueKey, issueNumber, repoSlug } from "../types/brands.ts";
 import {
-	ensureWorkspace,
+	createWorkspace,
 	pushBranch,
 	realRunShell,
 	removeWorkspace,
 	runRepoSetup,
+	sweepWorkspaces,
 } from "./workspace.ts";
 
 const exec = promisify(execFile);
@@ -37,7 +38,7 @@ beforeAll(async () => {
 		tmpdir(),
 		`test-bare-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.git`,
 	);
-	// Seed the bare with an initial main commit so ensureWorkspace clones
+	// Seed the bare with an initial main commit so createWorkspace clones
 	// a repo where `git checkout main` works.
 	await seedBareRepoMain(bareRepo);
 });
@@ -59,17 +60,29 @@ async function createWorkspaceRoot() {
 	};
 }
 
-describe("ensureWorkspace", () => {
-	it("returns created: false when workspace already exists", async () => {
+describe("createWorkspace", () => {
+	it("creates a per-run directory named <issueKey>-<runId> with a fresh clone", async () => {
 		await using ws = await createWorkspaceRoot();
 		const issue = createIssue(1);
 
-		const first = await ensureWorkspace(issue, ws.root, bareRepo);
-		expect(first.created).toBe(true);
+		const path = await createWorkspace(issue, ws.root, bareRepo, "run-abc");
 
-		const second = await ensureWorkspace(issue, ws.root, bareRepo);
-		expect(second.created).toBe(false);
-		expect(second.path).toBe(first.path);
+		expect(path).toBe(join(ws.root, "test-owner_test-repo_1-run-abc"));
+		await expect(access(join(path, ".git"))).resolves.toBeUndefined();
+	});
+
+	it("creates a distinct directory per run so prior runs cannot be inherited", async () => {
+		await using ws = await createWorkspaceRoot();
+		const issue = createIssue(2);
+
+		const first = await createWorkspace(issue, ws.root, bareRepo, "run-1");
+		await writeFile(join(first, "leftover.txt"), "from prior run");
+
+		const second = await createWorkspace(issue, ws.root, bareRepo, "run-2");
+
+		expect(second).not.toBe(first);
+		await expect(access(join(second, "leftover.txt"))).rejects.toThrow();
+		await expect(access(join(first, "leftover.txt"))).resolves.toBeUndefined();
 	});
 });
 
@@ -77,7 +90,7 @@ describe("pushBranch", () => {
 	it("force-pushes the branch to origin so the remote tip matches local HEAD", async () => {
 		await using ws = await createWorkspaceRoot();
 		const issue = createIssue(7);
-		const { path: wsPath } = await ensureWorkspace(issue, ws.root, bareRepo);
+		const wsPath = await createWorkspace(issue, ws.root, bareRepo, "run-7");
 		await exec("git", ["config", "user.email", "test@example.test"], {
 			cwd: wsPath,
 		});
@@ -103,32 +116,33 @@ describe("pushBranch", () => {
 	it("overwrites a divergent branch on the remote (re-run reuses the branch name)", async () => {
 		await using ws = await createWorkspaceRoot();
 		const issue = createIssue(8);
-		const { path: wsPath } = await ensureWorkspace(issue, ws.root, bareRepo);
+		const firstPath = await createWorkspace(issue, ws.root, bareRepo, "run-a");
 		await exec("git", ["config", "user.email", "test@example.test"], {
-			cwd: wsPath,
+			cwd: firstPath,
 		});
-		await exec("git", ["config", "user.name", "Test"], { cwd: wsPath });
-
-		// First attempt's branch lands on the remote.
-		await exec("git", ["checkout", "-B", "agent/issue-8"], { cwd: wsPath });
+		await exec("git", ["config", "user.name", "Test"], { cwd: firstPath });
+		await exec("git", ["checkout", "-B", "agent/issue-8"], { cwd: firstPath });
 		await exec("git", ["commit", "--allow-empty", "-m", "first attempt"], {
-			cwd: wsPath,
+			cwd: firstPath,
 		});
-		await pushBranch(wsPath, "agent/issue-8");
+		await pushBranch(firstPath, "agent/issue-8");
 		const { stdout: firstSha } = await exec("git", ["rev-parse", "HEAD"], {
-			cwd: wsPath,
+			cwd: firstPath,
 		});
 
-		// Second attempt: a fresh workspace, branch reset from main, different commit.
-		await exec("git", ["checkout", "main"], { cwd: wsPath });
-		await exec("git", ["checkout", "-B", "agent/issue-8"], { cwd: wsPath });
-		await exec("git", ["commit", "--allow-empty", "-m", "second attempt"], {
-			cwd: wsPath,
+		const secondPath = await createWorkspace(issue, ws.root, bareRepo, "run-b");
+		await exec("git", ["config", "user.email", "test@example.test"], {
+			cwd: secondPath,
 		});
-		await pushBranch(wsPath, "agent/issue-8");
+		await exec("git", ["config", "user.name", "Test"], { cwd: secondPath });
+		await exec("git", ["checkout", "-B", "agent/issue-8"], { cwd: secondPath });
+		await exec("git", ["commit", "--allow-empty", "-m", "second attempt"], {
+			cwd: secondPath,
+		});
+		await pushBranch(secondPath, "agent/issue-8");
 
 		const { stdout: secondSha } = await exec("git", ["rev-parse", "HEAD"], {
-			cwd: wsPath,
+			cwd: secondPath,
 		});
 		const { stdout: remoteSha } = await exec(
 			"git",
@@ -142,13 +156,11 @@ describe("pushBranch", () => {
 	it("rejects when the remote is unreachable", async () => {
 		await using ws = await createWorkspaceRoot();
 		const issue = createIssue(9);
-		const { path: wsPath } = await ensureWorkspace(issue, ws.root, bareRepo);
+		const wsPath = await createWorkspace(issue, ws.root, bareRepo, "run-9");
 		await exec(
 			"git",
 			["remote", "set-url", "origin", "/nonexistent/path.git"],
-			{
-				cwd: wsPath,
-			},
+			{ cwd: wsPath },
 		);
 		await exec("git", ["checkout", "-B", "agent/issue-9"], { cwd: wsPath });
 
@@ -161,10 +173,43 @@ describe("removeWorkspace", () => {
 		await using ws = await createWorkspaceRoot();
 		const issue = createIssue(4);
 
-		const { path: wsPath } = await ensureWorkspace(issue, ws.root, bareRepo);
+		const wsPath = await createWorkspace(issue, ws.root, bareRepo, "run-4");
 
 		await removeWorkspace(wsPath);
 		await expect(access(wsPath)).rejects.toThrow();
+	});
+});
+
+describe("sweepWorkspaces", () => {
+	it("removes workspace directories older than the TTL and leaves recent ones", async () => {
+		await using ws = await createWorkspaceRoot();
+		await mkdir(ws.root, { recursive: true });
+
+		const stale = join(ws.root, "stale-run");
+		const fresh = join(ws.root, "fresh-run");
+		await mkdir(stale);
+		await mkdir(fresh);
+
+		const now = Date.now();
+		const eightDaysAgo = new Date(now - 8 * 24 * 60 * 60 * 1000);
+		await utimes(stale, eightDaysAgo, eightDaysAgo);
+
+		const result = await sweepWorkspaces(ws.root, 7 * 24 * 60 * 60 * 1000, now);
+
+		expect(result.removed).toEqual([stale]);
+		await expect(access(stale)).rejects.toThrow();
+		await expect(access(fresh)).resolves.toBeUndefined();
+	});
+
+	it("returns no removals when the workspace root does not yet exist", async () => {
+		const path = join(
+			tmpdir(),
+			`ws-missing-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+		);
+
+		const result = await sweepWorkspaces(path, 1000);
+
+		expect(result.removed).toEqual([]);
 	});
 });
 

--- a/server/orchestrator/workspace.ts
+++ b/server/orchestrator/workspace.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { access, mkdir, rm } from "node:fs/promises";
+import { access, mkdir, readdir, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import type { Issue } from "../trackers/types.ts";
@@ -16,23 +16,19 @@ export function sanitizeKey(key: string): string {
 	return key.replace(/[^A-Za-z0-9._-]/g, "_");
 }
 
-export async function ensureWorkspace(
+export async function createWorkspace(
 	issue: Issue,
 	workspaceRoot: string,
 	cloneUrl: string,
-): Promise<{ path: string; created: boolean }> {
-	const dirName = sanitizeKey(issue.key);
+	runId: string,
+): Promise<string> {
+	const dirName = `${sanitizeKey(issue.key)}-${runId}`;
 	const wsPath = join(workspaceRoot, dirName);
-
-	try {
-		await access(wsPath);
-		return { path: wsPath, created: false };
-	} catch {}
 
 	await mkdir(wsPath, { recursive: true });
 	await exec("git", ["clone", cloneUrl, "."], { cwd: wsPath });
 
-	return { path: wsPath, created: true };
+	return wsPath;
 }
 
 export async function ensureBranch(
@@ -60,6 +56,35 @@ export async function removeWorkspace(wsPath: string): Promise<void> {
 		maxRetries: 5,
 		retryDelay: 25,
 	});
+}
+
+// Delete workspace directories older than `maxAgeMs`. Workspaces are kept on
+// failure for forensics, so without a sweep they'd accumulate indefinitely.
+export async function sweepWorkspaces(
+	workspaceRoot: string,
+	maxAgeMs: number,
+	now: number = Date.now(),
+): Promise<{ removed: string[] }> {
+	let entries: string[];
+	try {
+		entries = await readdir(workspaceRoot);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+			return { removed: [] };
+		}
+		throw err;
+	}
+
+	const removed: string[] = [];
+	for (const entry of entries) {
+		const path = join(workspaceRoot, entry);
+		const info = await stat(path).catch(() => null);
+		if (!info?.isDirectory()) continue;
+		if (now - info.mtimeMs < maxAgeMs) continue;
+		await removeWorkspace(path);
+		removed.push(path);
+	}
+	return { removed };
 }
 
 const SETUP_SCRIPT_PATH = ".agent/setup.sh";

--- a/server/test-support/fixtures.ts
+++ b/server/test-support/fixtures.ts
@@ -9,11 +9,9 @@ import { repoSlug } from "../types/brands.ts";
 import type { RepoWorkflow } from "../workflow/workflow.ts";
 
 type QueryParams = Parameters<typeof query>[0];
-export type LegacyRunAgent = (
-	params: QueryParams,
-) => AsyncIterable<AgentMessage>;
+export type TestRunAgent = (params: QueryParams) => AsyncIterable<AgentMessage>;
 
-export function adaptRunAgent(runAgent: LegacyRunAgent): AgentInvoker {
+export function adaptRunAgent(runAgent: TestRunAgent): AgentInvoker {
 	return {
 		invoke({ prompt, cwd, model, resumeSessionId }: AgentInvokeOptions) {
 			return runAgent({

--- a/server/test-support/test-orchestrator.ts
+++ b/server/test-support/test-orchestrator.ts
@@ -7,9 +7,9 @@ import { createCodeHostStub } from "./code-host-stub.ts";
 import {
 	adaptRunAgent,
 	createTestWorkflow,
-	type LegacyRunAgent,
 	noopAgent,
 	REPO,
+	type TestRunAgent,
 } from "./fixtures.ts";
 import { createTestConfig } from "./test-config.ts";
 import { createTestDb } from "./test-db.ts";
@@ -18,7 +18,7 @@ import { createTestWorkspaceRoot } from "./test-workspace.ts";
 import { createTrackerStub } from "./tracker-stub.ts";
 
 type CreateTestOrchestratorOptions = {
-	runAgent?: LegacyRunAgent;
+	runAgent?: TestRunAgent;
 	agent?: AgentInvoker;
 	configOverrides?: Parameters<typeof createTestConfig>[0];
 	workflow?: RepoWorkflow;
@@ -38,6 +38,9 @@ export async function createTestOrchestrator(
 
 	const tracker = createTrackerStub();
 	const codeHost = createCodeHostStub();
+
+	const defaultBare = await workspace.setupRepoRemote(REPO);
+	codeHost.setCloneUrl(REPO, defaultBare);
 
 	const agent = options.agent ?? adaptRunAgent(options.runAgent ?? noopAgent);
 

--- a/server/test-support/test-workspace.ts
+++ b/server/test-support/test-workspace.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { sanitizeKey } from "../orchestrator/workspace.ts";
+import type { RepoSlug } from "../types/brands.ts";
 
 const exec = promisify(execFile);
 
@@ -22,19 +23,11 @@ export async function seedBareRepoMain(barePath: string): Promise<void> {
 	await rm(seedDir, { recursive: true, force: true });
 }
 
-// brokenRemote: point origin at a missing path so `git push` fails — used to
-// exercise the lifecycle's push-failure path without needing real network.
-type PreCreateOptions = {
-	brokenRemote?: boolean;
-};
-
 type TestWorkspace = {
 	root: string;
-	preCreateWorkspace(
-		issueKey: string,
-		options?: PreCreateOptions,
-	): Promise<string>;
-	bareRemotePath(issueKey: string): string;
+	/** Seed a bare remote for `repo` and return its on-disk path (the clone URL). */
+	setupRepoRemote(repo: RepoSlug): Promise<string>;
+	bareRemotePath(repo: RepoSlug): string;
 	[Symbol.asyncDispose](): Promise<void>;
 };
 
@@ -46,40 +39,22 @@ export async function createTestWorkspaceRoot(): Promise<TestWorkspace> {
 	const remotesRoot = join(root, "__remotes__");
 	await mkdir(remotesRoot, { recursive: true });
 
-	function bareRemotePath(issueKey: string): string {
-		return join(remotesRoot, `${sanitizeKey(issueKey)}.git`);
+	function bareRemotePath(repo: RepoSlug): string {
+		return join(remotesRoot, `${sanitizeKey(repo)}.git`);
 	}
+
+	const seeded = new Set<RepoSlug>();
 
 	return {
 		root,
 		bareRemotePath,
-		async preCreateWorkspace(
-			issueKey: string,
-			options: PreCreateOptions = {},
-		): Promise<string> {
-			const wsPath = join(root, sanitizeKey(issueKey));
-			await mkdir(wsPath, { recursive: true });
-
-			const bare = bareRemotePath(issueKey);
-			await exec("git", ["init", "--bare", "--initial-branch=main", bare]);
-
-			await exec("git", ["init", "--initial-branch=main"], { cwd: wsPath });
-			await exec("git", ["config", "user.email", "test@example.test"], {
-				cwd: wsPath,
-			});
-			await exec("git", ["config", "user.name", "Test"], { cwd: wsPath });
-			await exec("git", ["commit", "--allow-empty", "-m", "seed"], {
-				cwd: wsPath,
-			});
-
-			const remoteUrl = options.brokenRemote
-				? join(root, "__nonexistent__", `${sanitizeKey(issueKey)}.git`)
-				: bare;
-			await exec("git", ["remote", "add", "origin", remoteUrl], {
-				cwd: wsPath,
-			});
-
-			return wsPath;
+		async setupRepoRemote(repo: RepoSlug): Promise<string> {
+			const bare = bareRemotePath(repo);
+			if (!seeded.has(repo)) {
+				await seedBareRepoMain(bare);
+				seeded.add(repo);
+			}
+			return bare;
 		},
 		async [Symbol.asyncDispose]() {
 			// maxRetries tolerates a tail of git i/o from a killed agent's


### PR DESCRIPTION
## Summary

- **Per-run workspaces.** `createWorkspace` now produces `<issueKey>-<runId>` dirs inside the run handler, replacing the pre-seeded per-issue workspace. Failed runs are kept on disk for inspection without risk of a later run inheriting their state. A startup `sweepWorkspaces` deletes dirs older than 7 days.
- **Surface git stderr through finalizeFailure.** `formatExecError` extracts stderr/stdout from Node's `execFile` errors so push/clone failures now show the real diagnostic ("does not appear to be a git repository" / "Could not read from remote") instead of just "Command failed: …".
- **Test fixtures.** Replaced `preCreateWorkspace` with `setupRepoRemote` keyed by repo slug (default REPO seeded automatically in `createTestOrchestrator`). Renamed misleading `LegacyRunAgent` → `TestRunAgent` — it's an SDK-shaped test helper, not a legacy production path.
- **Dashboard.** Long failure text in the recent runs column gets ellipsis with a hover `title` so it doesn't overflow.
- **Cleanup.** Removed `bugs.md` (issues now resolved), eliminated `wsPath | undefined` plumbing in run-lifecycle by extracting the workspace-creation phase, stripped narration comments.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 272 tests pass
- [ ] Manually verify a failing push surfaces "Could not read from remote" via dashboard error tag
- [ ] Manually verify successful runs delete their workspace and failures keep theirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)