### PR TITLE
feat: dashboard sticky side panels, scroll shadow, and run-selection highlight

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -38,7 +38,7 @@ export function App() {
 				<section className="center">
 					<CenterContent runId={runId} />
 				</section>
-				<RecentRunsColumn onSelectRun={navigate} />
+				<RecentRunsColumn activeRunId={runId} onSelectRun={navigate} />
 			</main>
 		</>
 	);

--- a/dashboard/src/components/recent-runs-column.tsx
+++ b/dashboard/src/components/recent-runs-column.tsx
@@ -9,10 +9,12 @@ import {
 import type { Run, RunPr } from "../lib/types.ts";
 
 type Props = {
+	activeRunId: string | null;
 	onSelectRun: (runId: string) => void;
 };
 
 export const RecentRunsColumn = memo(function RecentRunsColumn({
+	activeRunId,
 	onSelectRun,
 }: Props) {
 	const { data } = useRecentRuns();
@@ -28,7 +30,12 @@ export const RecentRunsColumn = memo(function RecentRunsColumn({
 				<Fragment key={group.label}>
 					<div className="hgroup-head">{group.label}</div>
 					{group.runs.map((run) => (
-						<HistoryRow key={run.id} run={run} onSelect={onSelectRun} />
+						<HistoryRow
+							key={run.id}
+							run={run}
+							selected={run.id === activeRunId}
+							onSelect={onSelectRun}
+						/>
 					))}
 				</Fragment>
 			))}
@@ -38,9 +45,11 @@ export const RecentRunsColumn = memo(function RecentRunsColumn({
 
 function HistoryRow({
 	run,
+	selected,
 	onSelect,
 }: {
 	run: Run;
+	selected: boolean;
 	onSelect: (runId: string) => void;
 }) {
 	const select = () => {
@@ -49,7 +58,7 @@ function HistoryRow({
 	return (
 		// biome-ignore lint/a11y/useSemanticElements: row contains a nested PR <a>, so the row itself can't be an <a>; role="link" + keyboard handler preserves accessibility.
 		<div
-			className="hrow"
+			className={`hrow${selected ? " active" : ""}`}
 			data-testid={`recent-run-${run.id}`}
 			role="link"
 			tabIndex={0}

--- a/dashboard/src/components/transcript.tsx
+++ b/dashboard/src/components/transcript.tsx
@@ -15,7 +15,11 @@ type Props = {
 export function Transcript({ events, steps }: Props) {
 	const groups = useMemo(() => groupByStep(events, steps), [events, steps]);
 	return (
-		<div className="transcript" data-testid="transcript">
+		<div
+			className="transcript"
+			data-testid="transcript"
+			onScroll={handleTranscriptScroll}
+		>
 			{groups.map((group) => {
 				if (group.kind === "step") {
 					return (
@@ -30,6 +34,10 @@ export function Transcript({ events, steps }: Props) {
 			})}
 		</div>
 	);
+}
+
+function handleTranscriptScroll(e: React.UIEvent<HTMLDivElement>) {
+	e.currentTarget.classList.toggle("scrolled", e.currentTarget.scrollTop > 0);
 }
 
 type StepGroup = { kind: "step"; step: Step; events: RunEvent[] };

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -57,7 +57,8 @@ body {
 
 body {
 	min-width: 1280px;
-	min-height: 100vh;
+	height: 100vh;
+	overflow: hidden;
 	background: var(--bg);
 	display: flex;
 	flex-direction: column;
@@ -293,6 +294,13 @@ header.app .meta-right {
 }
 
 /* ───── queue column ───── */
+
+.queue,
+.history,
+.transcript {
+	scrollbar-width: thin;
+	scrollbar-color: var(--line-2) transparent;
+}
 
 .queue {
 	overflow-y: auto;
@@ -744,6 +752,11 @@ h1.run-title {
 	overflow-y: auto;
 	padding: 18px 28px 80px;
 	position: relative;
+	transition: box-shadow 0.15s ease-out;
+}
+
+.transcript.scrolled {
+	box-shadow: inset 0 6px 8px -6px rgba(0, 0, 0, 0.18);
 }
 
 .transcript > .group,
@@ -942,6 +955,21 @@ h1.run-title {
 
 .hrow:hover {
 	background: var(--bg-1);
+}
+
+.hrow.active {
+	background: var(--bg-1);
+	position: relative;
+}
+
+.hrow.active::before {
+	content: "";
+	position: absolute;
+	left: 0;
+	top: 0;
+	bottom: 0;
+	width: 2px;
+	background: var(--running);
 }
 
 .hrow-top {


### PR DESCRIPTION
## Summary
- Lock body to viewport height so the left (Active/Queued) and right (Recent runs) columns stay pinned while the transcript scrolls — the open run no longer drifts off-screen when scrolling through long event lists.
- Mirror the existing Active-column "selected" treatment on the Recent runs column so the currently open run is visually identifiable wherever it lives (queued → active → recent).
- Add a subtle inset top shadow on the transcript when `scrollTop > 0`, toggled via direct `classList` mutation to keep the transient flag out of React state (avoids re-rendering the event list on the scroll-boundary cross).
- Use modern `scrollbar-width: thin` and `scrollbar-color` (both Baseline 2024) on the three scroll containers for a slim, on-brand thumb without WebKit-only pseudo-elements.

## Test plan
- [ ] Open a run from the Active column → ensure the row stays highlighted in place.
- [ ] Let a run complete and migrate to the Recent runs column → ensure the same row stays highlighted on the right.
- [ ] Scroll a long transcript → confirm the side columns and the overview strip stay pinned, and only the event list scrolls.
- [ ] Scroll the transcript down → confirm the subtle top shadow appears; scroll back to top → confirm it fades out.
- [ ] Inspect scrollbars in Chrome/Firefox/Safari → confirm the thin, subtle thumb renders consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)