### PR TITLE
Shorten bash paths, name skills in transcript, cap bash timeouts, prefix skills with la-

### DIFF
--- a/agent-settings.json
+++ b/agent-settings.json
@@ -11,6 +11,10 @@
 					{
 						"type": "command",
 						"command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/validate-commit-message.sh"
+					},
+					{
+						"type": "command",
+						"command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/cap-bash-timeout.sh"
 					}
 				]
 			}

--- a/hooks/cap-bash-timeout.sh
+++ b/hooks/cap-bash-timeout.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# PreToolUse hook for the Bash tool.
+#
+# Why: the SDK's Bash tool only SIGKILLs the immediate child shell on timeout,
+# so grandchildren (vitest workers, npm subprocesses) can survive and pin the
+# tool call open indefinitely. We rewrite the command to run the inner work in
+# its own process group via `set -m` and SIGKILL `-$pid` (the whole group)
+# from a sibling watchdog. Exit 124 mirrors `timeout(1)`'s convention so the
+# agent gets a recognisable timeout signal alongside the stderr explanation.
+#
+# This hook must run AFTER any hook that inspects `.tool_input.command` for
+# patterns (e.g. block-dangerous-git.sh), because once we rewrite the command
+# subsequent hooks would only see the wrapped form. The PreToolUse chain in
+# agent-settings.json controls that ordering.
+set -euo pipefail
+
+readonly INPUT=$(cat)
+readonly CAP_MS=180000
+
+readonly COMMAND=$(jq -r '.tool_input.command // empty' <<<"$INPUT")
+readonly REQUESTED=$(jq -r '.tool_input.timeout // empty' <<<"$INPUT")
+
+# Malformed/empty input: emit a no-op decision rather than blocking by exiting
+# non-zero. The SDK treats a non-zero hook exit as "deny tool call".
+if [[ -z "$COMMAND" ]]; then
+  jq '{hookSpecificOutput: {hookEventName: "PreToolUse"}}' <<<"$INPUT"
+  exit 0
+fi
+
+if [[ -z "$REQUESTED" ]] || (( REQUESTED > CAP_MS )); then
+  TIMEOUT_MS=$CAP_MS
+else
+  TIMEOUT_MS=$REQUESTED
+fi
+readonly TIMEOUT_MS
+# Round up so a 1500ms request still gets a >=2s watchdog.
+readonly TIMEOUT_S=$(( (TIMEOUT_MS + 999) / 1000 ))
+
+# Base64-encode the agent's command so we never have to escape arbitrary shell
+# into the wrapper. The base64 alphabet is shell-safe (no quoting needed).
+readonly ENCODED=$(printf '%s' "$COMMAND" | base64 | tr -d '\n')
+
+# We invoke `bash -c` explicitly because the SDK may select zsh as the
+# persistent shell (it picks bash or zsh based on CLAUDE_CODE_SHELL / SHELL /
+# discovery), and `set -m` is rejected in non-interactive zsh.
+readonly INNER=$(cat <<EOF
+set -m
+eval "\$(echo $ENCODED | base64 -d)" &
+pid=\$!
+(
+  sleep $TIMEOUT_S
+  echo "[cap-bash-timeout] killed pgroup after ${TIMEOUT_S}s (limit=${TIMEOUT_MS}ms, cap=${CAP_MS}ms) -- enforced by hooks/cap-bash-timeout.sh because the SDK only SIGKILLs the immediate shell. Check for leaked file/socket/worker handles, watch processes, or unawaited backgrounded subshells in the command." >&2
+  kill -KILL -\$pid 2>/dev/null
+) &
+wpid=\$!
+wait \$pid
+rc=\$?
+# Watchdog gone => it fired => normalise rc to timeout(1)'s 124.
+if ! kill -0 \$wpid 2>/dev/null; then
+  rc=124
+else
+  kill \$wpid 2>/dev/null
+fi
+exit \$rc
+EOF
+)
+readonly INNER_B64=$(printf '%s' "$INNER" | base64 | tr -d '\n')
+
+# Outer command uses `bash -c "$(...)"` (works in both bash and zsh outer
+# shells) and passes the decoded inner script as a single argument so the
+# inner command's stdin isn't hijacked by the decoding pipe.
+readonly WRAPPED="bash -c \"\$(echo $INNER_B64 | base64 -d)\""
+
+jq --arg cmd "$WRAPPED" --argjson t "$TIMEOUT_MS" \
+  '{hookSpecificOutput: {hookEventName: "PreToolUse", updatedInput: (.tool_input | .command = $cmd | .timeout = $t)}}' \
+  <<<"$INPUT"

--- a/server/orchestrator/agent-logging.test.ts
+++ b/server/orchestrator/agent-logging.test.ts
@@ -147,6 +147,33 @@ describe("emitAgentMessageEvents", () => {
 		]);
 	});
 
