### PR TITLE
feat: assign Jira issue to runner on pickup

### DIFF
--- a/server/trackers/jira-client.integration.test.ts
+++ b/server/trackers/jira-client.integration.test.ts
@@ -105,4 +105,106 @@ describe("Jira client", () => {
 			expect(called).toBe(false);
 		});
 	});
+
+	describe("getMyself", () => {
+		it("GETs /myself and returns the accountId", async () => {
+			server.use(
+				http.get(`${JIRA_API}/myself`, () =>
+					HttpResponse.json({
+						accountId: "acct-123",
+						displayName: "Agent Runner",
+						emailAddress: "agent@example.test",
+					}),
+				),
+			);
+
+			const client = createJiraClient({
+				baseUrl: JIRA_BASE_URL,
+				email: "agent@example.test",
+				apiToken: "jira-token",
+				maxAttempts: 1,
+			});
+
+			const me = await client.getMyself();
+
+			expect(me).toEqual({ accountId: "acct-123" });
+		});
+
+		it("caches the result across repeat calls", async () => {
+			let calls = 0;
+			server.use(
+				http.get(`${JIRA_API}/myself`, () => {
+					calls += 1;
+					return HttpResponse.json({ accountId: "acct-123" });
+				}),
+			);
+
+			const client = createJiraClient({
+				baseUrl: JIRA_BASE_URL,
+				email: "agent@example.test",
+				apiToken: "jira-token",
+				maxAttempts: 1,
+			});
+
+			await client.getMyself();
+			await client.getMyself();
+
+			expect(calls).toBe(1);
+		});
+
+		it("re-fetches after a failed call", async () => {
+			let calls = 0;
+			server.use(
+				http.get(`${JIRA_API}/myself`, () => {
+					calls += 1;
+					if (calls === 1) return new HttpResponse(null, { status: 500 });
+					return HttpResponse.json({ accountId: "acct-123" });
+				}),
+			);
+
+			const client = createJiraClient({
+				baseUrl: JIRA_BASE_URL,
+				email: "agent@example.test",
+				apiToken: "jira-token",
+				maxAttempts: 1,
+			});
+
+			await expect(client.getMyself()).rejects.toThrow();
+			const me = await client.getMyself();
+
+			expect(me).toEqual({ accountId: "acct-123" });
+			expect(calls).toBe(2);
+		});
+	});
+
+	describe("assignIssue", () => {
+		it("PUTs the assignee accountId for the issue", async () => {
+			const captured: { key: string; body: unknown }[] = [];
+			server.use(
+				http.put(
+					`${JIRA_API}/issue/:key/assignee`,
+					async ({ request, params }) => {
+						captured.push({
+							key: String(params["key"]),
+							body: await request.json(),
+						});
+						return new HttpResponse(null, { status: 204 });
+					},
+				),
+			);
+
+			const client = createJiraClient({
+				baseUrl: JIRA_BASE_URL,
+				email: "agent@example.test",
+				apiToken: "jira-token",
+				maxAttempts: 1,
+			});
+
+			await client.assignIssue("PROJ-7", "acct-123");
+
+			expect(captured).toEqual([
+				{ key: "PROJ-7", body: { accountId: "acct-123" } },
+			]);
+		});
+	});
 });

--- a/server/trackers/jira-client.ts
+++ b/server/trackers/jira-client.ts
@@ -30,11 +30,17 @@ const jiraTransitionsSchema = z.object({
 	),
 });
 
+const jiraMyselfSchema = z.object({
+	accountId: z.string(),
+});
+
 export type JiraIssue = z.infer<typeof jiraIssueSchema>;
 
 export type JiraTransition = z.infer<
 	typeof jiraTransitionsSchema
 >["transitions"][number];
