### PR TITLE
feat: configurable env passthrough to agent and repo setup

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -54,6 +54,26 @@ ${validJiraTracker}${validGitLabCodeHost}${fullDefaults}`);
 
 		expect(config.code_host.scopes).toEqual(["group/project"]);
 		expect(config.defaults.workspace_root).toBe("/tmp/workspaces");
+		expect(config.agent.env).toEqual({ include: [], set: {} });
+	});
+
+	it("accepts agent env allowlist configuration", () => {
+		using configFile = writeConfig(`
+${validJiraTracker}${validGitLabCodeHost}${fullDefaults}agent:
+  env:
+    include:
+      - PATH
+      - GITLAB_PACKAGES_TOKEN
+    set:
+      CI: "true"
+`);
+
+		const config = loadConfig(configFile.path);
+
+		expect(config.agent.env).toEqual({
+			include: ["PATH", "GITLAB_PACKAGES_TOKEN"],
+			set: { CI: "true" },
+		});
 	});
 
 	it("accepts gitlab code host with configured base URL", () => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -46,6 +46,18 @@ const configSchema = z
 				workspace_root: z.string().min(1),
 			})
 			.strict(),
+		agent: z
+			.object({
+				env: z
+					.object({
+						include: z.array(z.string().min(1)).default([]),
+						set: z.record(z.string(), z.string()).default({}),
+					})
+					.strict()
+					.default({ include: [], set: {} }),
+			})
+			.strict()
+			.default({ env: { include: [], set: {} } }),
 	})
 	.strict();
 

--- a/server/orchestrator/agent-env.test.ts
+++ b/server/orchestrator/agent-env.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { resolveAgentEnvironment } from "./agent-env.ts";
+
+describe("resolveAgentEnvironment", () => {
+	it("copies only included source variables and applies set values", () => {
+		const env = resolveAgentEnvironment(
+			{
+				include: ["PATH", "GITLAB_PACKAGES_TOKEN", "MISSING"],
+				set: {
+					CI: "true",
+					GITLAB_PACKAGES_TOKEN: "override",
+				},
+			},
+			{
+				PATH: "/usr/bin",
+				GITLAB_PACKAGES_TOKEN: "source-token",
+				AWS_SESSION_TOKEN: "do-not-copy",
+			},
+		);
+
+		expect(env).toEqual({
+			PATH: "/usr/bin",
+			CI: "true",
+			GITLAB_PACKAGES_TOKEN: "override",
+		});
+	});
+});

--- a/server/orchestrator/agent-env.ts
+++ b/server/orchestrator/agent-env.ts
@@ -1,0 +1,21 @@
+import type { Config } from "../config.ts";
+
+type AgentEnvConfig = Config["agent"]["env"];
+
+export function resolveAgentEnvironment(
+	config: AgentEnvConfig,
+	sourceEnv: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+	const env: Record<string, string> = {};
+
+	for (const key of config.include) {
+		const value = sourceEnv[key];
+		if (value !== undefined) env[key] = value;
+	}
+
+	for (const [key, value] of Object.entries(config.set)) {
+		env[key] = value;
+	}
+
+	return env;
+}

--- a/server/orchestrator/agent-invoker.ts
+++ b/server/orchestrator/agent-invoker.ts
@@ -33,7 +33,9 @@ export const DEFAULT_ALLOWED_TOOLS = [
 	"Task",
 ] as const;
 
-export function claudeSdkAgentInvoker(): AgentInvoker {
+export function claudeSdkAgentInvoker(
+	env: Record<string, string>,
+): AgentInvoker {
 	return {
 		invoke({
 			prompt,
@@ -49,6 +51,7 @@ export function claudeSdkAgentInvoker(): AgentInvoker {
 				options: {
 					cwd,
 					model,
+					env,
 					abortController: abortControllerFromSignal(signal),
 					allowedTools: [...(allowedTools ?? DEFAULT_ALLOWED_TOOLS)],
 					permissionMode: "dontAsk" as const,

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -7,6 +7,7 @@ import type { Runner } from "../runner/runner.ts";
 import type { Issue, TrackerAdapter } from "../trackers/types.ts";
 import type { IssueKey } from "../types/brands.ts";
 import type { RepoWorkflow } from "../workflow/workflow.ts";
+import { resolveAgentEnvironment } from "./agent-env.ts";
 import { type AgentInvoker, claudeSdkAgentInvoker } from "./agent-invoker.ts";
 import { type Clock, systemClock } from "./clock.ts";
 import { createRunLifecycle } from "./run-lifecycle.ts";
@@ -75,11 +76,12 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		workflow,
 		runner,
 		logger,
-		agent = claudeSdkAgentInvoker(),
 		clock = systemClock(),
 		runShell = realRunShell,
 	} = opts;
 	const { defaults } = config;
+	const agentEnv = resolveAgentEnvironment(config.agent.env);
+	const agent = opts.agent ?? claudeSdkAgentInvoker(agentEnv);
 
 	function logTransitionFailed(
 		repo: Issue["repo"],
@@ -107,6 +109,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		runShell,
 		logger,
 		workspaceRoot: defaults.workspace_root,
+		agentEnv,
 	});
 
 	function trackPostRun(done: Promise<unknown>): void {

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -46,6 +46,7 @@ type RunLifecycleDeps = {
 	runShell: RunShell;
 	logger: Logger;
 	workspaceRoot: string;
+	agentEnv: Record<string, string>;
 };
 
 type FailurePhase =
@@ -74,6 +75,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 		runShell,
 		logger,
 		workspaceRoot,
+		agentEnv,
 	} = deps;
 
 	async function dispatch(req: RunRequest): Promise<RunHandle> {
@@ -167,7 +169,11 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 
 							phase = "setup";
 							await ensureBranch(wsPath, branch);
-							const repoSetupRan = await runRepoSetup(wsPath, runShell);
+							const repoSetupRan = await runRepoSetup(
+								wsPath,
+								runShell,
+								agentEnv,
+							);
 							canonicalLog.set({ repo_setup_ran: repoSetupRan });
 							if (repoSetupRan) {
 								ctx.emit({

--- a/server/orchestrator/workspace.test.ts
+++ b/server/orchestrator/workspace.test.ts
@@ -242,12 +242,23 @@ describe("runRepoSetup", () => {
 		await using ws = await withWorkspace();
 		await writeSetupScript(ws.path, "#!/usr/bin/env bash\necho hi\n");
 
-		const calls: { script: string; cwd: string }[] = [];
-		await runRepoSetup(ws.path, async (script, cwd) => {
-			calls.push({ script, cwd });
-		});
+		const calls: {
+			script: string;
+			cwd: string;
+			env: Record<string, string>;
+		}[] = [];
+		const env = { PATH: "/bin", TOKEN: "secret" };
+		await runRepoSetup(
+			ws.path,
+			async (script, cwd, passedEnv) => {
+				calls.push({ script, cwd, env: passedEnv });
+			},
+			env,
+		);
 
-		expect(calls).toEqual([{ script: "bash .agent/setup.sh", cwd: ws.path }]);
+		expect(calls).toEqual([
+			{ script: "bash .agent/setup.sh", cwd: ws.path, env },
+		]);
 	});
 
 	it("realRunShell executes the script in the workspace and a non-zero exit rejects", async () => {
@@ -257,24 +268,30 @@ describe("runRepoSetup", () => {
 			"#!/usr/bin/env bash\necho ok > setup_output\n",
 		);
 
-		await runRepoSetup(ws.path, realRunShell);
+		const realEnv = { PATH: process.env["PATH"] ?? "" };
+		await runRepoSetup(ws.path, realRunShell, realEnv);
 
 		await expect(
 			access(join(ws.path, "setup_output")),
 		).resolves.toBeUndefined();
 
-		// Non-zero exit propagates as a rejection from realRunShell.
 		await writeSetupScript(ws.path, "#!/usr/bin/env bash\nexit 1\n");
-		await expect(runRepoSetup(ws.path, realRunShell)).rejects.toThrow();
+		await expect(
+			runRepoSetup(ws.path, realRunShell, realEnv),
+		).rejects.toThrow();
 	});
 
 	it("is a no-op when the script is absent", async () => {
 		await using ws = await withWorkspace();
 		const calls: { script: string; cwd: string }[] = [];
 
-		await runRepoSetup(ws.path, async (script, cwd) => {
-			calls.push({ script, cwd });
-		});
+		await runRepoSetup(
+			ws.path,
+			async (script, cwd) => {
+				calls.push({ script, cwd });
+			},
+			{},
+		);
 
 		expect(calls).toEqual([]);
 	});
@@ -284,9 +301,13 @@ describe("runRepoSetup", () => {
 		await writeSetupScript(ws.path, "#!/usr/bin/env bash\nexit 1\n");
 
 		await expect(
-			runRepoSetup(ws.path, async () => {
-				throw new Error("setup.sh exit 1");
-			}),
+			runRepoSetup(
+				ws.path,
+				async () => {
+					throw new Error("setup.sh exit 1");
+				},
+				{},
+			),
 		).rejects.toThrow(/setup.sh exit 1/);
 	});
 });

--- a/server/orchestrator/workspace.ts
+++ b/server/orchestrator/workspace.ts
@@ -6,10 +6,14 @@ import type { Issue } from "../trackers/types.ts";
 
 const exec = promisify(execFile);
 
-export type RunShell = (script: string, cwd: string) => Promise<void>;
+export type RunShell = (
+	script: string,
+	cwd: string,
+	env: Record<string, string>,
+) => Promise<void>;
 
-export const realRunShell: RunShell = async (script, cwd) => {
-	await exec("sh", ["-c", script], { cwd });
+export const realRunShell: RunShell = async (script, cwd, env) => {
+	await exec("sh", ["-c", script], { cwd, env });
 };
 
 export function sanitizeKey(key: string): string {
@@ -92,6 +96,7 @@ const SETUP_SCRIPT_PATH = ".agent/setup.sh";
 export async function runRepoSetup(
 	wsPath: string,
 	runShell: RunShell,
+	env: Record<string, string>,
 ): Promise<boolean> {
 	const scriptPath = join(wsPath, SETUP_SCRIPT_PATH);
 	try {
@@ -100,6 +105,6 @@ export async function runRepoSetup(
 		return false;
 	}
 
-	await runShell(`bash ${SETUP_SCRIPT_PATH}`, wsPath);
+	await runShell(`bash ${SETUP_SCRIPT_PATH}`, wsPath, env);
 	return true;
 }

--- a/server/test-support/test-config.ts
+++ b/server/test-support/test-config.ts
@@ -30,5 +30,11 @@ export function createTestConfig(
 			workspace_root: "/tmp/test-workspaces",
 			...overrides,
 		},
+		agent: {
+			env: {
+				include: [],
+				set: {},
+			},
+		},
 	};
 }


### PR DESCRIPTION
## Summary

- New `agent.env` config block with `include` (allow-list of env vars copied from the orchestrator process) and `set` (literal overrides).
- `resolveAgentEnvironment` helper wires that into both the Claude SDK invoker (`query({ env })`) and the repo setup script (`runRepoSetup`).
- Unblocks runs that need private registries — e.g. the GitLab npm registry behind a TLS-inspecting corporate proxy — by forwarding `GITLAB_PACKAGES_TOKEN` and the `NODE_EXTRA_CA_CERTS` / `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE` family.

Note: `config.yaml` itself is intentionally **not** part of this PR — operators set their own include list locally.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (278/278)
- [ ] Re-run a real issue end-to-end (e.g. COOR-157) and confirm `npm install` against the GitLab registry succeeds from inside the agent's Bash tool
- [ ] Confirm `repo setup ran` event still fires and `.agent/setup.sh` has the expected env

🤖 Generated with [Claude Code](https://claude.com/claude-code)