+	it("renders bash paths relative to the workdir, including the /private symlink prefix", () => {
+		const { ctx, emitted } = captureCtx();
+		emitAgentMessageEvents(
+			toolUseMsg("Bash", {
+				command:
+					"ls /private/tmp/local-agent-workspaces/AIENG-2308-66c8761c/docs/",
+			}),
+			{
+				ctx,
+				stepName: "implement",
+				cwd: "/tmp/local-agent-workspaces/AIENG-2308-66c8761c",
+			},
+		);
+		expect(emitted).toEqual([
+			{
+				kind: "tool:bash",
+				stepName: "implement",
+				data: {
+					command: "ls docs/",
+					cwd: "/tmp/local-agent-workspaces/AIENG-2308-66c8761c",
+					state: "running",
+					exitCode: null,
+				},
+			},
+		]);
+	});
+
 	it("emits tool:other for unrecognised tools, summarising via known input fields", () => {
 		const { ctx, emitted } = captureCtx();
 		emitAgentMessageEvents(
@@ -177,6 +204,21 @@ describe("emitAgentMessageEvents", () => {
 				kind: "tool:other",
 				stepName: "implement",
 				data: { tool: "Agent", summary: "find duplicate detection sites" },
+			},
+		]);
+	});
+
+	it("names the invoked skill in the tool:other summary for Skill", () => {
+		const { ctx, emitted } = captureCtx();
+		emitAgentMessageEvents(
+			toolUseMsg("Skill", { skill: "review", args: "PR #42" }),
+			{ ctx, stepName: "implement", cwd: "/work" },
+		);
+		expect(emitted).toEqual([
+			{
+				kind: "tool:other",
+				stepName: "implement",
+				data: { tool: "Skill", summary: "review" },
 			},
 		]);
 	});

--- a/server/orchestrator/agent-logging.ts
+++ b/server/orchestrator/agent-logging.ts
@@ -106,10 +106,21 @@ function emitToolEvent(
 				kind: "tool:bash",
 				stepName,
 				data: {
-					command: stringInput(input["command"]),
+					command: shortenCommand(stringInput(input["command"]), cwd),
 					cwd,
 					state: "running",
 					exitCode: null,
+				},
+			});
+			return;
+		}
+		case "Skill": {
+			ctx.emit({
+				kind: "tool:other",
+				stepName,
+				data: {
+					tool: "Skill",
+					summary: stringInput(input["skill"]).slice(0, 100),
 				},
 			});
 			return;
@@ -152,4 +163,13 @@ function shortPath(fullPath: string, workDir: string): string {
 		return fullPath.slice(workDir.length + 1);
 	}
 	return fullPath;
+}
+
+function shortenCommand(command: string, workDir: string): string {
+	if (workDir === "") return command;
+	return command
+		.split(`/private${workDir}/`)
+		.join("")
+		.split(`${workDir}/`)
+		.join("");
 }

--- a/skills/la-advisor/SKILL.md
+++ b/skills/la-advisor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: advisor
+name: la-advisor
 description: Escalation pattern for when you're stuck. Spawn a stronger model as a sub-agent, give it the failing context, apply its guidance, and continue. The advisor is a one-shot consultation — it does not take over the task. Use when you have tried the same approach three or more times and it keeps failing, when you cannot form a plausible hypothesis about why something is breaking, or when the user explicitly asks for "a second opinion" / "consult the advisor".
 ---
 
@@ -20,7 +20,7 @@ Do **not** invoke the advisor for:
 
 - Tasks you simply haven't started — the advisor isn't a planner.
 - Tasks the user said should be quick — pause and ask the user instead.
-- Generic "is this code good?" reviews — that's the `review` skill.
+- Generic "is this code good?" reviews — that's the `la-review` skill.
 
 ## Current state of the run
 

--- a/skills/la-implement/SKILL.md
+++ b/skills/la-implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: implement
-description: Work a single issue end-to-end on the current branch. Orient until you can predict the change, write a plan, execute the smallest change that resolves the issue, verify with the project's checks, and commit as you go. Defers to the tdd skill when the issue calls for test-first work or when the issue is a bug fix with a sensible test seam. Use when implementing an AFK issue, picking up a tracer-bullet ticket, or whenever the user asks to "implement the issue" / "work this ticket".
+name: la-implement
+description: Work a single issue end-to-end on the current branch. Orient until you can predict the change, write a plan, execute the smallest change that resolves the issue, verify with the project's checks, and commit as you go. Defers to the la-tdd skill when the issue calls for test-first work or when the issue is a bug fix with a sensible test seam. Use when implementing an AFK issue, picking up a tracer-bullet ticket, or whenever the user asks to "implement the issue" / "work this ticket".
 ---
 
 # Implement
@@ -24,12 +24,12 @@ If the issue's scope is genuinely unclear and you'd otherwise spend a long time 
 
 ### 2. Decide whether to use TDD
 
