### PR TITLE
feat: activate target repo's .nvmrc via fnm, refine PR title format

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ cp .env.example .env
 cp config.example.yaml config.yaml
 ```
 
+Install [`fnm`](https://github.com/Schniz/fnm) and make sure it is available on `PATH`. local-agents uses it to activate target repositories' `.nvmrc` versions before running repo setup and agent steps.
+
 Fill in `JIRA_EMAIL`, `JIRA_API_TOKEN`, and either `GITHUB_TOKEN` or `GITLAB_TOKEN` to match the configured code host.
 
 The Agent SDK uses your existing Claude Code login automatically. Make sure you're logged into Claude Code with an active subscription.
@@ -58,6 +60,7 @@ The dashboard shows all agent runs in real-time:
 
 - Node.js >= 22.6.0
 - pnpm
+- fnm
 - Claude Code (logged in with active subscription)
 - `JIRA_EMAIL` and `JIRA_API_TOKEN`
 - `GITHUB_TOKEN` or `GITLAB_TOKEN`, depending on the configured code host

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -299,3 +299,5 @@ pnpm codegen
 ```
 
 If the script is missing, that step is skipped silently. If it exists and fails, the run fails before any step runs.
+
+For Node.js repos, the orchestrator treats `.nvmrc` as the repo's runtime declaration. When a cloned workspace contains `.nvmrc`, local-agents activates that version with `fnm`, then uses the resulting environment for repo setup, trusted prompt shell blocks, and agent steps. Repos written in other languages keep the configured agent environment unchanged and should express their toolchain needs in their own setup script.

