### PR TITLE
feat: per-step allowed_tools and SDK hooks feeding canonical log

### DIFF
--- a/server/orchestrator/agent-hooks.ts
+++ b/server/orchestrator/agent-hooks.ts
@@ -1,0 +1,47 @@
+import type {
+	HookCallbackMatcher,
+	HookEvent,
+	HookInput,
+} from "@anthropic-ai/claude-agent-sdk";
+import * as canonicalLog from "../canonical-log.ts";
+
+export function buildCanonicalLogHooks(): Partial<
+	Record<HookEvent, HookCallbackMatcher[]>
+> {
+	return {
+		PostToolUse: [{ hooks: [safe(record)] }],
+		PostToolUseFailure: [{ hooks: [safe(record)] }],
+	};
+}
+
+function record(input: HookInput): void {
+	if (input.hook_event_name === "PostToolUse") {
+		addToolDuration(input.tool_name, input.duration_ms);
+		return;
+	}
+	if (input.hook_event_name === "PostToolUseFailure") {
+		canonicalLog.incrementMap("tool_failures_by_name", input.tool_name);
+		// Fold failure wall-time into the same map as successes so the per-tool
+		// total reflects all time spent in that tool, not just successful calls.
+		addToolDuration(input.tool_name, input.duration_ms);
+	}
+}
+
+function addToolDuration(toolName: string, durationMs: unknown): void {
+	if (typeof durationMs !== "number" || durationMs <= 0) return;
+	canonicalLog.incrementMap("tool_duration_ms_by_name", toolName, durationMs);
+}
+
+function safe(fn: (input: HookInput) => void) {
+	return async (input: HookInput) => {
+		try {
+			fn(input);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			console.warn(
+				`canonical-log hook (${input.hook_event_name}) failed: ${message}`,
+			);
+		}
+		return {};
+	};
+}

--- a/server/orchestrator/agent-invoker.ts
+++ b/server/orchestrator/agent-invoker.ts
@@ -1,4 +1,5 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
+import { buildCanonicalLogHooks } from "./agent-hooks.ts";
 
 export type AgentMessage =
 	ReturnType<typeof query> extends AsyncGenerator<infer T> ? T : never;
@@ -15,13 +16,14 @@ export type AgentInvokeOptions = {
 	resumeSessionId?: string;
 	signal: AbortSignal;
 	outputFormat?: OutputFormat;
+	allowedTools?: readonly string[];
 };
 
 export type AgentInvoker = {
 	invoke(opts: AgentInvokeOptions): AsyncIterable<AgentMessage>;
 };
 
