### PR TITLE
feat: always pass shell basics through to agent subprocess

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -17,3 +17,13 @@ defaults:
   polling_interval_ms: 30000
   max_concurrent: 2
   workspace_root: /tmp/local-agent-workspaces
+
+# HOME, PATH, SHELL, USER, LOGNAME, LANG, and TZ are always passed through
+# to the agent subprocess. Use agent.env.include for secrets the agent needs,
+# such as ANTHROPIC_API_KEY (only if you authenticate via API key instead of
+# `claude login`).
+#
+# agent:
+#   env:
+#     include:
+#       - ANTHROPIC_API_KEY

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,11 @@ defaults:
   max_concurrent: 2
   model: claude-sonnet-4-6
   workspace_root: /tmp/local-agent-workspaces
+
+agent:
+  env:
+    include:
+      - ANTHROPIC_API_KEY
 ```
 
 ### `tracker`
@@ -111,6 +116,43 @@ Tokens and credentials live in `.env`, not in `config.yaml`. The orchestrator va
 - `JIRA_EMAIL` and `JIRA_API_TOKEN` are required.
 - `GITHUB_TOKEN` is required when `code_host.kind` is `github`.
 - `GITLAB_TOKEN` is required when `code_host.kind` is `gitlab`.
+
+### `agent`
+
+Controls what the spawned Claude Agent SDK subprocess sees in its environment. The host orchestrator's env is **not** inherited wholesale; the agent gets a curated subset.
+
+```yaml
+agent:
+  env:
+    include:
+      - ANTHROPIC_API_KEY
+    set:
+      CI: "true"
+```
+
+| Field         | Type     | Default | Description |
+|---------------|----------|---------|-------------|
+| `env.include` | string[] | `[]`    | Names of host env vars to copy through to the agent. Use this for secrets and project-specific vars. |
+| `env.set`     | object   | `{}`    | Literal key/value pairs set in the agent's env. Overrides anything from `include` or the implicit shell basics. |
+
+#### Always-included shell basics
+
+These are passed through automatically and do not need to appear in `include`:
+
+`HOME`, `PATH`, `SHELL`, `USER`, `LOGNAME`, `LANG`, `TZ`.
+
+Without `HOME` the SDK can't read `~/.claude/` credentials and the agent fails to authenticate; without `PATH` it can't find `git`, `node`, `pnpm`, or `fnm`. These are prerequisites, not opt-ins.
+
+If you need to override one (for example, prepending to `PATH`), use `env.set`.
+
+#### What to put in `include`
+
+App secrets and project-specific vars the agent actually needs at runtime, for example:
+
+- `ANTHROPIC_API_KEY` if you authenticate via API key instead of `claude login`.
+- Private package registry tokens like `GITLAB_PACKAGES_TOKEN`.
+
+Everything else on the host stays on the host.
 
 ---
 

--- a/server/orchestrator/agent-env.test.ts
+++ b/server/orchestrator/agent-env.test.ts
@@ -2,26 +2,62 @@ import { describe, expect, it } from "vitest";
 import { resolveAgentEnvironment } from "./agent-env.ts";
 
 describe("resolveAgentEnvironment", () => {
-	it("copies only included source variables and applies set values", () => {
+	it("always passes shell basics, layers include and set on top", () => {
 		const env = resolveAgentEnvironment(
 			{
-				include: ["PATH", "GITLAB_PACKAGES_TOKEN", "MISSING"],
+				include: ["GITLAB_PACKAGES_TOKEN", "MISSING"],
 				set: {
 					CI: "true",
 					GITLAB_PACKAGES_TOKEN: "override",
 				},
 			},
 			{
+				HOME: "/Users/widget",
 				PATH: "/usr/bin",
+				SHELL: "/bin/zsh",
+				USER: "widget",
+				LOGNAME: "widget",
+				LANG: "en_US.UTF-8",
+				TZ: "Europe/London",
 				GITLAB_PACKAGES_TOKEN: "source-token",
 				AWS_SESSION_TOKEN: "do-not-copy",
 			},
 		);
 
 		expect(env).toEqual({
+			HOME: "/Users/widget",
 			PATH: "/usr/bin",
+			SHELL: "/bin/zsh",
+			USER: "widget",
+			LOGNAME: "widget",
+			LANG: "en_US.UTF-8",
+			TZ: "Europe/London",
 			CI: "true",
 			GITLAB_PACKAGES_TOKEN: "override",
+		});
+	});
+
+	it("skips shell basics that are absent from the source environment", () => {
+		const env = resolveAgentEnvironment(
+			{ include: [], set: {} },
+			{ HOME: "/Users/widget", PATH: "/usr/bin" },
+		);
+
+		expect(env).toEqual({
+			HOME: "/Users/widget",
+			PATH: "/usr/bin",
+		});
+	});
+
+	it("lets set override shell basics", () => {
+		const env = resolveAgentEnvironment(
+			{ include: [], set: { PATH: "/custom/bin" } },
+			{ HOME: "/Users/widget", PATH: "/usr/bin" },
+		);
+
+		expect(env).toEqual({
+			HOME: "/Users/widget",
+			PATH: "/custom/bin",
 		});
 	});
 });

--- a/server/orchestrator/agent-env.ts
+++ b/server/orchestrator/agent-env.ts
@@ -2,11 +2,30 @@ import type { Config } from "../config.ts";
 
 type AgentEnvConfig = Config["agent"]["env"];
 
+// Shell basics required for the Claude Agent SDK subprocess to function:
+// HOME locates `~/.claude/` credentials, PATH resolves git/node/pnpm/fnm,
+// and the rest are widely assumed by shell tooling. These are not sensitive,
+// so they're always passed through; opt-in `include` is for secrets.
+const ALWAYS_INCLUDED_ENV = [
+	"HOME",
+	"PATH",
+	"SHELL",
+	"USER",
+	"LOGNAME",
+	"LANG",
+	"TZ",
+] as const;
+
 export function resolveAgentEnvironment(
 	config: AgentEnvConfig,
 	sourceEnv: NodeJS.ProcessEnv = process.env,
 ): Record<string, string> {
 	const env: Record<string, string> = {};
+
+	for (const key of ALWAYS_INCLUDED_ENV) {
+		const value = sourceEnv[key];
+		if (value !== undefined) env[key] = value;
+	}
 
 	for (const key of config.include) {
 		const value = sourceEnv[key];


### PR DESCRIPTION
## Summary

- The agent SDK subprocess was getting an empty env unless every var was explicitly listed in `agent.env.include`. Without `HOME` the SDK couldn't read `~/.claude/` credentials and failed with "Not logged in"; without `PATH` it couldn't find `git`/`node`/`pnpm`/`fnm`. The "security via empty default" framing didn't hold up — it just made every fresh config broken until two specific entries were added.
- `HOME`, `PATH`, `SHELL`, `USER`, `LOGNAME`, `LANG`, and `TZ` are now always passed through. `agent.env.include` is reserved for genuine secrets; `agent.env.set` still wins on conflict.
- Documented the env behaviour in `docs/configuration.md` and updated `config.example.yaml` with a commented opt-in example.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (295 passing)
- [ ] Re-trigger a run on a Jira issue and confirm the branch agent authenticates without an explicit `agent.env.include` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)