### PR TITLE
feat: cut tokens via SDK caching, sub-agents, and shell-block spill

### DIFF
--- a/server/orchestrator/agent-invoker.ts
+++ b/server/orchestrator/agent-invoker.ts
@@ -28,6 +28,7 @@ export const ALLOWED_TOOLS = [
 	"Bash",
 	"Glob",
 	"Grep",
+	"Task",
 ] as const;
 
 export function claudeSdkAgentInvoker(): AgentInvoker {
@@ -41,6 +42,12 @@ export function claudeSdkAgentInvoker(): AgentInvoker {
 					abortController: abortControllerFromSignal(signal),
 					allowedTools: [...ALLOWED_TOOLS],
 					permissionMode: "dontAsk" as const,
+					settingSources: ["project"],
+					systemPrompt: {
+						type: "preset",
+						preset: "claude_code",
+						excludeDynamicSections: true,
+					},
 					...(resumeSessionId && { resume: resumeSessionId }),
 					...(outputFormat && { outputFormat }),
 				},

--- a/server/orchestrator/step-runner.ts
+++ b/server/orchestrator/step-runner.ts
@@ -124,7 +124,10 @@ async function runWorkflowStep({
 			base_branch: baseBranch,
 			outputs,
 		});
-		const prompt = await expandMarkedShellBlocks(renderedPrompt, { cwd });
+		const prompt = await expandMarkedShellBlocks(renderedPrompt, {
+			cwd,
+			stepName: step.name,
+		});
 
 		const outputFormat: OutputFormat | undefined = step.output_schema
 			? { type: "json_schema", schema: step.output_schema }

--- a/server/workflow/prompt-preprocessor.test.ts
+++ b/server/workflow/prompt-preprocessor.test.ts
@@ -1,4 +1,4 @@
-import { access, realpath } from "node:fs/promises";
+import { access, readFile, realpath } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { createTestWorkspaceRoot } from "../test-support/test-workspace.ts";
@@ -8,6 +8,7 @@ import {
 	expandMarkedShellBlocks,
 	markTrustedShellBlocks,
 	SHELL_BLOCK_MARKER,
+	SHELL_BLOCK_SPILL_DIR,
 } from "./prompt-preprocessor.ts";
 import { renderPrompt } from "./workflow.ts";
 
@@ -158,7 +159,7 @@ describe("shell block preprocessing", () => {
 
 		await expect(
 			expandMarkedShellBlocks(marked, { cwd: workspace.root }),
-		).rejects.toThrow(/exceeded max output/);
+		).rejects.toThrow(/exceeded hard output ceiling/);
 	});
 
 	it("fails when shell stderr exceeds the buffer cap", async () => {
@@ -170,7 +171,35 @@ describe("shell block preprocessing", () => {
 
 		await expect(
 			expandMarkedShellBlocks(marked, { cwd: workspace.root }),
-		).rejects.toThrow(/exceeded max output/);
+		).rejects.toThrow(/exceeded hard output ceiling/);
+	});
+
+	it("spills oversized output to disk and inlines a head + tail preview", async () => {
+		await using workspace = await createTestWorkspaceRoot();
+
+		const marked = markTrustedShellBlocks(
+			"!`yes hello | head -c 80000; printf END`",
+		);
+
+		const result = await expandMarkedShellBlocks(marked, {
+			cwd: workspace.root,
+			stepName: "review",
+		});
+
+		const spillPath = join(
+			workspace.root,
+			SHELL_BLOCK_SPILL_DIR,
+			"review-1.txt",
+		);
+		const spillContents = await readFile(spillPath, "utf8");
+
+		expect(spillContents.length).toBe(80003);
+		expect(spillContents.endsWith("END")).toBe(true);
+		expect(result).toMatch(
+			/\.\.\. \[truncated \d+ bytes; full output at \.agent\/shell-outputs\/review-1\.txt\] \.\.\./,
+		);
+		expect(result.endsWith("END")).toBe(true);
+		expect(result.length).toBeLessThan(spillContents.length);
 	});
 
 	it("keeps literal unmarked shell-looking text in the final prompt", async () => {

--- a/server/workflow/prompt-preprocessor.ts
+++ b/server/workflow/prompt-preprocessor.ts
@@ -1,10 +1,18 @@
 import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
-export const SHELL_BLOCK_MARKER = "\uE000";
+export const SHELL_BLOCK_MARKER = "";
+
+const SHELL_BLOCK_SOFT_CAP_BYTES = 64 * 1024;
+const SHELL_BLOCK_HARD_CEILING_BYTES = 1024 * 1024;
+const SHELL_BLOCK_PREVIEW_BYTES = 2 * 1024;
+export const SHELL_BLOCK_SPILL_DIR = join(".agent", "shell-outputs");
 
 type ExpandShellBlocksOptions = {
 	cwd: string;
 	timeoutMs?: number;
+	stepName?: string;
 };
 
 export function stripShellBlockMarkers(value: string): string {
@@ -30,7 +38,11 @@ export async function expandMarkedShellBlocks(
 	if (commands.length === 0) return prompt;
 
 	const outputs = await Promise.all(
-		commands.map((command) => runShellBlock(command, options)),
+		commands.map((command, index) =>
+			runShellBlock(command, index, options).then((rawOutput) =>
+				maybeSpillOversizedOutput(rawOutput, index, options),
+			),
+		),
 	);
 
 	let i = 0;
@@ -38,13 +50,13 @@ export async function expandMarkedShellBlocks(
 }
 
 const SHELL_EXPANSION_TIMEOUT_MS = 30_000;
-const SHELL_EXPANSION_MAX_BUFFER = 1024 * 1024;
 
 const unmarkedShellBlockPattern = /!`([^`]*)`/g;
-const markedShellBlockPattern = /!\uE000`([^`]*)`/g;
+const markedShellBlockPattern = /!`([^`]*)`/g;
 
 async function runShellBlock(
 	command: string,
+	_index: number,
 	{ cwd, timeoutMs = SHELL_EXPANSION_TIMEOUT_MS }: ExpandShellBlocksOptions,
 ): Promise<string> {
 	return new Promise((resolve, reject) => {
@@ -77,12 +89,12 @@ async function runShellBlock(
 		childStdout.setEncoding("utf8");
 		childStdout.on("data", (chunk: string) => {
 			stdout += chunk;
-			if (stdout.length + stderr.length > SHELL_EXPANSION_MAX_BUFFER) {
+			if (stdout.length + stderr.length > SHELL_BLOCK_HARD_CEILING_BYTES) {
 				fail(
 					new Error(
 						formatShellFailure(
 							command,
-							`exceeded max output of ${SHELL_EXPANSION_MAX_BUFFER} bytes`,
+							`exceeded hard output ceiling of ${SHELL_BLOCK_HARD_CEILING_BYTES} bytes`,
 							stderr,
 						),
 					),
@@ -93,12 +105,12 @@ async function runShellBlock(
 		childStderr.setEncoding("utf8");
 		childStderr.on("data", (chunk: string) => {
 			stderr += chunk;
-			if (stdout.length + stderr.length > SHELL_EXPANSION_MAX_BUFFER) {
+			if (stdout.length + stderr.length > SHELL_BLOCK_HARD_CEILING_BYTES) {
 				fail(
 					new Error(
 						formatShellFailure(
 							command,
-							`exceeded max output of ${SHELL_EXPANSION_MAX_BUFFER} bytes`,
+							`exceeded hard output ceiling of ${SHELL_BLOCK_HARD_CEILING_BYTES} bytes`,
 							stderr,
 						),
 					),
@@ -127,6 +139,54 @@ async function runShellBlock(
 			reject(new Error(formatShellFailure(command, reason, stderr)));
 		});
 	});
+}
+
+async function maybeSpillOversizedOutput(
+	output: string,
+	index: number,
+	{ cwd, stepName }: ExpandShellBlocksOptions,
+): Promise<string> {
+	if (Buffer.byteLength(output, "utf8") <= SHELL_BLOCK_SOFT_CAP_BYTES) {
+		return output;
+	}
+
+	const filename = `${stepName ?? "shell"}-${index + 1}.txt`;
+	const relPath = join(SHELL_BLOCK_SPILL_DIR, filename);
+	const absPath = join(cwd, relPath);
+
+	await mkdir(dirname(absPath), { recursive: true });
+	await writeFile(absPath, output, "utf8");
+
+	const head = takeUtf8Prefix(output, SHELL_BLOCK_PREVIEW_BYTES);
+	const tail = takeUtf8Suffix(output, SHELL_BLOCK_PREVIEW_BYTES);
+	const totalBytes = Buffer.byteLength(output, "utf8");
+	const omittedBytes =
+		totalBytes -
+		Buffer.byteLength(head, "utf8") -
+		Buffer.byteLength(tail, "utf8");
+
+	return [
+		head,
+		`\n... [truncated ${omittedBytes} bytes; full output at ${relPath}] ...\n`,
+		tail,
+	].join("");
+}
+
+function takeUtf8Prefix(value: string, maxBytes: number): string {
+	const buffer = Buffer.from(value, "utf8");
+	if (buffer.byteLength <= maxBytes) return value;
+	let end = maxBytes;
+	while (end > 0 && (buffer[end] & 0xc0) === 0x80) end -= 1;
+	return buffer.subarray(0, end).toString("utf8");
+}
+
+function takeUtf8Suffix(value: string, maxBytes: number): string {
+	const buffer = Buffer.from(value, "utf8");
+	if (buffer.byteLength <= maxBytes) return value;
+	let start = buffer.byteLength - maxBytes;
+	while (start < buffer.byteLength && (buffer[start] & 0xc0) === 0x80)
+		start += 1;
+	return buffer.subarray(start).toString("utf8");
 }
 
 function formatSpawnError(command: string, err: Error): Error {

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -45,19 +45,17 @@ steps:
       {{ issue.description }}
       </issue>
 
-      <repo_layout>
-      !`ls -1`
-      </repo_layout>
-
       <recent_commits>
       !`git log -n 10 --oneline`
       </recent_commits>
 
       # Approach
 
-      1. **Orient.** Read what this repo provides for orientation — agent
-         instructions, READMEs, contributing/standards docs, ADRs. Follow
-         what they say about conventions, testing, docs, and commits.
+      1. **Orient until you can predict the change.** Use what's already
+         in your context first. Pull in READMEs, ADRs, or surrounding
+         code only until you have enough confidence to make the change
+         correctly. Stop reading when you can name the files you'll
+         touch and the approach you'll take.
 
       2. **Investigate before editing.** Locate the existing
          implementation and tests for the area you'll change. Read the
@@ -69,9 +67,8 @@ steps:
          defensive checks, or configurability only when the issue calls
          for them.
 
-      4. **Verify with the project's checks** before committing.
-         Discover the commands from the repo. Run independent commands
-         in parallel.
+      4. **Verify with the project's checks** before committing. Discover 
+        the commands from the repo.
 
       # Stopping
 
@@ -108,9 +105,11 @@ steps:
 
       # Approach
 
-      1. **Orient.** Read what this repo provides for orientation — agent
-         instructions, READMEs, contributing/standards docs, ADRs. Review
-         against the project's conventions, not generic best practice.
+      1. **Orient until you can judge the change.** Use what's already
+         in your context first. Pull in conventions docs, ADRs, or
+         surrounding code only until you have enough confidence to tell
+         whether the diff fits the project. Stop reading when you can
+         defend a verdict.
 
       2. **Read changed files in their surrounding context.** The diff
          shows what changed; read the surrounding code to judge whether
@@ -144,6 +143,7 @@ steps:
       If the branch needs no changes, make none.
 
   - name: summarise
+    model: claude-haiku-4-5
     prompt: |
       <task>
       Write a reviewer-facing summary of the change on branch


### PR DESCRIPTION
## Summary

Implements the standalone cost-cutting items from [docs/cost-and-complexity-design.md](docs/cost-and-complexity-design.md), without the profile/complexity-label/scoper machinery from that doc.

- **SDK caching across runs.** `agent-invoker.ts` now pins `settingSources: ['project']` and sets `systemPrompt: { type: 'preset', preset: 'claude_code', excludeDynamicSections: true }`. The SDK pulls per-run cwd, memory paths, and git status out of the system prompt and re-injects them as the first user message, so the cacheable prefix (preset + project CLAUDE.md + tools) is byte-identical across runs of the same repo. Within a run, every step shares that prefix too.
- **Sub-agent delegation.** `Task` is now in `ALLOWED_TOOLS`. Exploration work can land in sub-agent contexts instead of bloating the parent.
- **Toned-down orient instructions.** `implement` and `review` no longer prescribe reading READMEs/ADRs/contributing docs as a checklist — they orient until they have enough confidence to act, then stop.
- **Dropped `<repo_layout>` shell block.** The Claude Code preset already supplies layout context.
- **Per-step model routing.** `summarise` runs on Haiku — it's prose-only.
- **Shell-block soft cap.** Outputs over 64 KB spill to `.agent/shell-outputs/<step>-<n>.txt` with a head/tail preview and the spill path inlined. 1 MB remains the hard ceiling.

Profile machinery (complexity labels, scope→implement two-pass, deep/standard/trivial tiers) is **not** in this PR.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm test` — 273/273 pass
- [x] New test in `prompt-preprocessor.test.ts` covers the soft-cap spill behaviour
- [ ] Run a real issue through the orchestrator and confirm cache-read tokens dominate on step 2+ (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)