-export const ALLOWED_TOOLS = [
+export const DEFAULT_ALLOWED_TOOLS = [
 	"Read",
 	"Write",
 	"Edit",
@@ -33,14 +35,22 @@ export const ALLOWED_TOOLS = [
 
 export function claudeSdkAgentInvoker(): AgentInvoker {
 	return {
-		invoke({ prompt, cwd, model, resumeSessionId, outputFormat, signal }) {
+		invoke({
+			prompt,
+			cwd,
+			model,
+			resumeSessionId,
+			outputFormat,
+			signal,
+			allowedTools,
+		}) {
 			return query({
 				prompt,
 				options: {
 					cwd,
 					model,
 					abortController: abortControllerFromSignal(signal),
-					allowedTools: [...ALLOWED_TOOLS],
+					allowedTools: [...(allowedTools ?? DEFAULT_ALLOWED_TOOLS)],
 					permissionMode: "dontAsk" as const,
 					settingSources: ["project"],
 					systemPrompt: {
@@ -48,6 +58,7 @@ export function claudeSdkAgentInvoker(): AgentInvoker {
 						preset: "claude_code",
 						excludeDynamicSections: true,
 					},
+					hooks: buildCanonicalLogHooks(),
 					...(resumeSessionId && { resume: resumeSessionId }),
 					...(outputFormat && { outputFormat }),
 				},

--- a/server/orchestrator/step-runner.test.ts
+++ b/server/orchestrator/step-runner.test.ts
@@ -707,6 +707,44 @@ describe("runWorkflowSteps", () => {
 		);
 	});
 
+	it("forwards a step's allowed_tools to the agent when present", async () => {
+		const recorder = createCtx();
+		const agent = createAgent(() => yieldAssistant("sess"));
+		const workflow: RepoWorkflow = {
+			branch: "b",
+			steps: [
+				{
+					name: "summarise",
+					prompt: "summarise",
+					resume_previous: false,
+					model: "claude-haiku-4-5",
+					allowed_tools: ["Read", "Glob", "Grep"],
+				},
+				{
+					name: "implement",
+					prompt: "do it",
+					resume_previous: false,
+					model: "claude-sonnet-4-6",
+				},
+			],
+			change_request: baseChangeRequest,
+		};
+
+		await runWorkflowSteps({
+			ctx: recorder.ctx,
+			runRepo: recorder.runRepo,
+			agent,
+			workflow,
+			issue,
+			cwd: "/work",
+			branch: "agent/issue-1",
+			baseBranch: "main",
+		});
+
+		expect(agent.calls[0]?.allowedTools).toEqual(["Read", "Glob", "Grep"]);
+		expect(agent.calls[1]?.allowedTools).toBeUndefined();
+	});
+
 	it("passes each step's declared model to the agent", async () => {
 		const recorder = createCtx();
 		const agent = createAgent(() => yieldAssistant("sess"));

--- a/server/orchestrator/step-runner.ts
+++ b/server/orchestrator/step-runner.ts
@@ -138,6 +138,7 @@ async function runWorkflowStep({
 			signal: ctx.signal,
 			...(resumeSessionId && { resumeSessionId }),
 			...(outputFormat && { outputFormat }),
+			...(step.allowed_tools && { allowedTools: step.allowed_tools }),
 		})) {
 			if (msg.type === "assistant") {
 				emitAgentMessageEvents(msg, { ctx, stepName: step.name, cwd });

--- a/server/test-support/fixtures.ts
+++ b/server/test-support/fixtures.ts
@@ -3,7 +3,7 @@ import {
 	type AgentInvokeOptions,
 	type AgentInvoker,
 	type AgentMessage,
-	ALLOWED_TOOLS,
+	DEFAULT_ALLOWED_TOOLS,
 } from "../orchestrator/agent-invoker.ts";
 import { repoSlug } from "../types/brands.ts";
 import type { RepoWorkflow } from "../workflow/workflow.ts";
@@ -19,7 +19,7 @@ export function adaptRunAgent(runAgent: TestRunAgent): AgentInvoker {
 				options: {
 					cwd,
 					model,
-					allowedTools: [...ALLOWED_TOOLS],
+					allowedTools: [...DEFAULT_ALLOWED_TOOLS],
 					permissionMode: "dontAsk" as const,
 					...(resumeSessionId && { resume: resumeSessionId }),
 				},

--- a/server/workflow/workflow.test.ts
+++ b/server/workflow/workflow.test.ts
@@ -306,6 +306,42 @@ ${validChangeRequest}`;
 		]);
 	});
 
+	it("accepts a step with an allowed_tools list", () => {
+		const yaml = `
+branch: my-branch
+steps:
+  - name: summarise
+    prompt: Summarise the issue
+    model: claude-haiku-4-5
+    allowed_tools: [Read, Glob, Grep]
+${validChangeRequest}`;
+
+		const result = parseRepoWorkflow(yaml);
+
+		expect(result.steps).toEqual([
+			{
+				name: "summarise",
+				prompt: "Summarise the issue",
+				resume_previous: false,
+				model: "claude-haiku-4-5",
+				allowed_tools: ["Read", "Glob", "Grep"],
+			},
+		]);
+	});
+
+	it("rejects a step with an empty allowed_tools list", () => {
+		const yaml = `
+branch: my-branch
+steps:
+  - name: summarise
+    prompt: Summarise
+    model: claude-haiku-4-5
+    allowed_tools: []
+${validChangeRequest}`;
+
+		expect(() => parseRepoWorkflow(yaml)).toThrow();
+	});
+
 	it("rejects a step missing model", () => {
 		const yaml = `
 branch: my-branch

--- a/server/workflow/workflow.ts
+++ b/server/workflow/workflow.ts
@@ -18,6 +18,7 @@ const workflowStepSchema = z
 		resume_previous: z.boolean().optional().default(false),
 		output_schema: jsonSchemaDocument.optional(),
 		model: modelIdSchema,
+		allowed_tools: z.array(z.string().min(1)).min(1).optional(),
 	})
 	.strict();
 

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -142,6 +142,7 @@ steps:
 
   - name: summarise
     model: claude-haiku-4-5
+    allowed_tools: [Read, Glob, Grep]
     prompt: |
       <task>
       Write a reviewer-facing summary of the change on branch


### PR DESCRIPTION
## Summary

- Each workflow step can now declare its own `allowed_tools`; absent means the default whitelist (`Read/Write/Edit/Bash/Glob/Grep/Task`). `summarise` is locked to `[Read, Glob, Grep]` since it only emits structured JSON.
- Wires the SDK's `PostToolUse` / `PostToolUseFailure` hooks into the run's canonical log, adding two new bag fields:
  - `tool_duration_ms_by_name` — per-tool wall-time, e.g. `{ Bash: 67340, Read: 412 }`
  - `tool_failures_by_name` — only present when something failed, e.g. `{ Bash: 2 }`
- Hooks warn-and-continue on error so instrumentation can't crash a run.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (276/276)
- [ ] Run an end-to-end agent run and confirm the new fields appear in the canonical log line
- [ ] Confirm `summarise` step still completes with the restricted tool set

🤖 Generated with [Claude Code](https://claude.com/claude-code)