+
+type JiraMyself = z.infer<typeof jiraMyselfSchema>;
 
 export type JiraClient = {
 	getIssue(key: string): Promise<JiraIssue>;
@@ -48,6 +54,8 @@ export type JiraClient = {
 		key: string,
 		changes: { add?: string[]; remove?: string[] },
 	): Promise<void>;
+	getMyself(): Promise<JiraMyself>;
+	assignIssue(key: string, accountId: string): Promise<void>;
 };
 
 type JiraClientOptions = HttpClientOptions & {
@@ -67,6 +75,8 @@ export function createJiraClient(options: JiraClientOptions): JiraClient {
 			Accept: "application/json",
 		},
 	});
+
+	let myselfCache: Promise<JiraMyself> | null = null;
 
 	return {
 		getIssue(key: string) {
@@ -121,6 +131,25 @@ export function createJiraClient(options: JiraClientOptions): JiraClient {
 			await request(`/issue/${encodeIssueKey(key)}`, {
 				method: "PUT",
 				body: { update: { labels: ops } },
+			});
+		},
+
+		getMyself() {
+			if (!myselfCache) {
+				myselfCache = request("/myself", { schema: jiraMyselfSchema }).catch(
+					(err) => {
+						myselfCache = null;
+						throw err;
+					},
+				);
+			}
+			return myselfCache;
+		},
+
+		assignIssue(key, accountId) {
+			return request(`/issue/${encodeIssueKey(key)}/assignee`, {
+				method: "PUT",
+				body: { accountId },
 			});
 		},
 	};

--- a/server/trackers/jira.integration.test.ts
+++ b/server/trackers/jira.integration.test.ts
@@ -296,6 +296,12 @@ describe("jiraTrackerAdapter", () => {
 
 		it("matches transition target status case-insensitively", async () => {
 			server.use(
+				http.get(`${JIRA_API}/myself`, () =>
+					HttpResponse.json({ accountId: "acct-123" }),
+				),
+				http.put(`${JIRA_API}/issue/:key/assignee`, () =>
+					HttpResponse.json(null, { status: 204 }),
+				),
 				http.get(`${JIRA_API}/issue/:key/transitions`, () =>
 					HttpResponse.json({
 						transitions: [
@@ -337,6 +343,134 @@ describe("jiraTrackerAdapter", () => {
 			await expect(
 				tracker.transitionState(REPO, issueNumber(42), "pending", "running"),
 			).resolves.toBeUndefined();
+		});
+
+		it("assigns the issue to the authenticated user before posting the transition", async () => {
+			const calls: Array<{ kind: string; key: string; body: unknown }> = [];
+			server.use(
+				http.get(`${JIRA_API}/myself`, () =>
+					HttpResponse.json({ accountId: "acct-123" }),
+				),
+				http.put(
+					`${JIRA_API}/issue/:key/assignee`,
+					async ({ request, params }) => {
+						calls.push({
+							kind: "assign",
+							key: String(params["key"]),
+							body: await request.json(),
+						});
+						return new HttpResponse(null, { status: 204 });
+					},
+				),
+				http.get(`${JIRA_API}/issue/:key/transitions`, () =>
+					HttpResponse.json({
+						transitions: [
+							{ id: "11", name: "Start", to: { name: "In Progress" } },
+						],
+					}),
+				),
+				http.post(
+					`${JIRA_API}/issue/:key/transitions`,
+					async ({ request, params }) => {
+						calls.push({
+							kind: "transition",
+							key: String(params["key"]),
+							body: await request.json(),
+						});
+						return new HttpResponse(null, { status: 204 });
+					},
+				),
+			);
+
+			const tracker = createTracker();
+
+			await tracker.transitionState(
+				REPO,
+				issueNumber(42),
+				"pending",
+				"running",
+			);
+
+			expect(calls).toEqual([
+				{
+					kind: "assign",
+					key: "PROJ-42",
+					body: { accountId: "acct-123" },
+				},
+				{
+					kind: "transition",
+					key: "PROJ-42",
+					body: { transition: { id: "11" } },
+				},
+			]);
+		});
+
+		it("does not assign or fetch the authenticated user when transitioning out of running", async () => {
+			let myselfCalled = false;
+			let assignCalled = false;
+			server.use(
+				http.get(`${JIRA_API}/myself`, () => {
+					myselfCalled = true;
+					return HttpResponse.json({ accountId: "acct-123" });
+				}),
+				http.put(`${JIRA_API}/issue/:key/assignee`, () => {
+					assignCalled = true;
+					return new HttpResponse(null, { status: 204 });
+				}),
+				http.get(`${JIRA_API}/issue/:key/transitions`, () =>
+					HttpResponse.json({
+						transitions: [
+							{ id: "21", name: "Review", to: { name: "In Review" } },
+						],
+					}),
+				),
+				http.post(`${JIRA_API}/issue/:key/transitions`, () =>
+					HttpResponse.json(null, { status: 204 }),
+				),
+			);
+
+			const tracker = createTracker();
+
+			await tracker.transitionState(
+				REPO,
+				issueNumber(42),
+				"running",
+				"awaiting_review",
+			);
+
+			expect(myselfCalled).toBe(false);
+			expect(assignCalled).toBe(false);
+		});
+
+		it("does not post the transition when fetching the authenticated user fails", async () => {
+			let transitionPosts = 0;
+			server.use(
+				http.get(
+					`${JIRA_API}/myself`,
+					() => new HttpResponse(null, { status: 500 }),
+				),
+				http.put(`${JIRA_API}/issue/:key/assignee`, () =>
+					HttpResponse.json(null, { status: 204 }),
+				),
+				http.get(`${JIRA_API}/issue/:key/transitions`, () =>
+					HttpResponse.json({
+						transitions: [
+							{ id: "11", name: "Start", to: { name: "In Progress" } },
+						],
+					}),
+				),
+				http.post(`${JIRA_API}/issue/:key/transitions`, () => {
+					transitionPosts += 1;
+					return new HttpResponse(null, { status: 204 });
+				}),
+			);
+
+			const tracker = createTracker();
+
+			await expect(
+				tracker.transitionState(REPO, issueNumber(42), "pending", "running"),
+			).rejects.toThrow();
+			expect(transitionPosts).toBe(0);
 		});
 
 		it("fails when Jira does not expose a transition to the target status", async () => {

--- a/server/trackers/jira.ts
+++ b/server/trackers/jira.ts
@@ -97,7 +97,16 @@ export function jiraTrackerAdapter(
 		async transitionState(_repo, issueNum, _from, to): Promise<void> {
 			const key = jiraIssueKey(options.project, issueNum);
 			const targetStatus = options.statuses[to].toLowerCase();
-			const transitions = await client.listTransitions(key);
+			const assign =
+				to === "running"
+					? client
+							.getMyself()
+							.then((me) => client.assignIssue(key, me.accountId))
+					: Promise.resolve();
+			const [, transitions] = await Promise.all([
+				assign,
+				client.listTransitions(key),
+			]);
 			const transition = transitions.find(
 				(t) => t.to.name.toLowerCase() === targetStatus,
 			);


### PR DESCRIPTION
## Summary
- Sets the Jira issue's assignee to the authenticated user before transitioning pending → running, so the board reflects ownership and teammates don't drag the ticket while the agent is working it.
- `JiraClient.getMyself()` now caches the runner's accountId for the process lifetime (re-fetches after failure); the tracker adapter no longer carries closure state.
- Assignee PUT and list-transitions GET run in parallel via `Promise.all` — independent calls, transition POST still last.
- Failure paths (`markFailed`, running→pending rollback) deliberately leave the assignee in place — runner stays responsible.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 293/293 passing
- [x] `pnpm exec biome check` clean on touched files
- [ ] Manual smoke against a real Jira project: drop a `repo:<scope>` labelled ticket as `pending`, watch the orchestrator pick it up, verify assignee is set to the runner and status moves to `running`
- [ ] Manual smoke for the failure path: revoke `/myself` access transiently and confirm the ticket stays in `pending` rather than transitioning without an assignee