### PR TITLE
feat: per-run agent tool-call log files

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,19 +1,38 @@
 tracker:
   kind: jira
-  base_url: https://nhollas.atlassian.net/
-  project: KAN
+  base_url: https://comparethemarket.atlassian.net/
+  project: COOR
   trigger_label: local-agents
   statuses:
-    pending: "To Do"
+    pending: "Ready for Development"
     running: "In Progress"
     awaiting_review: "In Review"
 
 code_host:
-  kind: github
+  kind: gitlab
+  base_url: https://gitlab.com/
   scopes:
-    - Nhollas
+    - comparethemarket
 
 defaults:
   polling_interval_ms: 30000
   max_concurrent: 2
   workspace_root: /tmp/local-agent-workspaces
+
+agent:
+  env:
+    include:
+      - HOME
+      - PATH
+      - SHELL
+      - TMPDIR
+      - USER
+      - LOGNAME
+      - LANG
+      - GITLAB_PACKAGES_TOKEN
+      - NODE_EXTRA_CA_CERTS
+      - SSL_CERT_FILE
+      - REQUESTS_CA_BUNDLE
+      - CURL_CA_BUNDLE
+    set:
+      CI: "true"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,7 @@ Operational settings shared across all runs.
 | `max_concurrent`       | integer | Maximum number of runs in flight at once across all repos. |
 | `model`                | string  | Default Claude model ID for steps. Steps may override this individually. |
 | `workspace_root`       | string  | Filesystem path where per-issue workspaces are created. |
+| `log_dir`              | string  | Directory for per-run agent tool-call logs (`<log_dir>/<run-id>.log`). Resolved relative to the orchestrator's working directory. Defaults to `./logs`. |
 
 ### Environment
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -44,6 +44,7 @@ const configSchema = z
 				polling_interval_ms: z.number().int().positive(),
 				max_concurrent: z.number().int().positive(),
 				workspace_root: z.string().min(1),
+				log_dir: z.string().min(1).default("./logs"),
 			})
 			.strict(),
 		agent: z

--- a/server/orchestrator/agent-hooks.ts
+++ b/server/orchestrator/agent-hooks.ts
@@ -1,16 +1,24 @@
 import type {
+	HookCallback,
 	HookCallbackMatcher,
 	HookEvent,
 	HookInput,
 } from "@anthropic-ai/claude-agent-sdk";
 import * as canonicalLog from "../canonical-log.ts";
+import type { RunLogWriter } from "./run-log-file.ts";
 
-export function buildCanonicalLogHooks(): Partial<
-	Record<HookEvent, HookCallbackMatcher[]>
-> {
+export function buildAgentHooks(
+	runLogWriter?: RunLogWriter,
+): Partial<Record<HookEvent, HookCallbackMatcher[]>> {
+	const postToolUse: HookCallback[] = [safe(record)];
+	const postToolUseFailure: HookCallback[] = [safe(record)];
+	if (runLogWriter) {
+		postToolUse.push(safe(writeRunLog(runLogWriter)));
+		postToolUseFailure.push(safe(writeRunLog(runLogWriter)));
+	}
 	return {
-		PostToolUse: [{ hooks: [safe(record)] }],
-		PostToolUseFailure: [{ hooks: [safe(record)] }],
+		PostToolUse: [{ hooks: postToolUse }],
+		PostToolUseFailure: [{ hooks: postToolUseFailure }],
 	};
 }
 
@@ -27,20 +35,49 @@ function record(input: HookInput): void {
 	}
 }
 
+function writeRunLog(writer: RunLogWriter) {
+	return async (input: HookInput): Promise<void> => {
+		const timestamp = new Date().toISOString();
+		if (input.hook_event_name === "PostToolUse") {
+			await writer.append({
+				timestamp,
+				toolName: input.tool_name,
+				status: "ok",
+				toolInput: input.tool_input,
+				toolResponse: input.tool_response,
+				...(typeof input.duration_ms === "number" && {
+					durationMs: input.duration_ms,
+				}),
+			});
+			return;
+		}
+		if (input.hook_event_name === "PostToolUseFailure") {
+			await writer.append({
+				timestamp,
+				toolName: input.tool_name,
+				status: "failed",
+				toolInput: input.tool_input,
+				error: input.error,
+				...(typeof input.duration_ms === "number" && {
+					durationMs: input.duration_ms,
+				}),
+			});
+		}
+	};
+}
+
 function addToolDuration(toolName: string, durationMs: unknown): void {
 	if (typeof durationMs !== "number" || durationMs <= 0) return;
 	canonicalLog.incrementMap("tool_duration_ms_by_name", toolName, durationMs);
 }
 
