### PR TITLE
feat: ship bundled skills into agent workspaces

### DIFF
--- a/agent-settings.json
+++ b/agent-settings.json
@@ -1,0 +1,19 @@
+{
+	"hooks": {
+		"PreToolUse": [
+			{
+				"matcher": "Bash",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-dangerous-git.sh"
+					},
+					{
+						"type": "command",
+						"command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/validate-commit-message.sh"
+					}
+				]
+			}
+		]
+	}
+}

--- a/hooks/block-dangerous-git.sh
+++ b/hooks/block-dangerous-git.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly COMMAND=$(jq -r '.tool_input.command' < /dev/stdin)
+
+# Any push is owned by the orchestrator, not the agent. Block every form.
+readonly -a PUSH_PATTERNS=(
+  "git push"
+)
+
+# Other destructive operations that can lose work.
+readonly -a DESTRUCTIVE_PATTERNS=(
+  "git reset --hard"
+  "git clean -f"
+  "git clean -fd"
+  "git clean -fdx"
+  "git checkout -- ."
+  "git checkout ."
+  "git restore ."
+  "git branch -D"
+  "git stash drop"
+  "git stash clear"
+)
+
+block() {
+  local kind="$1"
+  cat >&2 <<EOF
+BLOCKED ($kind): "$COMMAND"
+
+This command is reserved for the HITL or is destructive in a way that loses work.
+Do the actual work (edit, commit) and stop.
+EOF
+  exit 2
+}
+
+for pattern in "${PUSH_PATTERNS[@]}"; do
+  if [[ "$COMMAND" == *"$pattern"* ]]; then
+    block "push"
+  fi
+done
+
+for pattern in "${DESTRUCTIVE_PATTERNS[@]}"; do
+  if [[ "$COMMAND" == *"$pattern"* ]]; then
+    block "destructive git operation"
+  fi
+done

--- a/hooks/validate-commit-message.sh
+++ b/hooks/validate-commit-message.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly COMMAND=$(jq -r '.tool_input.command' < /dev/stdin)
+
+# Only care about git commit with -m flag
+case "$COMMAND" in
+  *"git commit"*"-m"*) ;;
+  *) exit 0 ;;
+esac
+
+# Skip amend commits — they may reuse an existing message
+[[ "$COMMAND" == *"--amend"* ]] && exit 0
+
+# Extract the first line of the commit message
+FIRST_LINE=""
+
+if [[ "$COMMAND" == *'<<'* ]]; then
+  # HEREDOC format: first non-blank line between EOF markers
+  FIRST_LINE=$(printf '%s\n' "$COMMAND" | sed -n "/<<.*EOF/,/^[[:space:]]*EOF/{
+    /<<.*EOF/d
+    /^[[:space:]]*EOF/d
+    /^[[:space:]]*$/d
+    p
+  }" | head -1 | sed 's/^[[:space:]]*//')
+else
+  # Inline format: content between quotes after -m
+  FIRST_LINE=$(printf '%s\n' "$COMMAND" | sed -n 's/.*-m "\([^"]*\).*/\1/p' | head -1)
+  if [[ -z "$FIRST_LINE" ]]; then
+    FIRST_LINE=$(printf '%s\n' "$COMMAND" | sed -n "s/.*-m '\([^']*\).*/\1/p" | head -1)
+  fi
+fi
+
+# If we couldn't extract a message, let it through (editor commit, -F, etc.)
+[[ -z "$FIRST_LINE" ]] && exit 0
+
+# Validate conventional commit format: type(optional-scope): description
+readonly PATTERN='^(feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert)(\([a-zA-Z0-9._-]+\))?!?: .+'
+
+if ! [[ "$FIRST_LINE" =~ $PATTERN ]]; then
+  cat >&2 <<EOF
+BLOCKED: Commit message does not follow Conventional Commits format.
+
+  Got: "$FIRST_LINE"
+
+Expected: <type>(<optional scope>): <description>
+Types: feat, fix, chore, docs, refactor, test, ci, perf, build, style, revert
+Examples:
+  feat: add user authentication
+  fix(api): handle null response body
+  docs: update README with setup instructions
+EOF
+  exit 2
+fi

--- a/server/orchestrator/agent-invoker.ts
+++ b/server/orchestrator/agent-invoker.ts
@@ -34,7 +34,7 @@ export const DEFAULT_ALLOWED_TOOLS = [
 	"Bash",
 	"Glob",
 	"Grep",
-	"Task",
+	"Agent",
 ] as const;
 
 export function claudeSdkAgentInvoker({
@@ -67,6 +67,11 @@ export function claudeSdkAgentInvoker({
 					allowedTools: [...(allowedTools ?? DEFAULT_ALLOWED_TOOLS)],
 					permissionMode: "dontAsk" as const,
 					settingSources: ["project"],
+					// Auto-enables the Skill tool so skills like `implement` can chain
+					// into others (e.g. `tdd`). Without this, `permissionMode: "dontAsk"`
+					// denies Skill because it isn't in `allowedTools`, and listing
+					// `"Skill"` there is deprecated (sdk.d.ts: use `skills` instead).
+					skills: "all",
 					systemPrompt: {
 						type: "preset",
 						preset: "claude_code",

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -1,4 +1,5 @@
 import { resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
 import * as canonicalLog from "../canonical-log.ts";
 import type { CodeHostAdapter } from "../code-hosts/types.ts";
 import type { Config } from "../config.ts";
@@ -15,6 +16,12 @@ import { createRunLifecycle } from "./run-lifecycle.ts";
 import { type RunShell, realRunShell, sweepWorkspaces } from "./workspace.ts";
 
 const WORKSPACE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// LA ships its own skills at `<repo-root>/skills/`. Resolve relative to this
+// source file so the path is tied to the install, not the launch CWD.
+const SKILLS_SOURCE_DIR = fileURLToPath(
+	new URL("../../skills/", import.meta.url),
+);
 
 type OrchestratorConfig = {
 	runRepo: RunRepository;
@@ -111,6 +118,7 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		runShell,
 		logger,
 		workspaceRoot: defaults.workspace_root,
+		skillsSourceDir: SKILLS_SOURCE_DIR,
 		agentEnv,
 	});
 

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -17,10 +17,17 @@ import { type RunShell, realRunShell, sweepWorkspaces } from "./workspace.ts";
 
 const WORKSPACE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
-// LA ships its own skills at `<repo-root>/skills/`. Resolve relative to this
-// source file so the path is tied to the install, not the launch CWD.
+// LA ships its own skills, hooks, and agent settings at `<repo-root>/`. Resolve
+// relative to this source file so the paths are tied to the install, not the
+// launch CWD.
 const SKILLS_SOURCE_DIR = fileURLToPath(
 	new URL("../../skills/", import.meta.url),
+);
+const HOOKS_SOURCE_DIR = fileURLToPath(
+	new URL("../../hooks/", import.meta.url),
+);
+const AGENT_SETTINGS_FILE = fileURLToPath(
+	new URL("../../agent-settings.json", import.meta.url),
 );
 
 type OrchestratorConfig = {
@@ -119,6 +126,8 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		logger,
 		workspaceRoot: defaults.workspace_root,
 		skillsSourceDir: SKILLS_SOURCE_DIR,
+		hooksSourceDir: HOOKS_SOURCE_DIR,
+		agentSettingsFile: AGENT_SETTINGS_FILE,
 		agentEnv,
 	});
 

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -20,6 +20,7 @@ import { runWorkflowSteps } from "./step-runner.ts";
 import {
 	createWorkspace,
 	ensureBranch,
+	installAgentDefaults,
 	installSkills,
 	pushBranch,
 	type RunShell,
@@ -49,6 +50,8 @@ type RunLifecycleDeps = {
 	logger: Logger;
 	workspaceRoot: string;
 	skillsSourceDir: string;
+	hooksSourceDir: string;
+	agentSettingsFile: string;
 	agentEnv: Record<string, string>;
 };
 
@@ -56,6 +59,7 @@ type FailurePhase =
 	| "workspace"
 	| "branch_resolver"
 	| "skills"
+	| "agent_defaults"
 	| "setup"
 	| "step"
 	| FinalizeFailurePhase;
@@ -80,6 +84,8 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 		logger,
 		workspaceRoot,
 		skillsSourceDir,
+		hooksSourceDir,
+		agentSettingsFile,
 		agentEnv,
 	} = deps;
 
@@ -200,6 +206,26 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 									},
 								});
 							}
