### PR TITLE
fix: count branch-resolver cost in run usage

### DIFF
--- a/server/orchestrator/branch-resolver.test.ts
+++ b/server/orchestrator/branch-resolver.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from "vitest";
+import type { RunRepository, StepUsage } from "../run-repository.ts";
 import {
 	buildAssistantMessage,
 	buildErrorResult,
 	buildSuccessResult,
 } from "../test-support/agent-messages.ts";
 import type { Issue } from "../trackers/types.ts";
-import { issueKey, issueNumber, repoSlug, runId } from "../types/brands.ts";
+import {
+	issueKey,
+	issueNumber,
+	type RunId,
+	repoSlug,
+	runId,
+} from "../types/brands.ts";
 import type {
 	AgentInvokeOptions,
 	AgentInvoker,
@@ -44,14 +51,30 @@ function createAgent(
 	};
 }
 
+type UsageCall = { runId: RunId; usage: StepUsage };
+
+function createRunRepo(): Pick<RunRepository, "addRunUsage"> & {
+	usageCalls: UsageCall[];
+} {
+	const usageCalls: UsageCall[] = [];
+	return {
+		usageCalls,
+		addRunUsage(runId, usage) {
+			usageCalls.push({ runId, usage });
+		},
+	};
+}
+
 describe("resolveBranch", () => {
 	it("renders the static template form against issue and attempt", async () => {
 		const agent = createAgent(async function* () {});
+		const runRepo = createRunRepo();
 
 		const result = await resolveBranch({
 			workflowBranch: "agent/issue-{{ issue.number }}",
 			issue,
 			agent,
+			runRepo,
 			cwd: "/work",
 			runId: runId("test-run"),
 			signal: new AbortController().signal,
@@ -59,6 +82,7 @@ describe("resolveBranch", () => {
 
 		expect(result).toBe("agent/issue-7");
 		expect(agent.calls).toEqual([]);
+		expect(runRepo.usageCalls).toEqual([]);
 	});
 
 	it("invokes the agent with outputFormat for the dynamic form", async () => {
@@ -69,6 +93,7 @@ describe("resolveBranch", () => {
 				structuredOutput: { name: "feat/owner-repo-1-fix-it" },
 			});
 		});
+		const runRepo = createRunRepo();
 
 		const result = await resolveBranch({
 			workflowBranch: {
@@ -78,6 +103,7 @@ describe("resolveBranch", () => {
 			},
 			issue,
 			agent,
+			runRepo,
 			cwd: "/work",
 			runId: runId("test-run"),
 			signal: new AbortController().signal,
@@ -114,6 +140,7 @@ describe("resolveBranch", () => {
 				},
 				issue,
 				agent,
+				runRepo: createRunRepo(),
 				cwd: "/work",
 				runId: runId("test-run"),
 				signal: new AbortController().signal,
@@ -127,6 +154,7 @@ describe("resolveBranch", () => {
 				uuid: "00000000-0000-0000-0000-000000000040",
 			});
 		});
+		const runRepo = createRunRepo();
 
 		await expect(
 			resolveBranch({
@@ -137,11 +165,14 @@ describe("resolveBranch", () => {
 				},
 				issue,
 				agent,
+				runRepo,
 				cwd: "/work",
 				runId: runId("test-run"),
 				signal: new AbortController().signal,
 			}),
 		).rejects.toThrow(/stream ended without a result message/);
+
+		expect(runRepo.usageCalls).toEqual([]);
 	});
 
 	it("aborts when the SDK returns error_max_structured_output_retries", async () => {
@@ -162,10 +193,56 @@ describe("resolveBranch", () => {
 				},
 				issue,
 				agent,
+				runRepo: createRunRepo(),
 				cwd: "/work",
 				runId: runId("test-run"),
 				signal: new AbortController().signal,
 			}),
 		).rejects.toThrow(/error_max_structured_output_retries/);
+	});
+
+	it("records cost and tokens against the run when the agent returns usage", async () => {
+		const agent = createAgent(async function* () {
+			yield buildSuccessResult({
+				uuid: "00000000-0000-0000-0000-000000000050",
+				sessionId: "sess-branch",
+				structuredOutput: { name: "feat/owner-repo-1-fix-it" },
+				totalCostUsd: 0.02,
+				modelUsage: {
+					"claude-haiku-4-5": {
+						inputTokens: 400,
+						outputTokens: 80,
+						cacheReadInputTokens: 0,
+						cacheCreationInputTokens: 0,
+						webSearchRequests: 0,
+						costUSD: 0.02,
+						contextWindow: 200_000,
+						maxOutputTokens: 8_000,
+					},
+				},
+			});
+		});
+		const runRepo = createRunRepo();
+
+		await resolveBranch({
+			workflowBranch: {
+				prompt: "Propose",
+				schema: branchSchema,
+				model: "claude-haiku-4-5",
+			},
+			issue,
+			agent,
+			runRepo,
+			cwd: "/work",
+			runId: runId("test-run"),
+			signal: new AbortController().signal,
+		});
+
+		expect(runRepo.usageCalls).toEqual([
+			{
+				runId: runId("test-run"),
+				usage: { costUsd: 0.02, tokensInput: 400, tokensOutput: 80 },
+			},
+		]);
 	});
 });

--- a/server/orchestrator/branch-resolver.ts
+++ b/server/orchestrator/branch-resolver.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { RunRepository } from "../run-repository.ts";
 import type { Issue } from "../trackers/types.ts";
 import type { RunId } from "../types/brands.ts";
 import type { WorkflowBranch } from "../workflow/workflow.ts";
@@ -13,6 +14,7 @@ type ResolveBranchParams = {
 	workflowBranch: WorkflowBranch;
 	issue: Issue;
 	agent: AgentInvoker;
+	runRepo: Pick<RunRepository, "addRunUsage">;
 	cwd: string;
 	runId: RunId;
 	signal: AbortSignal;
@@ -22,6 +24,7 @@ export async function resolveBranch({
 	workflowBranch,
 	issue,
 	agent,
+	runRepo,
 	cwd,
 	runId,
 	signal,
@@ -36,31 +39,46 @@ export async function resolveBranch({
 		schema: workflowBranch.schema,
 	};
 
-	for await (const msg of agent.invoke({
-		prompt,
-		cwd,
-		model: workflowBranch.model,
-		runId,
-		signal,
-		outputFormat,
-	})) {
-		if (msg.type === "assistant") {
-			trackAgentToolUseBag(msg);
-			continue;
-		}
-		if (msg.type !== "result") continue;
-		recordAgentResult(msg);
-		if (msg.subtype === "success") {
-			const parsed = branchOutputSchema.safeParse(msg.structured_output);
-			if (!parsed.success) {
-				throw new Error(
-					"branch agent returned no `name` field in structured output",
-				);
-			}
-			return parsed.data.name;
-		}
-		throw new Error(msg.subtype);
-	}
+	let costUsd = 0;
+	let tokensInput = 0;
+	let tokensOutput = 0;
 
-	throw new Error("branch agent stream ended without a result message");
+	try {
+		for await (const msg of agent.invoke({
+			prompt,
+			cwd,
+			model: workflowBranch.model,
+			runId,
+			signal,
+			outputFormat,
+		})) {
+			if (msg.type === "assistant") {
+				trackAgentToolUseBag(msg);
+				continue;
+			}
+			if (msg.type !== "result") continue;
+			recordAgentResult(msg);
+			costUsd += msg.total_cost_usd;
+			for (const usage of Object.values(msg.modelUsage)) {
+				tokensInput += usage.inputTokens;
+				tokensOutput += usage.outputTokens;
+			}
+			if (msg.subtype === "success") {
+				const parsed = branchOutputSchema.safeParse(msg.structured_output);
+				if (!parsed.success) {
+					throw new Error(
+						"branch agent returned no `name` field in structured output",
+					);
+				}
+				return parsed.data.name;
+			}
+			throw new Error(msg.subtype);
+		}
+
+		throw new Error("branch agent stream ended without a result message");
+	} finally {
+		if (costUsd > 0 || tokensInput > 0 || tokensOutput > 0) {
+			runRepo.addRunUsage(runId, { costUsd, tokensInput, tokensOutput });
+		}
+	}
 }

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -158,6 +158,7 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 								workflowBranch: workflow.branch,
 								issue,
 								agent,
+								runRepo,
 								cwd: wsPath,
 								runId: ctx.runId,
 								signal: ctx.signal,

--- a/skills/la-review/SKILL.md
+++ b/skills/la-review/SKILL.md
@@ -39,7 +39,7 @@ Collect the list. The Standards sub-agent will read them.
 
 ### 3. Spawn both sub-agents in parallel
 
-Send a single message with two `Agent` tool calls. Use the `general-purpose` subagent for both.
+Send a single message with two `Agent` tool calls. Use the `general-purpose` subagent for both, with `model: "sonnet"`.
 
 **Standards sub-agent prompt** — include:
 


### PR DESCRIPTION
## Summary
- Branch resolution was recording cost into the canonical log but never calling `runRepo.addRunUsage`, so its LLM spend was missing from per-run `costUsd` in the DB and dashboard. Thread `runRepo` through `resolveBranch`, accumulate `total_cost_usd` / `modelUsage` across result messages, and flush once in a `finally` — so the success path and the structured-output / error-subtype throw paths both record usage. The "stream ended without a result" path stays at zero.
- Pin the two `la-review` sub-agents to `model: "sonnet"`. The parent review step still runs on Opus 4.7, but the two parallel context-heavy reads were inheriting Opus too. Sonnet 4.6 is plenty for those.
- Added a lightweight test in `branch-resolver.test.ts` that pins `addRunUsage` is called with the expected `{ costUsd, tokensInput, tokensOutput }`, and threaded a stub repo through the existing tests.

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm test` — focus on `server/orchestrator/branch-resolver.test.ts`
- [ ] Run a workflow with the dynamic `branch:` form and confirm the run's `costUsd` in the dashboard now includes the branch-resolution turn
- [ ] Trigger the `review` step and confirm the two sub-agent calls report Sonnet usage rather than Opus

🤖 Generated with [Claude Code](https://claude.com/claude-code)