-Use the **tdd** skill when either is true:
+Use the **la-tdd** skill when either is true:
 
 - The issue describes test-first work or names automated tests as part of what to deliver.
 - The issue is a bug fix and the bug has a sensible test seam (a place where a failing repro test naturally lives).
 
-If either applies, load the tdd skill now via the `Skill` tool (`skill: "tdd"`) and follow its red-green-refactor loop for the rest of this issue.
+If either applies, load the la-tdd skill now via the `Skill` tool (`skill: "la-tdd"`) and follow its red-green-refactor loop for the rest of this issue.
 
 Otherwise, implement without forcing a test-first loop, and match the project's existing testing patterns when you add or update tests.
 
@@ -70,7 +70,7 @@ Match the repo's commit-message convention (read recent `git log`). Keep commits
 
 ## Anti-patterns
 
-- **Horizontal slicing.** Don't write all the code for layer A, then all the code for layer B. Land one vertical slice end-to-end and verify it, then the next. See the `tdd` skill for the disciplined version of this.
+- **Horizontal slicing.** Don't write all the code for layer A, then all the code for layer B. Land one vertical slice end-to-end and verify it, then the next. See the `la-tdd` skill for the disciplined version of this.
 - **Speculative scope.** If you find adjacent issues while implementing, note them in your final message. Do not fix them here.
 - **Silent skipping.** If a check is broken in a way you can't fix in scope, say so explicitly in your final message rather than skipping it quietly.
 

--- a/skills/la-review/SKILL.md
+++ b/skills/la-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: review
+name: la-review
 description: Two-axis review of the work on the current branch against its base. The Standards axis checks the diff against this repo's documented coding/testing standards. The Spec axis checks the diff against the originating issue. Both axes run as parallel sub-agents so they don't pollute each other's context. Use when reviewing a branch produced by an AFK agent run, refining the diff before opening a change request, or whenever the user asks to "review the changes" / "review this branch".
 ---
 

--- a/skills/la-tdd/SKILL.md
+++ b/skills/la-tdd/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tdd
+name: la-tdd
 description: Test-driven development with a red-green-refactor loop. Drive one behaviour at a time as a vertical slice — write a failing test, write the minimal code to pass it, repeat. Survives refactors because tests verify behaviour through public interfaces, not implementation details. Use when the issue calls for test-first work, when fixing a bug that has a sensible test seam, or when the user asks to "TDD this" / "red-green-refactor" / "test-first".
 ---
 

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -44,7 +44,7 @@ steps:
       {{ issue.description }}
       </issue>
 
-      Use the `implement` skill.
+      Use the `la-implement` skill.
 
   - name: review
     model: claude-opus-4-7
@@ -64,7 +64,7 @@ steps:
       !`git log origin/{{ base_branch }}..HEAD --oneline`
       </commits>
 
-      Use the `review` skill. The file list and commit list above are
+      Use the `la-review` skill. The file list and commit list above are
       pre-loaded — pass them through to the sub-agents along with the
       diff command `git diff origin/{{ base_branch }}...HEAD`. Apply
       fixes directly to this branch.


### PR DESCRIPTION
## Summary

Three independent change-sets bundled per request:

- **Transcript fixes (`server/orchestrator/agent-logging.ts`)**
  - Bash commands are emitted with workspace-relative paths — strips both `${cwd}/` and `/private${cwd}/` (macOS `/tmp` symlink) anywhere in the command. `ls /private/tmp/local-agent-workspaces/AIENG-2308-…/docs/` now renders as `ls docs/`.
  - `Skill` tool invocations now emit a `tool:other` with `summary` set to the invoked skill name, so the dashboard shows `Skill review` instead of an unnamed `Skill` badge.
  - Both behaviours covered by new tests in `agent-logging.test.ts`.
- **Bash timeout cap (`hooks/cap-bash-timeout.sh` + `agent-settings.json`)** — PreToolUse hook wraps each Bash command in its own process group via `set -m`, so a sibling watchdog can SIGKILL `-$pid` (the whole group) on timeout. Works around the SDK only killing the immediate child shell, which lets grandchildren (vitest workers, npm subprocesses) survive and pin the tool call open. Cap is 180s; exits 124 (mirrors `timeout(1)`) so the agent gets a recognisable timeout signal. Command is base64-passed to avoid arbitrary shell escaping.
- **Skill renames** — bundled skills prefixed with `la-` (`la-advisor`, `la-implement`, `la-review`, `la-tdd`) to avoid collisions with host-provided skills. `workflow.yaml` and cross-skill references updated to match.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (312 passed)
- [ ] Confirm new Bash rows in the dashboard render workspace-relative paths against a live run
- [ ] Confirm `Skill` rows show the skill name in the dashboard against a live run
- [ ] Confirm the timeout hook fires (kill long-running command, watch for `[cap-bash-timeout] killed pgroup after …` on stderr and exit 124)
- [ ] Confirm skill resolution still works end-to-end with the `la-` prefixes (workflow run picks up `la-implement` / `la-review`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)