+
+							phase = "agent_defaults";
+							const defaultsResult = await installAgentDefaults(
+								wsPath,
+								hooksSourceDir,
+								agentSettingsFile,
+							);
+							canonicalLog.set({
+								hooks_installed: defaultsResult.hooksInstalled,
+							});
+							ctx.emit({
+								kind: "system",
+								stepName: null,
+								data: {
+									message: `hooks installed: ${defaultsResult.hooksInstalled.length}`,
+									command: null,
+									path: null,
+									exitCode: null,
+								},
+							});
 
 							phase = "setup";
 							const workspaceEnv = await resolveWorkspaceEnvironment(

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -20,6 +20,7 @@ import { runWorkflowSteps } from "./step-runner.ts";
 import {
 	createWorkspace,
 	ensureBranch,
+	installSkills,
 	pushBranch,
 	type RunShell,
 	removeWorkspace,
@@ -47,12 +48,14 @@ type RunLifecycleDeps = {
 	runShell: RunShell;
 	logger: Logger;
 	workspaceRoot: string;
+	skillsSourceDir: string;
 	agentEnv: Record<string, string>;
 };
 
 type FailurePhase =
 	| "workspace"
 	| "branch_resolver"
+	| "skills"
 	| "setup"
 	| "step"
 	| FinalizeFailurePhase;
@@ -76,6 +79,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 		runShell,
 		logger,
 		workspaceRoot,
+		skillsSourceDir,
 		agentEnv,
 	} = deps;
 
@@ -169,8 +173,35 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 								},
 							});
 
-							phase = "setup";
 							await ensureBranch(wsPath, branch);
+
+							phase = "skills";
+							const skillsResult = await installSkills(
+								wsPath,
+								skillsSourceDir,
+								{ issue, branch, base_branch: baseBranch },
+							);
+							canonicalLog.set({
+								skills_installed: skillsResult.installed,
+								skills_skipped: skillsResult.skipped,
+							});
+							if (
+								skillsResult.installed.length > 0 ||
+								skillsResult.skipped.length > 0
+							) {
+								ctx.emit({
+									kind: "system",
+									stepName: null,
+									data: {
+										message: `skills installed: ${skillsResult.installed.length} (skipped ${skillsResult.skipped.length})`,
+										command: null,
+										path: null,
+										exitCode: null,
+									},
+								});
+							}
+
+							phase = "setup";
 							const workspaceEnv = await resolveWorkspaceEnvironment(
 								wsPath,
 								agentEnv,

--- a/server/orchestrator/workspace.test.ts
+++ b/server/orchestrator/workspace.test.ts
@@ -511,6 +511,55 @@ describe("installSkills", () => {
 		).resolves.toBe("detail for feat/ABC-42-thing");
 	});
 