--- a/server/orchestrator/agent-invoker.ts
+++ b/server/orchestrator/agent-invoker.ts
@@ -16,6 +16,7 @@ export type AgentInvokeOptions = {
 	cwd: string;
 	model: string;
 	runId: RunId;
+	env?: Record<string, string>;
 	resumeSessionId?: string;
 	signal: AbortSignal;
 	outputFormat?: OutputFormat;
@@ -49,6 +50,7 @@ export function claudeSdkAgentInvoker({
 			cwd,
 			model,
 			runId,
+			env: invocationEnv,
 			resumeSessionId,
 			outputFormat,
 			signal,
@@ -60,7 +62,7 @@ export function claudeSdkAgentInvoker({
 				options: {
 					cwd,
 					model,
-					env,
+					env: invocationEnv ?? env,
 					abortController: abortControllerFromSignal(signal),
 					allowedTools: [...(allowedTools ?? DEFAULT_ALLOWED_TOOLS)],
 					permissionMode: "dontAsk" as const,

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -23,6 +23,7 @@ import {
 	pushBranch,
 	type RunShell,
 	removeWorkspace,
+	resolveWorkspaceEnvironment,
 	runRepoSetup,
 } from "./workspace.ts";
 
@@ -170,10 +171,14 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 
 							phase = "setup";
 							await ensureBranch(wsPath, branch);
+							const workspaceEnv = await resolveWorkspaceEnvironment(
+								wsPath,
+								agentEnv,
+							);
 							const repoSetupRan = await runRepoSetup(
 								wsPath,
 								runShell,
-								agentEnv,
+								workspaceEnv,
 							);
 							canonicalLog.set({ repo_setup_ran: repoSetupRan });
 							if (repoSetupRan) {
@@ -199,6 +204,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 								branch,
 								baseBranch,
 								cwd: wsPath,
+								env: workspaceEnv,
 							});
 
 							result = {

--- a/server/orchestrator/step-runner.test.ts
+++ b/server/orchestrator/step-runner.test.ts
@@ -175,6 +175,38 @@ describe("runWorkflowSteps", () => {
 		expect(outputs).toEqual({});
 	});
 
+	it("passes the workspace environment to the agent", async () => {
+		const recorder = createCtx();
+		const agent = createAgent(() => yieldAssistant("sess"));
+		const env = { PATH: "/node-24/bin:/usr/bin", TOKEN: "secret" };
+		const workflow: RepoWorkflow = {
+			branch: "b",
+			steps: [
+				{
+					name: "implement",
+					prompt: "do it",
+					resume_previous: false,
+					model: "claude-sonnet-4-6",
+				},
+			],
+			change_request: baseChangeRequest,
+		};
+
+		await runWorkflowSteps({
+			ctx: recorder.ctx,
+			runRepo: recorder.runRepo,
+			agent,
+			workflow,
+			issue,
+			cwd: "/work",
+			branch: "agent/issue-1",
+			baseBranch: "main",
+			env,
+		});
+
+		expect(agent.calls[0]?.env).toEqual(env);
+	});
+
 	it("passes outputFormat, persists structured_output, and returns outputs", async () => {
 		const recorder = createCtx();
 		const structured = { title: "Hello", tags: ["a"] };

--- a/server/orchestrator/step-runner.ts
+++ b/server/orchestrator/step-runner.ts
@@ -26,6 +26,7 @@ type RunWorkflowStepsParams = {
 	branch: string;
 	baseBranch: string;
 	cwd: string;
+	env?: Record<string, string>;
 };
 
 export async function runWorkflowSteps({
@@ -37,6 +38,7 @@ export async function runWorkflowSteps({
 	branch,
 	baseBranch,
 	cwd,
+	env = {},
 }: RunWorkflowStepsParams): Promise<Record<string, unknown>> {
 	const { steps } = workflow;
 	const outputs: Record<string, unknown> = {};
@@ -60,6 +62,7 @@ export async function runWorkflowSteps({
 			branch,
 			baseBranch,
 			cwd,
+			env,
 			model: step.model,
 			...(stepResumeSessionId && { resumeSessionId: stepResumeSessionId }),
 		});
@@ -82,6 +85,7 @@ type RunWorkflowStepParams = {
 	branch: string;
 	baseBranch: string;
 	cwd: string;
+	env: Record<string, string>;
 	model: string;
 	resumeSessionId?: string;
 };
@@ -98,6 +102,7 @@ async function runWorkflowStep({
 	branch,
 	baseBranch,
 	cwd,
+	env,
 	model,
 	resumeSessionId,
 }: RunWorkflowStepParams): Promise<string | undefined> {
@@ -125,6 +130,7 @@ async function runWorkflowStep({
 		const prompt = await expandMarkedShellBlocks(renderedPrompt, {
 			cwd,
 			stepName: step.name,
+			env,
 		});
 
 		const outputFormat: OutputFormat | undefined = step.output_schema
@@ -137,6 +143,7 @@ async function runWorkflowStep({
 			model,
 			runId: ctx.runId,
 			signal: ctx.signal,
+			env,
 			...(resumeSessionId && { resumeSessionId }),
 			...(outputFormat && { outputFormat }),
 			...(step.allowed_tools && { allowedTools: step.allowed_tools }),

--- a/server/orchestrator/workspace.test.ts
+++ b/server/orchestrator/workspace.test.ts
@@ -12,6 +12,7 @@ import {
 	pushBranch,
 	realRunShell,
 	removeWorkspace,
+	resolveWorkspaceEnvironment,
 	runRepoSetup,
 	sweepWorkspaces,
 } from "./workspace.ts";
@@ -309,5 +310,62 @@ describe("runRepoSetup", () => {
 				{},
 			),
 		).rejects.toThrow(/setup.sh exit 1/);
+	});
+});
+
+describe("resolveWorkspaceEnvironment", () => {
+	it("returns the base env unchanged when the repo has no .nvmrc", async () => {
+		await using ws = await withWorkspace();
+		const baseEnv = { PATH: "/bin", TOKEN: "secret" };
+
+		const resolved = await resolveWorkspaceEnvironment(ws.path, baseEnv);
+
+		expect(resolved).toBe(baseEnv);
+	});
+
+	it("activates the .nvmrc version with fnm when available", async () => {
+		await using ws = await withWorkspace();
+		const fakeToolBin = join(ws.path, "tools", "bin");
+		const fakeNodeBin = join(ws.path, "node", "bin");
+		await mkdir(fakeToolBin, { recursive: true });
+		await mkdir(fakeNodeBin, { recursive: true });
+		await writeFile(join(ws.path, ".nvmrc"), "24.10.0\n");
+		const fnmPath = join(fakeToolBin, "fnm");
+		await writeFile(
+			fnmPath,
+			[
+				"#!/usr/bin/env bash",
+				'if [ "$1" = "env" ]; then',
+				"  cat <<'FNM_ENV'",
+				"fnm() {",
+				'  if [ "$1" = "use" ]; then',
+				`    export PATH="${fakeNodeBin}:$PATH"`,
+				"  fi",
+				"}",
+				"FNM_ENV",
+				"  exit 0",
+				"fi",
+				"exit 1",
+				"",
+			].join("\n"),
+		);
+		await chmod(fnmPath, 0o755);
+
+		const resolved = await resolveWorkspaceEnvironment(ws.path, {
+			PATH: `${fakeToolBin}:${process.env["PATH"] ?? ""}`,
+			TOKEN: "secret",
+		});
+
+		expect(resolved["PATH"]?.split(":")[0]).toBe(fakeNodeBin);
+		expect(resolved["TOKEN"]).toBe("secret");
+	});
+
+	it("fails clearly when .nvmrc is present but fnm is unavailable", async () => {
+		await using ws = await withWorkspace();
+		await writeFile(join(ws.path, ".nvmrc"), "24.10.0\n");
+
+		await expect(
+			resolveWorkspaceEnvironment(ws.path, { PATH: "/bin" }),
+		).rejects.toThrow(/fnm is not available on PATH/);
 	});
 });

--- a/server/orchestrator/workspace.ts
+++ b/server/orchestrator/workspace.ts
@@ -16,8 +16,56 @@ export const realRunShell: RunShell = async (script, cwd, env) => {
 	await exec("sh", ["-c", script], { cwd, env });
 };
 
+const ACTIVATE_NODE_VERSION_SCRIPT = `
+if [ -f .nvmrc ]; then
+  node_version="$(tr -d '[:space:]' < .nvmrc)"
+
+  if ! command -v fnm >/dev/null 2>&1; then
+    echo "Target repo declares .nvmrc but fnm is not available on PATH. Install fnm before running local-agents." >&2
+    exit 1
+  fi
+
+  eval "$(fnm env --shell bash)"
+  fnm use --install-if-missing "$node_version" >/dev/null
+fi
+
+env -0
+`.trim();
+
+export async function resolveWorkspaceEnvironment(
+	wsPath: string,
+	baseEnv: Record<string, string>,
+): Promise<Record<string, string>> {
+	const nvmrcPath = join(wsPath, ".nvmrc");
+	try {
+		await access(nvmrcPath);
+	} catch {
+		return baseEnv;
+	}
+
+	const { stdout } = await exec("bash", ["-c", ACTIVATE_NODE_VERSION_SCRIPT], {
+		cwd: wsPath,
+		env: baseEnv,
+	});
+
+	return parseNullDelimitedEnv(stdout);
+}
+
 export function sanitizeKey(key: string): string {
 	return key.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function parseNullDelimitedEnv(stdout: string): Record<string, string> {
+	const env: Record<string, string> = {};
+
+	for (const entry of stdout.split("\0")) {
+		if (entry === "") continue;
+		const equalsIndex = entry.indexOf("=");
+		if (equalsIndex <= 0) continue;
+		env[entry.slice(0, equalsIndex)] = entry.slice(equalsIndex + 1);
+	}
+
+	return env;
 }
 
 export async function createWorkspace(

--- a/server/workflow/prompt-preprocessor.test.ts
+++ b/server/workflow/prompt-preprocessor.test.ts
@@ -62,6 +62,18 @@ describe("shell block preprocessing", () => {
 		expect(result).toBe("one\ntwo");
 	});
 
+	it("runs marked shell blocks with the provided environment", async () => {
+		await using workspace = await createTestWorkspaceRoot();
+
+		const marked = markTrustedShellBlocks('!`printf "$TOOLCHAIN_BIN"`');
+		const result = await expandMarkedShellBlocks(marked, {
+			cwd: workspace.root,
+			env: { PATH: process.env["PATH"] ?? "", TOOLCHAIN_BIN: "node-24" },
+		});
+
+		expect(result).toBe("node-24");
+	});
+
 	it("does not execute shell-looking text injected through issue fields", async () => {
 		await using workspace = await createTestWorkspaceRoot();
 		const issue: Issue = {

--- a/server/workflow/prompt-preprocessor.ts
+++ b/server/workflow/prompt-preprocessor.ts
@@ -11,6 +11,7 @@ export const SHELL_BLOCK_SPILL_DIR = join(".agent", "shell-outputs");
 
 type ExpandShellBlocksOptions = {
 	cwd: string;
+	env?: Record<string, string>;
 	timeoutMs?: number;
 	stepName?: string;
 };
@@ -57,11 +58,16 @@ const markedShellBlockPattern = /!`([^`]*)`/g;
 async function runShellBlock(
 	command: string,
 	_index: number,
-	{ cwd, timeoutMs = SHELL_EXPANSION_TIMEOUT_MS }: ExpandShellBlocksOptions,
+	{
+		cwd,
+		env,
+		timeoutMs = SHELL_EXPANSION_TIMEOUT_MS,
+	}: ExpandShellBlocksOptions,
 ): Promise<string> {
 	return new Promise((resolve, reject) => {
 		const child = spawn("sh", ["-c", command], {
 			cwd,
+			env,
 			stdio: ["ignore", "pipe", "pipe"],
 		});
 		const { stdout: childStdout, stderr: childStderr } = child;

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -15,15 +15,15 @@ branch:
     - `type`: one of `feat`, `fix`, `chore`, `docs`, `refactor`, `test`. Pick
       what best matches the work — `feat` for new behaviour, `fix` for bugs,
       `refactor` for non-behavioural restructuring, etc.
-    - `issue-key`: tracker key verbatim (e.g. `AINENG-2310`).
+    - `issue-key`: tracker key verbatim (e.g. `AIENG-2310`).
     - `short-desc`: kebab-case 2-5 word summary. Lowercase letters, digits,
       and hyphens only.
     </format>
 
     <examples>
-    - `feat/AINENG-2310-state-clear-command`
-    - `fix/AINENG-1180-token-refresh-race`
-    - `refactor/AINENG-905-extract-run-lifecycle`
+    - `feat/AIENG-2310-state-clear-command`
+    - `fix/AIENG-1180-token-refresh-race`
+    - `refactor/AIENG-905-extract-run-lifecycle`
     </examples>
   schema:
     type: object
@@ -159,8 +159,9 @@ steps:
 
       Produce:
 
-      - `title`: one line, under 70 characters, written as a Conventional
-        Commit-style summary (e.g. `feat: add state clear command`).
+      - `type`: one of `feat`, `fix`, `chore`, `docs`, `refactor`, `test`.
+      - `description`: one line, written as an imperative title-cased summary
+        without a trailing period (e.g. `Add state clear command`).
       - `body`: short markdown for the human reviewing the change request.
         Lead with the user-visible change and why, then implementation
         notes worth a reviewer's attention. Skip the commit-by-commit
@@ -168,12 +169,15 @@ steps:
     output_schema:
       type: object
       properties:
-        title: { type: string }
+        type:
+          type: string
+          enum: [feat, fix, chore, docs, refactor, test]
+        description: { type: string }
         body: { type: string }
-      required: [title, body]
+      required: [type, description, body]
 
 change_request:
-  title: "{{ steps.summarise.output.title }}"
+  title: "{{ steps.summarise.output.type }}: {{ issue.key }} - {{ steps.summarise.output.description }}"
   body: |
     Closes {{ issue.key }}: {{ issue.title }}.
 


### PR DESCRIPTION
## Summary
- Resolve the workspace's Node toolchain from the cloned repo's `.nvmrc` using `fnm`, then thread the resulting environment through repo setup, trusted prompt shell blocks, and every agent step. Repos without `.nvmrc` keep the configured agent env unchanged.
- New `resolveWorkspaceEnvironment` helper in `server/orchestrator/workspace.ts` plus tests covering the no-`.nvmrc`, fnm-available, and fnm-missing paths.
- README + `docs/configuration.md` updated to call out the `fnm` requirement and how the activation flow works.
- `workflow.yaml` tweaks: structured PR title (`type: ISSUE-KEY - description`) via a new `output_schema`, and fix `AINENG` -> `AIENG` in the branch-naming examples.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (286/286)
- [ ] Manual: run against a repo with `.nvmrc` and confirm `node --version` inside an agent step matches the file.
- [ ] Manual: run against a repo without `.nvmrc` and confirm behaviour is unchanged.
- [ ] Manual: temporarily remove `fnm` from `PATH` against a repo with `.nvmrc` and confirm the clear failure message surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)