-function safe(fn: (input: HookInput) => void) {
-	return async (input: HookInput) => {
+function safe(fn: (input: HookInput) => void | Promise<void>): HookCallback {
+	return async (input) => {
 		try {
-			fn(input);
+			await fn(input);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
-			console.warn(
-				`canonical-log hook (${input.hook_event_name}) failed: ${message}`,
-			);
+			console.warn(`agent hook (${input.hook_event_name}) failed: ${message}`);
 		}
 		return {};
 	};

--- a/server/orchestrator/agent-invoker.ts
+++ b/server/orchestrator/agent-invoker.ts
@@ -1,5 +1,7 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
-import { buildCanonicalLogHooks } from "./agent-hooks.ts";
+import type { RunId } from "../types/brands.ts";
+import { buildAgentHooks } from "./agent-hooks.ts";
+import { createRunLogWriter } from "./run-log-file.ts";
 
 export type AgentMessage =
 	ReturnType<typeof query> extends AsyncGenerator<infer T> ? T : never;
@@ -13,6 +15,7 @@ export type AgentInvokeOptions = {
 	prompt: string;
 	cwd: string;
 	model: string;
+	runId: RunId;
 	resumeSessionId?: string;
 	signal: AbortSignal;
 	outputFormat?: OutputFormat;
@@ -33,19 +36,25 @@ export const DEFAULT_ALLOWED_TOOLS = [
 	"Task",
 ] as const;
 
-export function claudeSdkAgentInvoker(
-	env: Record<string, string>,
-): AgentInvoker {
+export function claudeSdkAgentInvoker({
+	env,
+	logDir,
+}: {
+	env: Record<string, string>;
+	logDir: string;
+}): AgentInvoker {
 	return {
 		invoke({
 			prompt,
 			cwd,
 			model,
+			runId,
 			resumeSessionId,
 			outputFormat,
 			signal,
 			allowedTools,
 		}) {
+			const runLogWriter = createRunLogWriter(logDir, runId);
 			return query({
 				prompt,
 				options: {
@@ -61,7 +70,7 @@ export function claudeSdkAgentInvoker(
 						preset: "claude_code",
 						excludeDynamicSections: true,
 					},
-					hooks: buildCanonicalLogHooks(),
+					hooks: buildAgentHooks(runLogWriter),
 					...(resumeSessionId && { resume: resumeSessionId }),
 					...(outputFormat && { outputFormat }),
 				},

--- a/server/orchestrator/branch-resolver.test.ts
+++ b/server/orchestrator/branch-resolver.test.ts
@@ -5,7 +5,7 @@ import {
 	buildSuccessResult,
 } from "../test-support/agent-messages.ts";
 import type { Issue } from "../trackers/types.ts";
-import { issueKey, issueNumber, repoSlug } from "../types/brands.ts";
+import { issueKey, issueNumber, repoSlug, runId } from "../types/brands.ts";
 import type {
 	AgentInvokeOptions,
 	AgentInvoker,
@@ -53,6 +53,7 @@ describe("resolveBranch", () => {
 			issue,
 			agent,
 			cwd: "/work",
+			runId: runId("test-run"),
 			signal: new AbortController().signal,
 		});
 
@@ -78,6 +79,7 @@ describe("resolveBranch", () => {
 			issue,
 			agent,
 			cwd: "/work",
+			runId: runId("test-run"),
 			signal: new AbortController().signal,
 		});
 
@@ -113,6 +115,7 @@ describe("resolveBranch", () => {
 				issue,
 				agent,
 				cwd: "/work",
+				runId: runId("test-run"),
 				signal: new AbortController().signal,
 			}),
 		).rejects.toThrow(/no `name` field/);
@@ -135,6 +138,7 @@ describe("resolveBranch", () => {
 				issue,
 				agent,
 				cwd: "/work",
+				runId: runId("test-run"),
 				signal: new AbortController().signal,
 			}),
 		).rejects.toThrow(/stream ended without a result message/);
@@ -159,6 +163,7 @@ describe("resolveBranch", () => {
 				issue,
 				agent,
 				cwd: "/work",
+				runId: runId("test-run"),
 				signal: new AbortController().signal,
 			}),
 		).rejects.toThrow(/error_max_structured_output_retries/);

--- a/server/orchestrator/branch-resolver.ts
+++ b/server/orchestrator/branch-resolver.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { Issue } from "../trackers/types.ts";
+import type { RunId } from "../types/brands.ts";
 import type { WorkflowBranch } from "../workflow/workflow.ts";
 import { renderPrompt } from "../workflow/workflow.ts";
 import type { AgentInvoker, OutputFormat } from "./agent-invoker.ts";
@@ -13,6 +14,7 @@ type ResolveBranchParams = {
 	issue: Issue;
 	agent: AgentInvoker;
 	cwd: string;
+	runId: RunId;
 	signal: AbortSignal;
 };
 
@@ -21,6 +23,7 @@ export async function resolveBranch({
 	issue,
 	agent,
 	cwd,
+	runId,
 	signal,
 }: ResolveBranchParams): Promise<string> {
 	if (typeof workflowBranch === "string") {
@@ -37,6 +40,7 @@ export async function resolveBranch({
 		prompt,
 		cwd,
 		model: workflowBranch.model,
+		runId,
 		signal,
 		outputFormat,
 	})) {

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -1,3 +1,4 @@
+import { resolve as resolvePath } from "node:path";
 import * as canonicalLog from "../canonical-log.ts";
 import type { CodeHostAdapter } from "../code-hosts/types.ts";
 import type { Config } from "../config.ts";
@@ -81,7 +82,8 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 	} = opts;
 	const { defaults } = config;
 	const agentEnv = resolveAgentEnvironment(config.agent.env);
-	const agent = opts.agent ?? claudeSdkAgentInvoker(agentEnv);
+	const logDir = resolvePath(process.cwd(), defaults.log_dir);
+	const agent = opts.agent ?? claudeSdkAgentInvoker({ env: agentEnv, logDir });
 
 	function logTransitionFailed(
 		repo: Issue["repo"],

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -148,6 +148,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 								issue,
 								agent,
 								cwd: wsPath,
+								runId: ctx.runId,
 								signal: ctx.signal,
 							});
 							canonicalLog.set({

--- a/server/orchestrator/run-log-file.test.ts
+++ b/server/orchestrator/run-log-file.test.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runId } from "../types/brands.ts";
+import { createRunLogWriter } from "./run-log-file.ts";
+
+describe("createRunLogWriter", () => {
+	let logDir: string;
+
+	beforeEach(() => {
+		logDir = mkdtempSync(join(tmpdir(), "local-agents-runlog-"));
+	});
+
+	afterEach(() => {
+		rmSync(logDir, { recursive: true, force: true });
+	});
+
+	it("appends a formatted block for a successful tool call", async () => {
+		const writer = createRunLogWriter(logDir, runId("run-abc"));
+
+		await writer.append({
+			timestamp: "2026-05-12T10:00:00.000Z",
+			toolName: "Bash",
+			durationMs: 1500,
+			status: "ok",
+			toolInput: { command: "echo hi" },
+			toolResponse: "hi\n",
+		});
+
+		const contents = readFileSync(join(logDir, "run-abc.log"), "utf8");
+		expect(contents).toContain("[2026-05-12T10:00:00.000Z] Bash");
+		expect(contents).toContain("status=ok");
+		expect(contents).toContain("duration=2s");
+		expect(contents).toContain('"command": "echo hi"');
+		expect(contents).toContain("hi\n");
+	});
+
+	it("renders a failed block with an error section", async () => {
+		const writer = createRunLogWriter(logDir, runId("run-fail"));
+
+		await writer.append({
+			timestamp: "2026-05-12T10:00:01.000Z",
+			toolName: "Bash",
+			durationMs: 500,
+			status: "failed",
+			toolInput: { command: "false" },
+			error: "exit code 1",
+		});
+
+		const contents = readFileSync(join(logDir, "run-fail.log"), "utf8");
+		expect(contents).toContain("status=failed");
+		expect(contents).toContain("duration=500ms");
+		expect(contents).toContain("error:\nexit code 1");
+	});
+
+	it("appends multiple blocks in order across concurrent calls", async () => {
+		const writer = createRunLogWriter(logDir, runId("run-order"));
+
+		const a = writer.append({
+			timestamp: "2026-05-12T10:00:00.000Z",
+			toolName: "Read",
+			status: "ok",
+			toolInput: { file_path: "/a" },
+			toolResponse: "A",
+		});
+		const b = writer.append({
+			timestamp: "2026-05-12T10:00:01.000Z",
+			toolName: "Read",
+			status: "ok",
+			toolInput: { file_path: "/b" },
+			toolResponse: "B",
+		});
+		await Promise.all([a, b]);
+
+		const contents = readFileSync(join(logDir, "run-order.log"), "utf8");
+		const aIndex = contents.indexOf("/a");
+		const bIndex = contents.indexOf("/b");
+		expect(aIndex).toBeGreaterThan(-1);
+		expect(bIndex).toBeGreaterThan(aIndex);
+	});
+});

--- a/server/orchestrator/run-log-file.ts
+++ b/server/orchestrator/run-log-file.ts
@@ -1,0 +1,77 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { RunId } from "../types/brands.ts";
+
+export type ToolBlock = {
+	timestamp: string;
+	toolName: string;
+	durationMs?: number;
+	toolInput: unknown;
+	toolResponse?: unknown;
+	error?: string;
+	status: "ok" | "failed";
+};
+
+export type RunLogWriter = {
+	append(block: ToolBlock): Promise<void>;
+};
+
+export function createRunLogWriter(logDir: string, id: RunId): RunLogWriter {
+	const filePath = join(logDir, `${id}.log`);
+	const ready = mkdir(logDir, { recursive: true }).then(() => {});
+	let chain: Promise<void> = ready;
+	return {
+		append(block) {
+			const next = chain.then(() =>
+				appendFile(filePath, formatBlock(block), "utf8"),
+			);
+			chain = next.catch(() => {});
+			return next;
+		},
+	};
+}
+
+function formatBlock(block: ToolBlock): string {
+	const meta = [
+		`status=${block.status}`,
+		block.durationMs !== undefined
+			? `duration=${formatDuration(block.durationMs)}`
+			: undefined,
+	].filter((p): p is string => p !== undefined);
+	const sections = [
+		`─── [${block.timestamp}] ${block.toolName} · ${meta.join(" · ")} ───`,
+		`input:\n${formatValue(block.toolInput)}`,
+	];
+	if (block.status === "failed") {
+		sections.push(`error:\n${block.error ?? "(no error message)"}`);
+		if (block.toolResponse !== undefined) {
+			sections.push(`response:\n${formatValue(block.toolResponse)}`);
+		}
+	} else {
+		sections.push(`response:\n${formatValue(block.toolResponse)}`);
+	}
+	return `${sections.join("\n")}\n\n`;
+}
+
+function formatValue(value: unknown): string {
+	if (value === undefined) return "(no value)";
+	if (value === null) return "null";
+	if (typeof value === "string") return value;
+	if (typeof value === "number" || typeof value === "boolean") {
+		return String(value);
+	}
+	try {
+		return JSON.stringify(value, null, 2);
+	} catch {
+		return String(value);
+	}
+}
+
+function formatDuration(ms: number): string {
+	if (ms < 1000) return `${ms}ms`;
+	const totalSeconds = Math.round(ms / 1000);
+	if (totalSeconds < 60) return `${totalSeconds}s`;
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	return seconds === 0 ? `${minutes}m` : `${minutes}m${seconds}s`;
+}

--- a/server/orchestrator/step-runner.ts
+++ b/server/orchestrator/step-runner.ts
@@ -135,6 +135,7 @@ async function runWorkflowStep({
 			prompt,
 			cwd,
 			model,
+			runId: ctx.runId,
 			signal: ctx.signal,
 			...(resumeSessionId && { resumeSessionId }),
 			...(outputFormat && { outputFormat }),

--- a/server/test-support/test-config.ts
+++ b/server/test-support/test-config.ts
@@ -28,6 +28,7 @@ export function createTestConfig(
 			polling_interval_ms: 100,
 			max_concurrent: 2,
 			workspace_root: "/tmp/test-workspaces",
+			log_dir: "/tmp/test-logs",
 			...overrides,
 		},
 		agent: {


### PR DESCRIPTION
## What

Adds per-run log files that capture every agent tool call (input, response or error, duration) to `<log_dir>/<run-id>.log`. `log_dir` is a new `defaults` config key (defaults to `./logs`).

- New `RunLogWriter` (`server/orchestrator/run-log-file.ts`) — serialises appends via a promise chain, creates the log directory once at writer construction, and survives individual append failures without poisoning the queue.
- `buildAgentHooks` (renamed from `buildCanonicalLogHooks`) wires the writer into `PostToolUse` and `PostToolUseFailure` alongside the existing canonical-log recorder.
- `claudeSdkAgentInvoker` now takes `{ env, logDir }` and creates a writer per invocation, keyed by `RunId`.
- `resolveBranch` and `step-runner` thread `runId` through to the invoker.

## Why

We had no per-run record of what tools the agent ran or what they returned, which makes post-hoc debugging of a run painful. Canonical-log captures durations but not tool I/O. This gives a human-readable file per run for inspection.

## How to test

- [x] `pnpm typecheck`
- [x] `pnpm test` (281 passed, including new `run-log-file.test.ts` covering formatting, failure rendering, and concurrent-append ordering)
- [ ] Manual: start a run and confirm `./logs/<run-id>.log` is created and populated with tool blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)