+	it("adds installed skills to .git/info/exclude so they stay out of git status", async () => {
+		await using ws = await createWorkspaceRoot();
+		const issue = createIssue(100);
+		const wsPath = await createWorkspace(
+			issue,
+			ws.root,
+			bareRepo,
+			"run-skills-exclude",
+		);
+		await using src = await makeSkillsSource({
+			review: "review body",
+			implement: "implement body",
+		});
+
+		await installSkills(wsPath, src.path, TEST_RENDER_VARS);
+
+		const { stdout: status } = await exec(
+			"git",
+			["status", "--porcelain", "--ignored"],
+			{ cwd: wsPath },
+		);
+		expect(status).not.toMatch(/\.claude\/skills\/review/);
+		expect(status).not.toMatch(/\.claude\/skills\/implement/);
+
+		const exclude = await readFile(join(wsPath, ".git/info/exclude"), "utf8");
+		expect(exclude).toMatch(/\.claude\/skills\/review\//);
+		expect(exclude).toMatch(/\.claude\/skills\/implement\//);
+	});
+
+	it("does not duplicate exclude entries on repeated installs", async () => {
+		await using ws = await createWorkspaceRoot();
+		const issue = createIssue(101);
+		const wsPath = await createWorkspace(
+			issue,
+			ws.root,
+			bareRepo,
+			"run-skills-idempotent",
+		);
+		await using src = await makeSkillsSource({ review: "review" });
+
+		await installSkills(wsPath, src.path, TEST_RENDER_VARS);
+		await rm(join(wsPath, ".claude/skills/review"), { recursive: true });
+		await installSkills(wsPath, src.path, TEST_RENDER_VARS);
+
+		const exclude = await readFile(join(wsPath, ".git/info/exclude"), "utf8");
+		const matches = exclude.match(/\.claude\/skills\/review\//g) ?? [];
+		expect(matches.length).toBe(1);
+	});
+
 	it("leaves non-.md files untouched", async () => {
 		await using ws = await withWorkspace();
 		await using src = await makeSkillsSource({
@@ -602,6 +651,33 @@ describe("installAgentDefaults", () => {
 
 		const info = await stat(join(ws.path, ".claude/hooks/noop.sh"));
 		expect(info.mode & 0o111).not.toBe(0);
+	});
+
+	it("excludes installed hooks and settings from git via .git/info/exclude", async () => {
+		await using ws = await createWorkspaceRoot();
+		const issue = createIssue(102);
+		const wsPath = await createWorkspace(
+			issue,
+			ws.root,
+			bareRepo,
+			"run-defaults-exclude",
+		);
+		await using src = await makeAgentDefaultsSource(
+			{ "noop.sh": "#!/usr/bin/env bash\nexit 0\n" },
+			'{"hooks":{}}',
+		);
+
+		await installAgentDefaults(wsPath, src.hooksDir, src.settingsFile);
+
+		const { stdout: status } = await exec("git", ["status", "--porcelain"], {
+			cwd: wsPath,
+		});
+		expect(status).not.toMatch(/\.claude\/hooks/);
+		expect(status).not.toMatch(/\.claude\/settings\.json/);
+
+		const exclude = await readFile(join(wsPath, ".git/info/exclude"), "utf8");
+		expect(exclude).toMatch(/\.claude\/hooks\//);
+		expect(exclude).toMatch(/\.claude\/settings\.json/);
 	});
 
 	it("overwrites an existing settings.json so target-repo customisations cannot bypass orchestrator policy", async () => {

--- a/server/orchestrator/workspace.test.ts
+++ b/server/orchestrator/workspace.test.ts
@@ -1,5 +1,13 @@
 import { execFile } from "node:child_process";
-import { access, chmod, mkdir, rm, utimes, writeFile } from "node:fs/promises";
+import {
+	access,
+	chmod,
+	mkdir,
+	readFile,
+	rm,
+	utimes,
+	writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -9,6 +17,7 @@ import type { Issue } from "../trackers/types.ts";
 import { issueKey, issueNumber, repoSlug } from "../types/brands.ts";
 import {
 	createWorkspace,
+	installSkills,
 	pushBranch,
 	realRunShell,
 	removeWorkspace,
@@ -367,5 +376,156 @@ describe("resolveWorkspaceEnvironment", () => {
 		await expect(
 			resolveWorkspaceEnvironment(ws.path, { PATH: "/bin" }),
 		).rejects.toThrow(/fnm is not available on PATH/);
+	});
+});
+
+async function makeSkillsSource(skills: Record<string, string>): Promise<{
+	path: string;
+	[Symbol.asyncDispose](): Promise<void>;
+}> {
+	const path = join(
+		tmpdir(),
+		`skills-src-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+	);
+	await mkdir(path, { recursive: true });
+	for (const [name, body] of Object.entries(skills)) {
+		await mkdir(join(path, name), { recursive: true });
+		await writeFile(join(path, name, "SKILL.md"), body);
+	}
+	return {
+		path,
+		async [Symbol.asyncDispose]() {
+			await rm(path, { recursive: true, force: true });
+		},
+	};
+}
+
+const TEST_RENDER_VARS = {
+	issue: createIssue(42),
+	branch: "feat/ABC-42-thing",
+	base_branch: "main",
+};
+
+describe("installSkills", () => {
+	it("copies each skill directory into <ws>/.claude/skills/", async () => {
+		await using ws = await withWorkspace();
+		await using src = await makeSkillsSource({
+			review: "review body",
+			implement: "implement body",
+		});
+
+		const result = await installSkills(ws.path, src.path, TEST_RENDER_VARS);
+
+		expect(result.installed.sort()).toEqual(["implement", "review"]);
+		expect(result.skipped).toEqual([]);
+		await expect(
+			readFile(join(ws.path, ".claude/skills/review/SKILL.md"), "utf8"),
+		).resolves.toBe("review body");
+		await expect(
+			readFile(join(ws.path, ".claude/skills/implement/SKILL.md"), "utf8"),
+		).resolves.toBe("implement body");
+	});
+
+	it("skips skills the target repo already ships under the same name", async () => {
+		await using ws = await withWorkspace();
+		await mkdir(join(ws.path, ".claude/skills/review"), { recursive: true });
+		await writeFile(
+			join(ws.path, ".claude/skills/review/SKILL.md"),
+			"repo-provided review",
+		);
+		await using src = await makeSkillsSource({
+			review: "LA review",
+			implement: "LA implement",
+		});
+
+		const result = await installSkills(ws.path, src.path, TEST_RENDER_VARS);
+
+		expect(result.installed).toEqual(["implement"]);
+		expect(result.skipped).toEqual(["review"]);
+		await expect(
+			readFile(join(ws.path, ".claude/skills/review/SKILL.md"), "utf8"),
+		).resolves.toBe("repo-provided review");
+	});
+
+	it("returns empty when the skills source directory is missing", async () => {
+		await using ws = await withWorkspace();
+		const missing = join(
+			tmpdir(),
+			`missing-skills-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+		);
+
+		const result = await installSkills(ws.path, missing, TEST_RENDER_VARS);
+
+		expect(result).toEqual({ installed: [], skipped: [] });
+		await expect(access(join(ws.path, ".claude/skills"))).rejects.toThrow();
+	});
+
+	it("ignores non-directory entries in the source", async () => {
+		await using ws = await withWorkspace();
+		await using src = await makeSkillsSource({ review: "review" });
+		await writeFile(join(src.path, "README.md"), "not a skill");
+
+		const result = await installSkills(ws.path, src.path, TEST_RENDER_VARS);
+
+		expect(result.installed).toEqual(["review"]);
+	});
+
+	it("renders {{ }} substitutions in .md files using the supplied vars", async () => {
+		await using ws = await withWorkspace();
+		await using src = await makeSkillsSource({
+			advisor:
+				"<commits>\n!`git log origin/{{ base_branch }}..HEAD --oneline`\n</commits>\n\nIssue: {{ issue.key }}, Branch: {{ branch }}.",
+		});
+
+		await installSkills(ws.path, src.path, TEST_RENDER_VARS);
+
+		const rendered = await readFile(
+			join(ws.path, ".claude/skills/advisor/SKILL.md"),
+			"utf8",
+		);
+		expect(rendered).toContain("!`git log origin/main..HEAD --oneline`");
+		expect(rendered).toContain(
+			`Issue: ${TEST_RENDER_VARS.issue.key}, Branch: feat/ABC-42-thing.`,
+		);
+	});
+
+	it("renders sibling .md files inside a skill directory, not just SKILL.md", async () => {
+		await using ws = await withWorkspace();
+		await using src = await makeSkillsSource({
+			review: "main on {{ base_branch }}",
+		});
+		await writeFile(
+			join(src.path, "review", "details.md"),
+			"detail for {{ branch }}",
+		);
+
+		await installSkills(ws.path, src.path, TEST_RENDER_VARS);
+
+		await expect(
+			readFile(join(ws.path, ".claude/skills/review/SKILL.md"), "utf8"),
+		).resolves.toBe("main on main");
+		await expect(
+			readFile(join(ws.path, ".claude/skills/review/details.md"), "utf8"),
+		).resolves.toBe("detail for feat/ABC-42-thing");
+	});
+
+	it("leaves non-.md files untouched", async () => {
+		await using ws = await withWorkspace();
+		await using src = await makeSkillsSource({
+			advisor: "see {{ base_branch }}",
+		});
+		await writeFile(
+			join(src.path, "advisor", "fixture.txt"),
+			"literal {{ base_branch }} stays",
+		);
+
+		await installSkills(ws.path, src.path, TEST_RENDER_VARS);
+
+		await expect(
+			readFile(join(ws.path, ".claude/skills/advisor/SKILL.md"), "utf8"),
+		).resolves.toBe("see main");
+		await expect(
+			readFile(join(ws.path, ".claude/skills/advisor/fixture.txt"), "utf8"),
+		).resolves.toBe("literal {{ base_branch }} stays");
 	});
 });

--- a/server/orchestrator/workspace.test.ts
+++ b/server/orchestrator/workspace.test.ts
@@ -5,6 +5,7 @@ import {
 	mkdir,
 	readFile,
 	rm,
+	stat,
 	utimes,
 	writeFile,
 } from "node:fs/promises";
@@ -17,6 +18,7 @@ import type { Issue } from "../trackers/types.ts";
 import { issueKey, issueNumber, repoSlug } from "../types/brands.ts";
 import {
 	createWorkspace,
+	installAgentDefaults,
 	installSkills,
 	pushBranch,
 	realRunShell,
@@ -527,5 +529,134 @@ describe("installSkills", () => {
 		await expect(
 			readFile(join(ws.path, ".claude/skills/advisor/fixture.txt"), "utf8"),
 		).resolves.toBe("literal {{ base_branch }} stays");
+	});
+});
+
+async function makeAgentDefaultsSource(
+	hookScripts: Record<string, string>,
+	settings: string,
+): Promise<{
+	hooksDir: string;
+	settingsFile: string;
+	[Symbol.asyncDispose](): Promise<void>;
+}> {
+	const root = join(
+		tmpdir(),
+		`defaults-src-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+	);
+	const hooksDir = join(root, "hooks");
+	await mkdir(hooksDir, { recursive: true });
+	for (const [name, body] of Object.entries(hookScripts)) {
+		const path = join(hooksDir, name);
+		await writeFile(path, body);
+		await chmod(path, 0o755);
+	}
+	const settingsFile = join(root, "agent-settings.json");
+	await writeFile(settingsFile, settings);
+	return {
+		hooksDir,
+		settingsFile,
+		async [Symbol.asyncDispose]() {
+			await rm(root, { recursive: true, force: true });
+		},
+	};
+}
+
+describe("installAgentDefaults", () => {
+	it("copies hook scripts to <ws>/.claude/hooks/ and the settings file to <ws>/.claude/settings.json", async () => {
+		await using ws = await withWorkspace();
+		await using src = await makeAgentDefaultsSource(
+			{
+				"block-dangerous-git.sh": "#!/usr/bin/env bash\necho block\n",
+				"validate-commit-message.sh": "#!/usr/bin/env bash\necho commit\n",
+			},
+			'{"hooks":{}}',
+		);
+
+		const result = await installAgentDefaults(
+			ws.path,
+			src.hooksDir,
+			src.settingsFile,
+		);
+
+		expect(result).toEqual({
+			hooksInstalled: ["block-dangerous-git.sh", "validate-commit-message.sh"],
+			settingsInstalled: true,
+		});
+		await expect(
+			readFile(join(ws.path, ".claude/hooks/block-dangerous-git.sh"), "utf8"),
+		).resolves.toBe("#!/usr/bin/env bash\necho block\n");
+		await expect(
+			readFile(join(ws.path, ".claude/settings.json"), "utf8"),
+		).resolves.toBe('{"hooks":{}}');
+	});
+
+	it("makes installed hook scripts executable", async () => {
+		await using ws = await withWorkspace();
+		await using src = await makeAgentDefaultsSource(
+			{ "noop.sh": "#!/usr/bin/env bash\nexit 0\n" },
+			"{}",
+		);
+
+		await installAgentDefaults(ws.path, src.hooksDir, src.settingsFile);
+
+		const info = await stat(join(ws.path, ".claude/hooks/noop.sh"));
+		expect(info.mode & 0o111).not.toBe(0);
+	});
+
+	it("overwrites an existing settings.json so target-repo customisations cannot bypass orchestrator policy", async () => {
+		await using ws = await withWorkspace();
+		await mkdir(join(ws.path, ".claude"), { recursive: true });
+		await writeFile(
+			join(ws.path, ".claude/settings.json"),
+			'{"target":"repo-provided"}',
+		);
+		await using src = await makeAgentDefaultsSource(
+			{},
+			'{"orchestrator":"wins"}',
+		);
+
+		await installAgentDefaults(ws.path, src.hooksDir, src.settingsFile);
+
+		await expect(
+			readFile(join(ws.path, ".claude/settings.json"), "utf8"),
+		).resolves.toBe('{"orchestrator":"wins"}');
+	});
+
+	it("still installs settings when the hooks source directory is missing", async () => {
+		await using ws = await withWorkspace();
+		const missingHooks = join(
+			tmpdir(),
+			`missing-hooks-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+		);
+		await using src = await makeAgentDefaultsSource({}, '{"k":"v"}');
+
+		const result = await installAgentDefaults(
+			ws.path,
+			missingHooks,
+			src.settingsFile,
+		);
+
+		expect(result).toEqual({ hooksInstalled: [], settingsInstalled: true });
+		await expect(
+			readFile(join(ws.path, ".claude/settings.json"), "utf8"),
+		).resolves.toBe('{"k":"v"}');
+	});
+
+	it("ignores non-file entries in the hooks source directory", async () => {
+		await using ws = await withWorkspace();
+		await using src = await makeAgentDefaultsSource(
+			{ "real.sh": "#!/usr/bin/env bash\nexit 0\n" },
+			"{}",
+		);
+		await mkdir(join(src.hooksDir, "nested"), { recursive: true });
+
+		const result = await installAgentDefaults(
+			ws.path,
+			src.hooksDir,
+			src.settingsFile,
+		);
+
+		expect(result.hooksInstalled).toEqual(["real.sh"]);
 	});
 });

--- a/server/orchestrator/workspace.ts
+++ b/server/orchestrator/workspace.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import {
 	access,
+	chmod,
 	cp,
 	mkdir,
 	readdir,
@@ -205,6 +206,49 @@ export async function installSkills(
 	}
 
 	return { installed, skipped };
+}
+
+const WORKSPACE_HOOKS_DIR = ".claude/hooks";
+const WORKSPACE_SETTINGS_FILE = ".claude/settings.json";
+
+// Hooks and settings are policy the orchestrator enforces, not skills the target
+// repo can opt out of. We always overwrite — the agent must not be able to bypass
+// the guardrails by committing a competing .claude/settings.json into its repo.
+export async function installAgentDefaults(
+	wsPath: string,
+	hooksSourceDir: string,
+	settingsSourceFile: string,
+): Promise<{ hooksInstalled: string[]; settingsInstalled: boolean }> {
+	const destHooks = join(wsPath, WORKSPACE_HOOKS_DIR);
+	await mkdir(destHooks, { recursive: true });
+
+	let entries: string[];
+	try {
+		entries = await readdir(hooksSourceDir);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+			entries = [];
+		} else {
+			throw err;
+		}
+	}
+
+	const hooksInstalled: string[] = [];
+	for (const name of entries) {
+		const source = join(hooksSourceDir, name);
+		const info = await stat(source).catch(() => null);
+		if (!info?.isFile()) continue;
+		const target = join(destHooks, name);
+		await cp(source, target);
+		// Restore the exec bit — `cp` honours mode but some FS layouts (npm pack,
+		// fat archives) can strip it. Hooks must be executable to fire.
+		await chmod(target, 0o755);
+		hooksInstalled.push(name);
+	}
+
+	await cp(settingsSourceFile, join(wsPath, WORKSPACE_SETTINGS_FILE));
+
+	return { hooksInstalled, settingsInstalled: true };
 }
 
 async function renderMarkdownInPlace(

--- a/server/orchestrator/workspace.ts
+++ b/server/orchestrator/workspace.ts
@@ -1,8 +1,18 @@
 import { execFile } from "node:child_process";
-import { access, mkdir, readdir, rm, stat } from "node:fs/promises";
+import {
+	access,
+	cp,
+	mkdir,
+	readdir,
+	readFile,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import type { Issue } from "../trackers/types.ts";
+import { renderPrompt } from "../workflow/workflow.ts";
 
 const exec = promisify(execFile);
 
@@ -36,12 +46,7 @@ export async function resolveWorkspaceEnvironment(
 	wsPath: string,
 	baseEnv: Record<string, string>,
 ): Promise<Record<string, string>> {
-	const nvmrcPath = join(wsPath, ".nvmrc");
-	try {
-		await access(nvmrcPath);
-	} catch {
-		return baseEnv;
-	}
+	if (!(await pathExists(join(wsPath, ".nvmrc")))) return baseEnv;
 
 	const { stdout } = await exec("bash", ["-c", ACTIVATE_NODE_VERSION_SCRIPT], {
 		cwd: wsPath,
@@ -139,6 +144,89 @@ export async function sweepWorkspaces(
 	return { removed };
 }
 
+async function pathExists(path: string): Promise<boolean> {
+	try {
+		await access(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+	const info = await stat(path).catch(() => null);
+	return info?.isDirectory() === true;
+}
+
+const WORKSPACE_SKILLS_DIR = ".claude/skills";
+
+type SkillRenderVars = {
+	issue: Issue;
+	branch: string;
+	base_branch: string;
+};
+
+// Target-repo wins on name collision: a skill committed under `.claude/skills/<name>`
+// in the workspace overrides LA's bundled one. We only render `{{ var }}` in the
+// copied .md files — Claude Code's own `!`cmd`` blocks still fire at skill-load time.
+export async function installSkills(
+	wsPath: string,
+	skillsSourceDir: string,
+	vars: SkillRenderVars,
+): Promise<{ installed: string[]; skipped: string[] }> {
+	let entries: string[];
+	try {
+		entries = await readdir(skillsSourceDir);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+			return { installed: [], skipped: [] };
+		}
+		throw err;
+	}
+
+	const destRoot = join(wsPath, WORKSPACE_SKILLS_DIR);
+	await mkdir(destRoot, { recursive: true });
+
+	const installed: string[] = [];
+	const skipped: string[] = [];
+
+	for (const name of entries) {
+		const source = join(skillsSourceDir, name);
+		if (!(await isDirectory(source))) continue;
+
+		const target = join(destRoot, name);
+		if (await pathExists(target)) {
+			skipped.push(name);
+			continue;
+		}
+		await cp(source, target, { recursive: true });
+		await renderMarkdownInPlace(target, vars);
+		installed.push(name);
+	}
+
+	return { installed, skipped };
+}
+
+async function renderMarkdownInPlace(
+	dir: string,
+	vars: SkillRenderVars,
+): Promise<void> {
+	const entries = await readdir(dir, { withFileTypes: true });
+	for (const entry of entries) {
+		const path = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			await renderMarkdownInPlace(path, vars);
+			continue;
+		}
+		if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+		const source = await readFile(path, "utf8");
+		const rendered = renderPrompt(source, vars);
+		if (rendered !== source) {
+			await writeFile(path, rendered);
+		}
+	}
+}
+
 const SETUP_SCRIPT_PATH = ".agent/setup.sh";
 
 export async function runRepoSetup(
@@ -146,13 +234,7 @@ export async function runRepoSetup(
 	runShell: RunShell,
 	env: Record<string, string>,
 ): Promise<boolean> {
-	const scriptPath = join(wsPath, SETUP_SCRIPT_PATH);
-	try {
-		await access(scriptPath);
-	} catch {
-		return false;
-	}
-
+	if (!(await pathExists(join(wsPath, SETUP_SCRIPT_PATH)))) return false;
 	await runShell(`bash ${SETUP_SCRIPT_PATH}`, wsPath, env);
 	return true;
 }

--- a/server/orchestrator/workspace.ts
+++ b/server/orchestrator/workspace.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import {
 	access,
+	appendFile,
 	chmod,
 	cp,
 	mkdir,
@@ -205,6 +206,11 @@ export async function installSkills(
 		installed.push(name);
 	}
 
+	await appendToGitExclude(
+		wsPath,
+		installed.map((name) => `${WORKSPACE_SKILLS_DIR}/${name}/`),
+	);
+
 	return { installed, skipped };
 }
 
@@ -248,7 +254,40 @@ export async function installAgentDefaults(
 
 	await cp(settingsSourceFile, join(wsPath, WORKSPACE_SETTINGS_FILE));
 
+	await appendToGitExclude(wsPath, [
+		`${WORKSPACE_HOOKS_DIR}/`,
+		WORKSPACE_SETTINGS_FILE,
+	]);
+
 	return { hooksInstalled, settingsInstalled: true };
+}
+
+// Per-clone exclude in .git/info/exclude — keeps orchestrator-injected files out
+// of `git status` without writing a .gitignore the agent would see in the tree.
+async function appendToGitExclude(
+	wsPath: string,
+	entries: string[],
+): Promise<void> {
+	const excludePath = join(wsPath, ".git", "info", "exclude");
+	let existing: string;
+	try {
+		existing = await readFile(excludePath, "utf8");
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw err;
+	}
+
+	const present = new Set(
+		existing
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0 && !line.startsWith("#")),
+	);
+	const toAppend = entries.filter((entry) => !present.has(entry));
+	if (toAppend.length === 0) return;
+
+	const prefix = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+	await appendFile(excludePath, `${prefix}${toAppend.join("\n")}\n`);
 }
 
 async function renderMarkdownInPlace(

--- a/skills/advisor/SKILL.md
+++ b/skills/advisor/SKILL.md
@@ -42,7 +42,7 @@ Use these as raw material for the "What I've tried" section below. Distil to att
 
 ## How to invoke
 
-Spawn a single sub-agent via the `Agent` tool. Use `subagent_type: "general-purpose"` with `model: claude-opus-4-7` (or the strongest model available in this environment).
+Spawn a single sub-agent via the `Agent` tool. Use `subagent_type: "general-purpose"` with `model: "opus"` — the SDK accepts only the family name (`"sonnet" | "opus" | "haiku"`), not full IDs.
 
 The prompt to the advisor must be **self-contained** — the advisor sees none of your prior conversation. Include, in this order:
 

--- a/skills/advisor/SKILL.md
+++ b/skills/advisor/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: advisor
+description: Escalation pattern for when you're stuck. Spawn a stronger model as a sub-agent, give it the failing context, apply its guidance, and continue. The advisor is a one-shot consultation — it does not take over the task. Use when you have tried the same approach three or more times and it keeps failing, when you cannot form a plausible hypothesis about why something is breaking, or when the user explicitly asks for "a second opinion" / "consult the advisor".
+---
+
+# Advisor
+
+You are stuck. The advisor is a one-shot consultation with a stronger model, not a hand-off. You bring it the problem, you receive guidance, you decide what to do with the guidance, and you keep working.
+
+## When to invoke
+
+Use the advisor when any of these are true:
+
+- You have tried the same fix three or more times and it keeps failing in the same place.
+- You cannot state a falsifiable hypothesis about why the current failure is happening.
+- You have two reasonable approaches and no basis to pick between them.
+- The user explicitly asked for a second opinion.
+
+Do **not** invoke the advisor for:
+
+- Tasks you simply haven't started — the advisor isn't a planner.
+- Tasks the user said should be quick — pause and ask the user instead.
+- Generic "is this code good?" reviews — that's the `review` skill.
+
+## Current state of the run
+
+Pre-loaded for you at skill-load time so you can compose the consultation prompt without scraping. These are live snapshots — they re-fetch every time this skill is loaded.
+
+<commits_so_far>
+!`git log origin/{{ base_branch }}..HEAD --oneline`
+</commits_so_far>
+
+<uncommitted_state>
+!`git status --short`
+</uncommitted_state>
+
+<uncommitted_diff>
+!`git diff`
+</uncommitted_diff>
+
+Use these as raw material for the "What I've tried" section below. Distil to attempts, expected vs actual, and the specific question — do **not** paste the snapshots verbatim into the consultation prompt. The advisor doesn't need every diff hunk; it needs the shape of what you tried and why it failed.
+
+## How to invoke
+
+Spawn a single sub-agent via the `Agent` tool. Use `subagent_type: "general-purpose"` with `model: claude-opus-4-7` (or the strongest model available in this environment).
+
+The prompt to the advisor must be **self-contained** — the advisor sees none of your prior conversation. Include, in this order:
+
+1. **What I'm trying to do.** One paragraph stating the goal and the user-visible behaviour the success state should have.
+2. **What I've tried.** Bullet list, one bullet per attempt. For each: what you did, what you expected, what actually happened. Include the verbatim error message or test output where possible.
+3. **What I've ruled out.** Bullet list. Helps the advisor avoid re-suggesting things you already know don't work.
+4. **The specific question.** End with one clear question. Examples:
+   - "Is my mental model of how X works wrong, and if so, where?"
+   - "Which of approach A or approach B is correct, and why?"
+   - "What hypothesis am I missing that would explain this failure?"
+
+Ask the advisor for: a verdict on what's going wrong, a concrete next step, and an explicit signal if the problem is outside what it can judge from the context given.
+
+Cap the response shape — for example, "Reply in under 300 words." The advisor's value is sharpness, not length.
+
+## Applying the guidance
+
+Treat the advisor's reply as a strong recommendation, not a command:
+
+- If the verdict makes sense and you can act on it directly, do so.
+- If the verdict points at something you can verify cheaply (a file to read, a command to run), verify before acting.
+- If the verdict contradicts what you've already established as true, surface the contradiction in your reasoning and re-check the contradicting evidence before changing course.
+
+When you continue working, summarise the advisor's verdict and your decision in one short paragraph so the next reader of the run log understands what changed and why.
+
+## Anti-patterns
+
+- **Repeated consultation.** One advisor call per stuck point. If the first call didn't unblock you, the problem is not "needs more consultation" — it's "stop and report what's missing to the user."
+- **Dumping the whole transcript.** The advisor doesn't need every step you took. Distil to attempts, expected vs actual, and the question.
+- **Acting on guidance without understanding it.** If you cannot restate the advisor's reasoning in your own words, you don't understand it well enough to apply it. Re-read or stop.
+
+## After the consultation
+
+The advisor sub-agent has exited; there is no ongoing session to return to. Resume the original task you were working on, applying or rejecting the advisor's guidance as described above. Do not spawn the advisor again for the same stuck point — if you are still blocked, stop and report what is missing to the user.

--- a/skills/advisor/SKILL.md
+++ b/skills/advisor/SKILL.md
@@ -24,8 +24,6 @@ Do **not** invoke the advisor for:
 
 ## Current state of the run
 
-Pre-loaded for you at skill-load time so you can compose the consultation prompt without scraping. These are live snapshots — they re-fetch every time this skill is loaded.
-
 <commits_so_far>
 !`git log origin/{{ base_branch }}..HEAD --oneline`
 </commits_so_far>

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: implement
+description: Work a single issue end-to-end on the current branch. Orient until you can predict the change, write a plan, execute the smallest change that resolves the issue, verify with the project's checks, and commit as you go. Defers to the tdd skill when the issue calls for test-first work or when the issue is a bug fix with a sensible test seam. Use when implementing an AFK issue, picking up a tracer-bullet ticket, or whenever the user asks to "implement the issue" / "work this ticket".
+---
+
+# Implement
+
+You are working a single issue end-to-end on a branch the orchestrator has already created and checked out. Commit your work as you go. Do **not** push and do **not** open a change request — the orchestrator owns those steps.
+
+## Process
+
+### 1. Orient until you can predict the change
+
+Use what's already in your context first. Read the issue body carefully. Then pull in only what you need to make the change correctly:
+
+- READMEs, ADRs, conventions docs in the area you'll touch.
+- The existing implementation and tests for what you're changing.
+
+Read independent files in parallel.
+
+If the issue's scope is genuinely unclear and you'd otherwise spend a long time exploring, spawn an `Explore` sub-agent with a tight question ("where is X defined and who calls it?"). Don't use it for trivial lookups — direct reads are faster.
+
+**Stop reading when you can name the files you'll touch and the approach you'll take.** Over-reading bloats context and hurts the change you're about to make.
+
+### 2. Decide whether to use TDD
+
+Use the **tdd** skill when either is true:
+
+- The issue describes test-first work or names automated tests as part of what to deliver.
+- The issue is a bug fix and the bug has a sensible test seam (a place where a failing repro test naturally lives).
+
+If either applies, load the tdd skill now via the `Skill` tool (`skill: "tdd"`) and follow its red-green-refactor loop for the rest of this issue.
+
+Otherwise, implement without forcing a test-first loop, and match the project's existing testing patterns when you add or update tests.
+
+### 3. Write the plan
+
+Before editing anything, write a short plan inside your reasoning:
+
+- The files you'll touch and what changes in each.
+- The behaviour you expect to add/change.
+- How you'll verify it.
+
+The plan is a checkpoint against rambling, not an artefact. It does not need to be committed or posted.
+
+### 4. Make the smallest change that resolves the issue
+
+Match the existing complexity in the codebase. Do not add:
+
+- Abstractions the issue did not ask for.
+- Defensive validation for scenarios that cannot happen.
+- Configurability "in case we need it later".
+- Backwards-compatibility shims, migration paths, or dual-read code unless the target repo's docs explicitly say to preserve compatibility.
+
+Three similar lines is better than a premature abstraction.
+
+### 5. Verify with the project's checks
+
+Discover the commands from the repo (`package.json`, `Makefile`, `justfile`, repo READMEs). Run independent commands in parallel where you can. Common shape:
+
+- A typecheck (`pnpm typecheck`, `tsc --noEmit`, `mypy`, …).
+- A test command (`pnpm test`, `vitest run`, `pytest`, …).
+- A linter only if the repo treats lint as part of CI; format-only tools can be skipped.
+
+If a check fails, fix the cause. Do **not** silence the check (no `--no-verify`, no skipped tests, no commented-out assertions) unless the issue explicitly authorises it.
+
+### 6. Commit as you go
+
+Match the repo's commit-message convention (read recent `git log`). Keep commits focused — one logical change per commit. The final commit set is what the reviewer will read.
+
+## Anti-patterns
+
+- **Horizontal slicing.** Don't write all the code for layer A, then all the code for layer B. Land one vertical slice end-to-end and verify it, then the next. See the `tdd` skill for the disciplined version of this.
+- **Speculative scope.** If you find adjacent issues while implementing, note them in your final message. Do not fix them here.
+- **Silent skipping.** If a check is broken in a way you can't fix in scope, say so explicitly in your final message rather than skipping it quietly.
+
+## Stopping
+
+If the issue is blocked or under-specified, stop without committing speculative work. Leave a final message describing what you found, what you tried, and what's missing. The orchestrator will route the issue back appropriately.
+
+Delete temporary scratch files before stopping. Do not push the branch. Do not open a change request.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -5,7 +5,7 @@ description: Work a single issue end-to-end on the current branch. Orient until 
 
 # Implement
 
-You are working a single issue end-to-end on a branch the orchestrator has already created and checked out. Commit your work as you go. Do **not** push and do **not** open a change request — the orchestrator owns those steps.
+You are working a single issue end-to-end on the current branch. Commit your work as you go.
 
 ## Process
 
@@ -76,6 +76,6 @@ Match the repo's commit-message convention (read recent `git log`). Keep commits
 
 ## Stopping
 
-If the issue is blocked or under-specified, stop without committing speculative work. Leave a final message describing what you found, what you tried, and what's missing. The orchestrator will route the issue back appropriately.
+If the issue is blocked or under-specified, stop without committing speculative work. Leave a final message describing what you found, what you tried, and what's missing.
 
-Delete temporary scratch files before stopping. Do not push the branch. Do not open a change request.
+Delete temporary scratch files before stopping.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -5,7 +5,7 @@ description: Two-axis review of the work on the current branch against its base.
 
 # Review
 
-Two-axis review of the diff between `HEAD` and the base branch you were given:
+Two-axis review of the diff between `HEAD` and its base branch:
 
 - **Standards** — does the code conform to this repo's documented standards?
 - **Spec** — does the code faithfully implement the originating issue?
@@ -18,9 +18,7 @@ This is review-as-refinement: surface every issue, then fix what matters on this
 
 ### 1. Pin the diff
 
-The base branch, the changed-file list, and the commit list have been pre-loaded into your context by the orchestrator. Do **not** re-run `git diff --name-status` or `git log` to fetch them — they are already there.
-
-You still need a diff command to hand to the sub-agents so they can read the actual hunks. Use:
+The diff command to hand to the sub-agents:
 
 ```
 git diff origin/<base>...HEAD
@@ -36,15 +34,10 @@ Anything in the repo that documents how code should be written. Common locations
 - `CONTRIBUTING.md`
 - `docs/coding-standards.md`, `docs/testing-standards.md`, `docs/architecture.md`
 - `docs/adr/` — architectural decisions are standards
-- `.editorconfig`, `biome.json`, `tsconfig.json` — note them but don't re-check what tooling enforces
 
 Collect the list. The Standards sub-agent will read them.
 
-### 3. Identify the spec
-
-The originating issue is the spec. If you were not given its full body, fetch it before spawning the sub-agent. If no spec exists — explicitly, not just "I couldn't find one" — the Spec sub-agent will skip and report "no spec available".
-
-### 4. Spawn both sub-agents in parallel
+### 3. Spawn both sub-agents in parallel
 
 Send a single message with two `Agent` tool calls. Use the `general-purpose` subagent for both.
 
@@ -60,9 +53,7 @@ Send a single message with two `Agent` tool calls. Use the `general-purpose` sub
 - The issue body verbatim.
 - The brief: "Read the issue. Then read the diff. Report: (a) requirements the issue asked for that are missing or partial; (b) behaviour in the diff that wasn't asked for (scope creep); (c) requirements that look implemented but where the implementation looks wrong. Quote the issue line for each finding. Under 400 words."
 
-If the issue body is not available, skip the Spec sub-agent and note it in the final report.
-
-### 5. Decide what to fix
+### 4. Decide what to fix
 
 Stay scoped to this issue. Fix anything that affects:
 
@@ -73,13 +64,13 @@ Stay scoped to this issue. Fix anything that affects:
 
 Note pre-existing problems unrelated to this change in your final message and leave them as-is. It is better to surface a finding and decide it doesn't need fixing than to silently drop a real bug.
 
-### 6. Apply fixes and verify
+### 5. Apply fixes and verify
 
-Apply fixes directly on the branch, one focused commit per logical refinement. After fixing, re-run the project's checks (`pnpm typecheck`, `pnpm test`, or whatever the repo declares). If a check cannot run, say so in your final message.
+Apply fixes directly on the branch, one focused commit per logical refinement. After fixing, re-run the project's typecheck and test commands — discover them from the repo (`package.json`, `Makefile`, `justfile`, READMEs). If a check cannot run, say so in your final message.
 
-### 7. Report
+### 6. Report
 
-The final message is consumed by both a human reviewer and the orchestrator's summariser. Use this exact shape — three top-level sections, in this order, no other top-level headings:
+Use this exact shape — three top-level sections, in this order, no other top-level headings:
 
 ```
 ## Standards
@@ -88,13 +79,13 @@ The final message is consumed by both a human reviewer and the orchestrator's su
 
 ## Spec
 
-<verbatim Spec sub-agent report, or "No spec available." if step 3 had no issue body>
+<verbatim Spec sub-agent report>
 
 ## Summary
 
 - Standards: <N> findings — <M> fixed, <K> left
 - Spec: <N> findings — <M> fixed, <K> left
-- Checks: <pnpm typecheck: pass|fail|skipped>, <pnpm test: pass|fail|skipped>, …
+- Checks: <typecheck: pass|fail|skipped>, <tests: pass|fail|skipped>, …
 - Outcome: <changes-applied | no-changes>
 ```
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -117,5 +117,4 @@ Reporting them separately stops one axis from masking the other.
 ## Stopping
 
 - If the branch needs no changes, make none. End with "no changes" plus the two reports.
-- Do **not** push the branch. Do **not** open a change request. The orchestrator owns those steps.
 - Do **not** restructure code beyond what the findings call for.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: review
+description: Two-axis review of the work on the current branch against its base. The Standards axis checks the diff against this repo's documented coding/testing standards. The Spec axis checks the diff against the originating issue. Both axes run as parallel sub-agents so they don't pollute each other's context. Use when reviewing a branch produced by an AFK agent run, refining the diff before opening a change request, or whenever the user asks to "review the changes" / "review this branch".
+---
+
+# Review
+
+Two-axis review of the diff between `HEAD` and the base branch you were given:
+
+- **Standards** — does the code conform to this repo's documented standards?
+- **Spec** — does the code faithfully implement the originating issue?
+
+Both axes run as **parallel sub-agents** so they don't pollute each other's context. This skill aggregates the findings and applies the fixes it considers in-scope.
+
+This is review-as-refinement: surface every issue, then fix what matters on this branch. "Looks good" is a valid outcome — make no changes if the branch is already right.
+
+## Process
+
+### 1. Pin the diff
+
+The base branch, the changed-file list, and the commit list have been pre-loaded into your context by the orchestrator. Do **not** re-run `git diff --name-status` or `git log` to fetch them — they are already there.
+
+You still need a diff command to hand to the sub-agents so they can read the actual hunks. Use:
+
+```
+git diff origin/<base>...HEAD
+```
+
+Three-dot, so the comparison is against the merge-base. The sub-agents will run this themselves (or narrower variants of it) against the specific files they need.
+
+### 2. Identify the standards sources
+
+Anything in the repo that documents how code should be written. Common locations:
+
+- `CLAUDE.md`, `AGENTS.md`
+- `CONTRIBUTING.md`
+- `docs/coding-standards.md`, `docs/testing-standards.md`, `docs/architecture.md`
+- `docs/adr/` — architectural decisions are standards
+- `.editorconfig`, `biome.json`, `tsconfig.json` — note them but don't re-check what tooling enforces
+
+Collect the list. The Standards sub-agent will read them.
+
+### 3. Identify the spec
+
+The originating issue is the spec. If you were not given its full body, fetch it before spawning the sub-agent. If no spec exists — explicitly, not just "I couldn't find one" — the Spec sub-agent will skip and report "no spec available".
+
+### 4. Spawn both sub-agents in parallel
+
+Send a single message with two `Agent` tool calls. Use the `general-purpose` subagent for both.
+
+**Standards sub-agent prompt** — include:
+
+- The diff command and commit list.
+- The list of standards files from step 2.
+- The brief: "Read the standards docs. Then read the diff. Report — per file/hunk where relevant — every place the diff violates a documented standard. Cite the standard (file + the rule). Distinguish hard violations from judgement calls. Skip anything tooling enforces. Under 400 words."
+
+**Spec sub-agent prompt** — include:
+
+- The diff command and commit list.
+- The issue body verbatim.
+- The brief: "Read the issue. Then read the diff. Report: (a) requirements the issue asked for that are missing or partial; (b) behaviour in the diff that wasn't asked for (scope creep); (c) requirements that look implemented but where the implementation looks wrong. Quote the issue line for each finding. Under 400 words."
+
+If the issue body is not available, skip the Spec sub-agent and note it in the final report.
+
+### 5. Decide what to fix
+
+Stay scoped to this issue. Fix anything that affects:
+
+- correctness
+- behaviour matching the issue
+- tests for the change
+- fit with project conventions
+
+Note pre-existing problems unrelated to this change in your final message and leave them as-is. It is better to surface a finding and decide it doesn't need fixing than to silently drop a real bug.
+
+### 6. Apply fixes and verify
+
+Apply fixes directly on the branch, one focused commit per logical refinement. After fixing, re-run the project's checks (`pnpm typecheck`, `pnpm test`, or whatever the repo declares). If a check cannot run, say so in your final message.
+
+### 7. Report
+
+The final message is consumed by both a human reviewer and the orchestrator's summariser. Use this exact shape — three top-level sections, in this order, no other top-level headings:
+
+```
+## Standards
+
+<verbatim Standards sub-agent report, or "No standards sources found." if step 2 turned up nothing>
+
+## Spec
+
+<verbatim Spec sub-agent report, or "No spec available." if step 3 had no issue body>
+
+## Summary
+
+- Standards: <N> findings — <M> fixed, <K> left
+- Spec: <N> findings — <M> fixed, <K> left
+- Checks: <pnpm typecheck: pass|fail|skipped>, <pnpm test: pass|fail|skipped>, …
+- Outcome: <changes-applied | no-changes>
+```
+
+Rules:
+
+- Paste the sub-agent reports verbatim. Do **not** merge, rerank, or summarise across the two axes — they are deliberately separate so a human reviewer can see them independently.
+- The Summary counts must reconcile with the reports above: every finding is either fixed in this branch or listed as left.
+- "Left" findings should be ones you deliberately scoped out (pre-existing, out of scope for this issue, or judgement calls you rejected). Name them in the relevant axis report so a human can re-litigate.
+- `Outcome: no-changes` is valid and expected when the branch is already right.
+
+## Why two axes
+
+A change can pass one axis and fail the other:
+
+- Code that follows every standard but implements the wrong thing → **Standards pass, Spec fail.**
+- Code that does exactly what the issue asked but breaks the project's conventions → **Spec pass, Standards fail.**
+
+Reporting them separately stops one axis from masking the other.
+
+## Stopping
+
+- If the branch needs no changes, make none. End with "no changes" plus the two reports.
+- Do **not** push the branch. Do **not** open a change request. The orchestrator owns those steps.
+- Do **not** restructure code beyond what the findings call for.

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: tdd
+description: Test-driven development with a red-green-refactor loop. Drive one behaviour at a time as a vertical slice — write a failing test, write the minimal code to pass it, repeat. Survives refactors because tests verify behaviour through public interfaces, not implementation details. Use when the issue calls for test-first work, when fixing a bug that has a sensible test seam, or when the user asks to "TDD this" / "red-green-refactor" / "test-first".
+---
+
+# Test-Driven Development
+
+## Philosophy
+
+**Core principle:** tests verify behaviour through public interfaces, not implementation details. Code can change entirely; tests shouldn't.
+
+**Good tests** are integration-style: they exercise real code paths through public APIs. They describe _what_ the system does, not _how_ it does it. A good test reads like a specification — "user can checkout with a valid cart" tells you exactly what capability exists. These tests survive refactors because they don't care about internal structure.
+
+**Bad tests** are coupled to implementation. They mock internal collaborators, test private methods, or verify through external means (querying a database directly instead of using the interface). The warning sign: your test breaks when you refactor, but behaviour hasn't changed. If you rename an internal function and tests fail, those tests were testing implementation, not behaviour.
+
+## Anti-pattern: horizontal slicing
+
+**DO NOT write all tests first, then all implementation.** This is "horizontal slicing" — treating RED as "write all tests" and GREEN as "write all code."
+
+This produces **crap tests**:
+
+- Tests written in bulk test _imagined_ behaviour, not _actual_ behaviour.
+- You end up testing the _shape_ of things (data structures, function signatures) rather than user-facing behaviour.
+- Tests become insensitive to real changes — they pass when behaviour breaks, fail when behaviour is fine.
+- You outrun your headlights, committing to test structure before understanding the implementation.
+
+**Correct approach:** vertical slices via tracer bullets. One test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because you just wrote the code, you know exactly what behaviour matters and how to verify it.
+
+- Wrong: `test1, test2, …, testN` then `impl1, impl2, …, implN`.
+- Right: `test1 → impl1 → test2 → impl2 → …`
+
+## Workflow
+
+### 1. Plan the behaviours
+
+Before writing any code:
+
+- List the behaviours to test, ranked by importance. Critical paths and complex logic first.
+- Identify the public interface you're testing against. Avoid private functions and internal collaborators.
+- Sketch the test seam — where the test naturally lives. If there is no clean seam, that itself is the finding (note it and either restructure or implement without TDD).
+
+You cannot test everything. Focus testing effort on critical paths, not every possible edge case.
+
+### 2. Tracer bullet
+
+Write ONE test that confirms ONE thing about the system:
+
+```
+RED:   Write test for first behaviour → test fails
+GREEN: Write minimal code to pass → test passes
+```
+
+This is the tracer bullet — proves the path works end-to-end.
+
+### 3. Incremental loop
+
+For each remaining behaviour:
+
+```
+RED:   Write next test → fails
+GREEN: Minimal code to pass → passes
+```
+
+Rules:
+
+- One test at a time.
+- Only enough code to pass the current test.
+- Don't anticipate future tests.
+- Keep tests focused on observable behaviour.
+
+### 4. Refactor
+
+After all tests pass, look for refactor candidates:
+
+- Extract duplication.
+- Deepen modules — move complexity behind simple interfaces.
+- Consider what new code reveals about existing code.
+- Run tests after each refactor step.
+
+**Never refactor while RED.** Get to GREEN first.
+
+## Checklist per cycle
+
+```
+[ ] Test describes behaviour, not implementation
+[ ] Test uses public interface only
+[ ] Test would survive an internal refactor
+[ ] Code is minimal for this test
+[ ] No speculative features added
+```
+
+## Bug-fix variant
+
+When TDD is being used to lock down a bug fix:
+
+1. Turn the minimised repro into a failing test at the correct seam.
+2. Watch it fail (confirms the test would catch a regression).
+3. Apply the fix.
+4. Watch it pass.
+5. Re-run the original repro to confirm the fix actually addresses the user-visible symptom, not a nearby one.
+
+If there is no correct seam for the regression test — the bug needs multiple callers, or the unit test can't replicate the chain that triggered it — say so explicitly and implement the fix without a forced shallow test. A misleading regression test is worse than no test.

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -44,8 +44,7 @@ steps:
       {{ issue.description }}
       </issue>
 
-      Use the `implement` skill. Commit your work as you go. Do not push
-      and do not open a change request — the orchestrator owns those.
+      Use the `implement` skill.
 
   - name: review
     model: claude-opus-4-7
@@ -68,8 +67,7 @@ steps:
       Use the `review` skill. The file list and commit list above are
       pre-loaded — pass them through to the sub-agents along with the
       diff command `git diff origin/{{ base_branch }}...HEAD`. Apply
-      fixes directly to this branch. Do not push and do not open a
-      change request — the orchestrator owns those.
+      fixes directly to this branch.
 
   - name: summarise
     model: claude-haiku-4-5

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -37,55 +37,23 @@ steps:
   - name: implement
     model: claude-sonnet-4-6
     prompt: |
-      <role>
-      You are an autonomous software engineer working a single issue
-      end-to-end on branch `{{ branch }}`, cut from `{{ base_branch }}`.
-      Commit your work as you go. Do not push or open a pull request.
-      </role>
+      You are working issue {{ issue.key }} end-to-end on branch
+      `{{ branch }}`, cut from `{{ base_branch }}`.
 
-      <issue key="{{ issue.key }}" title="{{ issue.title }}">
+      <issue title="{{ issue.title }}">
       {{ issue.description }}
       </issue>
 
-      # Approach
-
-      1. **Orient until you can predict the change.** Use what's already
-         in your context first. Pull in READMEs, ADRs, or surrounding
-         code only until you have enough confidence to make the change
-         correctly. Stop reading when you can name the files you'll
-         touch and the approach you'll take.
-
-      2. **Investigate before editing.** Locate the existing
-         implementation and tests for the area you'll change. Read the
-         code before claiming anything about it. Read independent files
-         in parallel.
-
-      3. **Make the smallest change that resolves the issue.** Match
-         the existing complexity in the codebase. Add abstractions,
-         defensive checks, or configurability only when the issue calls
-         for them.
-
-      4. **Verify with the project's checks** before committing. Discover 
-        the commands from the repo.
-
-      # Stopping
-
-      Delete temporary scratch files. If the issue is blocked or
-      under-specified, stop without committing speculative work and
-      leave a final message describing what you found and what's missing.
+      Use the `implement` skill. Commit your work as you go. Do not push
+      and do not open a change request — the orchestrator owns those.
 
   - name: review
     model: claude-opus-4-7
     prompt: |
-      <role>
-      Review the changes on branch `{{ branch }}` against
-      `{{ base_branch }}`. This is review-as-refinement: find issues, fix
-      them on this branch, commit the refinements. If the branch is already
-      good, make no changes — "looks good" is a valid outcome. Do not push
-      or open a pull request.
-      </role>
+      Review the work on branch `{{ branch }}` against `{{ base_branch }}`
+      for issue {{ issue.key }}.
 
-      <issue key="{{ issue.key }}" title="{{ issue.title }}">
+      <issue title="{{ issue.title }}">
       {{ issue.description }}
       </issue>
 
@@ -97,48 +65,11 @@ steps:
       !`git log origin/{{ base_branch }}..HEAD --oneline`
       </commits>
 
-      <diff base="origin/{{ base_branch }}" head="HEAD">
-      !`git diff origin/{{ base_branch }}...HEAD`
-      </diff>
-
-      # Approach
-
-      1. **Orient until you can judge the change.** Use what's already
-         in your context first. Pull in conventions docs, ADRs, or
-         surrounding code only until you have enough confidence to tell
-         whether the diff fits the project. Stop reading when you can
-         defend a verdict.
-
-      2. **Read changed files in their surrounding context.** The diff
-         shows what changed; read the surrounding code to judge whether
-         the change is correct, complete, and consistent with how this
-         codebase actually works. Read independent files in parallel.
-
-      3. **Find issues exhaustively before deciding what to fix.** At
-         the finding stage, surface every concern — correctness,
-         untested behaviour, unhandled cases, drift from conventions,
-         broken docs, stale comments. Filter for importance only when
-         you decide what to fix in step 5. It is better to surface a
-         finding and decide it doesn't need fixing than to silently
-         drop a real bug.
-
-      4. **Verify the project's checks.** Discover the commands from
-         the repo and run them; run independent commands in parallel.
-         If a check cannot run (e.g. missing dependency), say so in your
-         final message.
-
-      5. **Decide what to fix on this branch.** Stay scoped to this
-         issue: fix anything that affects correctness, behaviour
-         matching the issue, tests for the change, or fit with project
-         conventions. Note pre-existing problems unrelated to this
-         change in your final message and leave them as-is.
-
-      6. **Apply fixes directly and commit.** Keep each refinement
-         focused.
-
-      # Stopping
-
-      If the branch needs no changes, make none.
+      Use the `review` skill. The file list and commit list above are
+      pre-loaded — pass them through to the sub-agents along with the
+      diff command `git diff origin/{{ base_branch }}...HEAD`. Apply
+      fixes directly to this branch. Do not push and do not open a
+      change request — the orchestrator owns those.
 
   - name: summarise
     model: claude-haiku-4-5


### PR DESCRIPTION
## Summary
- LA now ships a `skills/` tree at the repo root (advisor, implement, review, tdd) and installs it into `<workspace>/.claude/skills/` on each run, between branch resolution and repo setup
- `installSkills` renders `{{ issue.* }}`, `{{ branch }}`, `{{ base_branch }}` into every `.md` file as it lands so identifiers are baked into the workspace copy; target-repo wins on name collision
- Trimmed `workflow.yaml`'s `implement` prompt now that the bundled skill carries the body

## Test plan
- [ ] `pnpm test server/orchestrator/workspace.test.ts` covers install, name-collision skip, missing source dir, non-dir entries, template rendering across siblings, and non-`.md` files left untouched
- [ ] End-to-end: run an issue and confirm `<workspace>/.claude/skills/` is populated with rendered SKILL.md files, that `skills_installed` / `skills_skipped` appear in canonical log, and that the `skills installed: N (skipped M)` system event surfaces in the run timeline
- [ ] Drop a `.claude/skills/implement/` in a target repo and confirm it's preserved (not overwritten by LA's bundled one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)