### PR TITLE
feat: KAN-13 - Add self-hosted Langfuse and OTel telemetry from agent subprocesses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,10 @@ GITLAB_TOKEN=
 # Jira Cloud credentials (required)
 JIRA_EMAIL=
 JIRA_API_TOKEN=
+
+# Langfuse credentials (required). Get the keys from
+# http://localhost:3000 → Project → Settings → API keys after
+# `pnpm langfuse:up` and signing in.
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+# LANGFUSE_HOST=http://localhost:3000

--- a/infra/langfuse/.env.example
+++ b/infra/langfuse/.env.example
@@ -1,4 +1,6 @@
-# Langfuse v3 self-hosted — required secrets
+# Langfuse v3 self-hosted — required secrets for the docker compose stack.
+# These configure Langfuse's own containers (web/worker/postgres/clickhouse/
+# minio/redis); they are NOT consumed by this repo's app code.
 # Copy this file to .env and fill in each value before running pnpm langfuse:up.
 # .env is gitignored; never commit real secrets.
 
@@ -10,7 +12,9 @@ SALT=
 #   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ENCRYPTION_KEY=
 
-# Random secret for NextAuth.js session signing — generate same as SALT above
+# Session-signing secret for the Langfuse web UI. The Langfuse web container
+# is a Next.js app that uses NextAuth.js internally — this is for *its* auth,
+# not for anything in this repo. Generate same as SALT above.
 NEXTAUTH_SECRET=
 
 # PostgreSQL password for the langfuse database user
@@ -19,8 +23,10 @@ POSTGRES_PASSWORD=
 # ClickHouse password
 CLICKHOUSE_PASSWORD=
 
-# MinIO root password (S3-compatible blob store)
+# MinIO root password (S3-compatible blob store used by Langfuse to persist
+# raw events and media uploads — required by Langfuse v3 architecture)
 MINIO_ROOT_PASSWORD=
 
-# Redis AUTH password
+# Redis AUTH password (Langfuse v3 uses Redis as the queue between web
+# and worker — required, not optional)
 REDIS_AUTH=

--- a/infra/langfuse/.env.example
+++ b/infra/langfuse/.env.example
@@ -1,0 +1,26 @@
+# Langfuse v3 self-hosted — required secrets
+# Copy this file to .env and fill in each value before running pnpm langfuse:up.
+# .env is gitignored; never commit real secrets.
+
+# 32-byte hex string — generate with:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+SALT=
+
+# 64-byte hex string (AES-256 key) — generate with:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+ENCRYPTION_KEY=
+
+# Random secret for NextAuth.js session signing — generate same as SALT above
+NEXTAUTH_SECRET=
+
+# PostgreSQL password for the langfuse database user
+POSTGRES_PASSWORD=
+
+# ClickHouse password
+CLICKHOUSE_PASSWORD=
+
+# MinIO root password (S3-compatible blob store)
+MINIO_ROOT_PASSWORD=
+
+# Redis AUTH password
+REDIS_AUTH=

--- a/infra/langfuse/docker-compose.yml
+++ b/infra/langfuse/docker-compose.yml
@@ -1,0 +1,140 @@
+# Langfuse v3 self-hosted — reference release v3.174.0 (:3 tag tracks v3 major)
+# Secrets live in infra/langfuse/.env (gitignored). See .env.example for required vars.
+# Start: pnpm langfuse:up  Stop: pnpm langfuse:down  Logs: pnpm langfuse:logs
+
+x-langfuse-depends: &langfuse-depends
+  postgres:
+    condition: service_healthy
+  clickhouse:
+    condition: service_healthy
+  minio:
+    condition: service_healthy
+  redis:
+    condition: service_healthy
+
+x-langfuse-env: &langfuse-env
+  DATABASE_URL: "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/langfuse"
+  SALT: "${SALT}"
+  ENCRYPTION_KEY: "${ENCRYPTION_KEY}"
+  NEXTAUTH_SECRET: "${NEXTAUTH_SECRET}"
+  NEXTAUTH_URL: "http://localhost:3000"
+  TELEMETRY_ENABLED: "false"
+  LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES: "false"
+  CLICKHOUSE_MIGRATION_URL: "clickhouse://clickhouse:${CLICKHOUSE_PASSWORD}@clickhouse:9000"
+  CLICKHOUSE_URL: "http://clickhouse:8123"
+  CLICKHOUSE_USER: "clickhouse"
+  CLICKHOUSE_PASSWORD: "${CLICKHOUSE_PASSWORD}"
+  REDIS_HOST: "redis"
+  REDIS_PORT: "6379"
+  REDIS_AUTH: "${REDIS_AUTH}"
+  LANGFUSE_S3_MEDIA_UPLOAD_ENABLED: "true"
+  LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: "langfuse"
+  LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: "http://minio:9000"
+  LANGFUSE_S3_MEDIA_UPLOAD_REGION: "auto"
+  LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: "minio"
+  LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: "${MINIO_ROOT_PASSWORD}"
+  LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
+  LANGFUSE_S3_EVENT_UPLOAD_ENABLED: "true"
+  LANGFUSE_S3_EVENT_UPLOAD_BUCKET: "langfuse"
+  LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: "http://minio:9000"
+  LANGFUSE_S3_EVENT_UPLOAD_REGION: "auto"
+  LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: "minio"
+  LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: "${MINIO_ROOT_PASSWORD}"
+  LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+  LANGFUSE_S3_BATCH_EXPORT_ENABLED: "false"
+
+services:
+  langfuse-worker:
+    image: docker.io/langfuse/langfuse-worker:3
+    restart: unless-stopped
+    depends_on: *langfuse-depends
+    environment:
+      <<: *langfuse-env
+
+  langfuse-web:
+    image: docker.io/langfuse/langfuse:3
+    restart: unless-stopped
+    depends_on: *langfuse-depends
+    ports:
+      - "3000:3000"
+    environment:
+      <<: *langfuse-env
+
+  clickhouse:
+    image: docker.io/clickhouse/clickhouse-server
+    restart: unless-stopped
+    user: "101:101"
+    environment:
+      CLICKHOUSE_DB: "langfuse"
+      CLICKHOUSE_USER: "clickhouse"
+      CLICKHOUSE_PASSWORD: "${CLICKHOUSE_PASSWORD}"
+    volumes:
+      - langfuse_clickhouse_data:/var/lib/clickhouse
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:8123/ping",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 1s
+
+  minio:
+    image: cgr.dev/chainguard/minio
+    restart: unless-stopped
+    entrypoint: sh
+    command: -c 'minio server /data --console-address ":9001"'
+    environment:
+      MINIO_ROOT_USER: "minio"
+      MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD}"
+    volumes:
+      - langfuse_minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 1s
+
+  redis:
+    image: docker.io/redis:7
+    restart: unless-stopped
+    command: >-
+      --requirepass ${REDIS_AUTH}
+      --save 60 1
+      --loglevel warning
+    volumes:
+      - langfuse_redis_data:/data
+    healthcheck:
+      test:
+        ["CMD", "redis-cli", "--no-auth-warning", "-a", "${REDIS_AUTH}", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  postgres:
+    image: docker.io/postgres:17
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_DB: "langfuse"
+    volumes:
+      - langfuse_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  langfuse_postgres_data:
+  langfuse_clickhouse_data:
+  langfuse_minio_data:
+  langfuse_redis_data:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
 		"test:dashboard": "vitest run --project dashboard",
 		"typecheck": "tsc --noEmit && tsc --noEmit -p dashboard/tsconfig.json",
 		"knip": "knip",
-		"db:generate": "drizzle-kit generate"
+		"db:generate": "drizzle-kit generate",
+		"langfuse:up": "docker compose -f infra/langfuse/docker-compose.yml --env-file infra/langfuse/.env up -d",
+		"langfuse:down": "docker compose -f infra/langfuse/docker-compose.yml down",
+		"langfuse:logs": "docker compose -f infra/langfuse/docker-compose.yml logs -f langfuse-web langfuse-worker"
 	},
 	"lint-staged": {
 		"*.{ts,tsx,json,mjs}": "biome check --write --no-errors-on-unmatched"

--- a/server/env.ts
+++ b/server/env.ts
@@ -19,6 +19,9 @@ const envSchema = z.object({
 	GITHUB_TOKEN: z.string().optional(),
 	JIRA_EMAIL: z.string().optional(),
 	JIRA_API_TOKEN: z.string().optional(),
+	LANGFUSE_PUBLIC_KEY: z.string().min(1),
+	LANGFUSE_SECRET_KEY: z.string().min(1),
+	LANGFUSE_HOST: z.url().default("http://localhost:3000"),
 });
 
 type Env = z.infer<typeof envSchema>;

--- a/server/orchestrator/agent-invoker.ts
+++ b/server/orchestrator/agent-invoker.ts
@@ -1,6 +1,7 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { IssueKey, RunId } from "../types/brands.ts";
 import { buildAgentHooks } from "./agent-hooks.ts";
+import { buildOtelEnv } from "./otel-env.ts";
 import { createRunLogWriter } from "./run-log-file.ts";
 
 export type AgentMessage =
@@ -103,43 +104,4 @@ function abortControllerFromSignal(signal: AbortSignal): AbortController {
 			once: true,
 		});
 	return controller;
-}
-
-function buildOtelEnv({
-	runId,
-	issueKey,
-	stepName,
-}: {
-	runId: RunId;
-	issueKey: IssueKey | undefined;
-	stepName: string | undefined;
-}): Record<string, string> {
-	const publicKey = process.env["LANGFUSE_PUBLIC_KEY"];
-	const secretKey = process.env["LANGFUSE_SECRET_KEY"];
-	if (!publicKey || !secretKey) return {};
-
-	const credentials = Buffer.from(`${publicKey}:${secretKey}`).toString(
-		"base64",
-	);
-
-	const resourceParts = [`service.name=local-agents`, `run.id=${runId}`];
-	if (issueKey) resourceParts.push(`issue.key=${issueKey}`);
-	if (stepName) resourceParts.push(`workflow.step=${stepName}`);
-
-	return {
-		CLAUDE_CODE_ENABLE_TELEMETRY: "1",
-		CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: "1",
-		OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:3000/api/public/otel",
-		OTEL_EXPORTER_OTLP_HEADERS: `Authorization=Basic ${credentials}`,
-		OTEL_TRACES_EXPORTER: "otlp",
-		OTEL_METRICS_EXPORTER: "otlp",
-		OTEL_LOGS_EXPORTER: "otlp",
-		OTEL_LOG_USER_PROMPTS: "1",
-		OTEL_LOG_TOOL_DETAILS: "1",
-		OTEL_LOG_TOOL_CONTENT: "1",
-		OTEL_TRACES_EXPORT_INTERVAL: "1000",
-		OTEL_METRICS_EXPORT_INTERVAL: "1000",
-		OTEL_LOGS_EXPORT_INTERVAL: "1000",
-		OTEL_RESOURCE_ATTRIBUTES: resourceParts.join(","),
-	};
 }

--- a/server/orchestrator/agent-invoker.ts
+++ b/server/orchestrator/agent-invoker.ts
@@ -1,5 +1,5 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
-import type { RunId } from "../types/brands.ts";
+import type { IssueKey, RunId } from "../types/brands.ts";
 import { buildAgentHooks } from "./agent-hooks.ts";
 import { createRunLogWriter } from "./run-log-file.ts";
 
@@ -16,6 +16,8 @@ export type AgentInvokeOptions = {
 	cwd: string;
 	model: string;
 	runId: RunId;
+	issueKey?: IssueKey;
+	stepName?: string;
 	env?: Record<string, string>;
 	resumeSessionId?: string;
 	signal: AbortSignal;
@@ -50,6 +52,8 @@ export function claudeSdkAgentInvoker({
 			cwd,
 			model,
 			runId,
+			issueKey,
+			stepName,
 			env: invocationEnv,
 			resumeSessionId,
 			outputFormat,
@@ -57,12 +61,17 @@ export function claudeSdkAgentInvoker({
 			allowedTools,
 		}) {
 			const runLogWriter = createRunLogWriter(logDir, runId);
+			const baseEnv = invocationEnv ?? env;
+			const resolvedEnv = {
+				...baseEnv,
+				...buildOtelEnv({ runId, issueKey, stepName }),
+			};
 			return query({
 				prompt,
 				options: {
 					cwd,
 					model,
-					env: invocationEnv ?? env,
+					env: resolvedEnv,
 					abortController: abortControllerFromSignal(signal),
 					allowedTools: [...(allowedTools ?? DEFAULT_ALLOWED_TOOLS)],
 					permissionMode: "dontAsk" as const,
@@ -94,4 +103,43 @@ function abortControllerFromSignal(signal: AbortSignal): AbortController {
 			once: true,
 		});
 	return controller;
+}
+
+function buildOtelEnv({
+	runId,
+	issueKey,
+	stepName,
+}: {
+	runId: RunId;
+	issueKey: IssueKey | undefined;
+	stepName: string | undefined;
+}): Record<string, string> {
+	const publicKey = process.env["LANGFUSE_PUBLIC_KEY"];
+	const secretKey = process.env["LANGFUSE_SECRET_KEY"];
+	if (!publicKey || !secretKey) return {};
+
+	const credentials = Buffer.from(`${publicKey}:${secretKey}`).toString(
+		"base64",
+	);
+
+	const resourceParts = [`service.name=local-agents`, `run.id=${runId}`];
+	if (issueKey) resourceParts.push(`issue.key=${issueKey}`);
+	if (stepName) resourceParts.push(`workflow.step=${stepName}`);
+
+	return {
+		CLAUDE_CODE_ENABLE_TELEMETRY: "1",
+		CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: "1",
+		OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:3000/api/public/otel",
+		OTEL_EXPORTER_OTLP_HEADERS: `Authorization=Basic ${credentials}`,
+		OTEL_TRACES_EXPORTER: "otlp",
+		OTEL_METRICS_EXPORTER: "otlp",
+		OTEL_LOGS_EXPORTER: "otlp",
+		OTEL_LOG_USER_PROMPTS: "1",
+		OTEL_LOG_TOOL_DETAILS: "1",
+		OTEL_LOG_TOOL_CONTENT: "1",
+		OTEL_TRACES_EXPORT_INTERVAL: "1000",
+		OTEL_METRICS_EXPORT_INTERVAL: "1000",
+		OTEL_LOGS_EXPORT_INTERVAL: "1000",
+		OTEL_RESOURCE_ATTRIBUTES: resourceParts.join(","),
+	};
 }

--- a/server/orchestrator/agent-invoker.ts
+++ b/server/orchestrator/agent-invoker.ts
@@ -40,12 +40,20 @@ export const DEFAULT_ALLOWED_TOOLS = [
 	"Agent",
 ] as const;
 
+export type LangfuseConfig = {
+	publicKey: string;
+	secretKey: string;
+	host: string;
+};
+
 export function claudeSdkAgentInvoker({
 	env,
 	logDir,
+	langfuse,
 }: {
 	env: Record<string, string>;
 	logDir: string;
+	langfuse: LangfuseConfig;
 }): AgentInvoker {
 	return {
 		invoke({
@@ -65,7 +73,7 @@ export function claudeSdkAgentInvoker({
 			const baseEnv = invocationEnv ?? env;
 			const resolvedEnv = {
 				...baseEnv,
-				...buildOtelEnv({ runId, issueKey, stepName }),
+				...buildOtelEnv({ runId, issueKey, stepName, langfuse }),
 			};
 			return query({
 				prompt,

--- a/server/orchestrator/branch-resolver.ts
+++ b/server/orchestrator/branch-resolver.ts
@@ -49,6 +49,7 @@ export async function resolveBranch({
 			cwd,
 			model: workflowBranch.model,
 			runId,
+			issueKey: issue.key,
 			signal,
 			outputFormat,
 		})) {

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -10,7 +10,11 @@ import type { Issue, TrackerAdapter } from "../trackers/types.ts";
 import type { IssueKey } from "../types/brands.ts";
 import type { RepoWorkflow } from "../workflow/workflow.ts";
 import { resolveAgentEnvironment } from "./agent-env.ts";
-import { type AgentInvoker, claudeSdkAgentInvoker } from "./agent-invoker.ts";
+import {
+	type AgentInvoker,
+	claudeSdkAgentInvoker,
+	type LangfuseConfig,
+} from "./agent-invoker.ts";
 import { type Clock, systemClock } from "./clock.ts";
 import { createRunLifecycle } from "./run-lifecycle.ts";
 import { type RunShell, realRunShell, sweepWorkspaces } from "./workspace.ts";
@@ -38,6 +42,7 @@ type OrchestratorConfig = {
 	workflow: RepoWorkflow;
 	runner: Runner;
 	logger: Logger;
+	langfuse: LangfuseConfig;
 	agent?: AgentInvoker;
 	clock?: Clock;
 	runShell?: RunShell;
@@ -91,13 +96,15 @@ export function createOrchestrator(opts: OrchestratorConfig): Orchestrator {
 		workflow,
 		runner,
 		logger,
+		langfuse,
 		clock = systemClock(),
 		runShell = realRunShell,
 	} = opts;
 	const { defaults } = config;
 	const agentEnv = resolveAgentEnvironment(config.agent.env);
 	const logDir = resolvePath(process.cwd(), defaults.log_dir);
-	const agent = opts.agent ?? claudeSdkAgentInvoker({ env: agentEnv, logDir });
+	const agent =
+		opts.agent ?? claudeSdkAgentInvoker({ env: agentEnv, logDir, langfuse });
 
 	function logTransitionFailed(
 		repo: Issue["repo"],

--- a/server/orchestrator/otel-env.test.ts
+++ b/server/orchestrator/otel-env.test.ts
@@ -4,31 +4,20 @@ import { buildOtelEnv } from "./otel-env.ts";
 
 const RUN_ID = runId("run-abc");
 const ISSUE_KEY = issueKey("KAN-13");
+const LANGFUSE = {
+	publicKey: "pk-123",
+	secretKey: "sk-456",
+	host: "http://localhost:3000",
+};
 
 describe("buildOtelEnv", () => {
-	it("returns an empty record when Langfuse credentials are absent", () => {
-		const env = buildOtelEnv(
-			{ runId: RUN_ID, issueKey: ISSUE_KEY, stepName: "implement" },
-			{},
-		);
-
-		expect(env).toEqual({});
-	});
-
-	it("returns an empty record when only the public key is set", () => {
-		const env = buildOtelEnv(
-			{ runId: RUN_ID, issueKey: ISSUE_KEY, stepName: "implement" },
-			{ LANGFUSE_PUBLIC_KEY: "pk" },
-		);
-
-		expect(env).toEqual({});
-	});
-
 	it("emits OTel env with base64-encoded Basic auth and all resource attributes", () => {
-		const env = buildOtelEnv(
-			{ runId: RUN_ID, issueKey: ISSUE_KEY, stepName: "implement" },
-			{ LANGFUSE_PUBLIC_KEY: "pk-123", LANGFUSE_SECRET_KEY: "sk-456" },
-		);
+		const env = buildOtelEnv({
+			runId: RUN_ID,
+			issueKey: ISSUE_KEY,
+			stepName: "implement",
+			langfuse: LANGFUSE,
+		});
 
 		const expectedCreds = Buffer.from("pk-123:sk-456").toString("base64");
 		expect(env["OTEL_EXPORTER_OTLP_HEADERS"]).toBe(
@@ -44,11 +33,26 @@ describe("buildOtelEnv", () => {
 		);
 	});
 
-	it("omits issue.key from resource attributes when undefined", () => {
-		const env = buildOtelEnv(
-			{ runId: RUN_ID, issueKey: undefined, stepName: "implement" },
-			{ LANGFUSE_PUBLIC_KEY: "pk", LANGFUSE_SECRET_KEY: "sk" },
+	it("uses the configured Langfuse host for the OTLP endpoint", () => {
+		const env = buildOtelEnv({
+			runId: RUN_ID,
+			issueKey: ISSUE_KEY,
+			stepName: "implement",
+			langfuse: { ...LANGFUSE, host: "https://langfuse.internal" },
+		});
+
+		expect(env["OTEL_EXPORTER_OTLP_ENDPOINT"]).toBe(
+			"https://langfuse.internal/api/public/otel",
 		);
+	});
+
+	it("omits issue.key from resource attributes when undefined", () => {
+		const env = buildOtelEnv({
+			runId: RUN_ID,
+			issueKey: undefined,
+			stepName: "implement",
+			langfuse: LANGFUSE,
+		});
 
 		expect(env["OTEL_RESOURCE_ATTRIBUTES"]).toBe(
 			"service.name=local-agents,run.id=run-abc,workflow.step=implement",
@@ -56,10 +60,12 @@ describe("buildOtelEnv", () => {
 	});
 
 	it("omits workflow.step from resource attributes when undefined", () => {
-		const env = buildOtelEnv(
-			{ runId: RUN_ID, issueKey: ISSUE_KEY, stepName: undefined },
-			{ LANGFUSE_PUBLIC_KEY: "pk", LANGFUSE_SECRET_KEY: "sk" },
-		);
+		const env = buildOtelEnv({
+			runId: RUN_ID,
+			issueKey: ISSUE_KEY,
+			stepName: undefined,
+			langfuse: LANGFUSE,
+		});
 
 		expect(env["OTEL_RESOURCE_ATTRIBUTES"]).toBe(
 			"service.name=local-agents,run.id=run-abc,issue.key=KAN-13",
@@ -67,10 +73,12 @@ describe("buildOtelEnv", () => {
 	});
 
 	it("emits only service.name and run.id when both issueKey and stepName are undefined", () => {
-		const env = buildOtelEnv(
-			{ runId: RUN_ID, issueKey: undefined, stepName: undefined },
-			{ LANGFUSE_PUBLIC_KEY: "pk", LANGFUSE_SECRET_KEY: "sk" },
-		);
+		const env = buildOtelEnv({
+			runId: RUN_ID,
+			issueKey: undefined,
+			stepName: undefined,
+			langfuse: LANGFUSE,
+		});
 
 		expect(env["OTEL_RESOURCE_ATTRIBUTES"]).toBe(
 			"service.name=local-agents,run.id=run-abc",

--- a/server/orchestrator/otel-env.test.ts
+++ b/server/orchestrator/otel-env.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { issueKey, runId } from "../types/brands.ts";
+import { buildOtelEnv } from "./otel-env.ts";
+
+const RUN_ID = runId("run-abc");
+const ISSUE_KEY = issueKey("KAN-13");
+
+describe("buildOtelEnv", () => {
+	it("returns an empty record when Langfuse credentials are absent", () => {
+		const env = buildOtelEnv(
+			{ runId: RUN_ID, issueKey: ISSUE_KEY, stepName: "implement" },
+			{},
+		);
+
+		expect(env).toEqual({});
+	});
+
+	it("returns an empty record when only the public key is set", () => {
+		const env = buildOtelEnv(
+			{ runId: RUN_ID, issueKey: ISSUE_KEY, stepName: "implement" },
+			{ LANGFUSE_PUBLIC_KEY: "pk" },
+		);
+
+		expect(env).toEqual({});
+	});
+
+	it("emits OTel env with base64-encoded Basic auth and all resource attributes", () => {
+		const env = buildOtelEnv(
+			{ runId: RUN_ID, issueKey: ISSUE_KEY, stepName: "implement" },
+			{ LANGFUSE_PUBLIC_KEY: "pk-123", LANGFUSE_SECRET_KEY: "sk-456" },
+		);
+
+		const expectedCreds = Buffer.from("pk-123:sk-456").toString("base64");
+		expect(env["OTEL_EXPORTER_OTLP_HEADERS"]).toBe(
+			`Authorization=Basic ${expectedCreds}`,
+		);
+		expect(env["OTEL_RESOURCE_ATTRIBUTES"]).toBe(
+			"service.name=local-agents,run.id=run-abc,issue.key=KAN-13,workflow.step=implement",
+		);
+		expect(env["CLAUDE_CODE_ENABLE_TELEMETRY"]).toBe("1");
+		expect(env["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"]).toBe("1");
+		expect(env["OTEL_EXPORTER_OTLP_ENDPOINT"]).toBe(
+			"http://localhost:3000/api/public/otel",
+		);
+	});
+
+	it("omits issue.key from resource attributes when undefined", () => {
+		const env = buildOtelEnv(
+			{ runId: RUN_ID, issueKey: undefined, stepName: "implement" },
+			{ LANGFUSE_PUBLIC_KEY: "pk", LANGFUSE_SECRET_KEY: "sk" },
+		);
+
+		expect(env["OTEL_RESOURCE_ATTRIBUTES"]).toBe(
+			"service.name=local-agents,run.id=run-abc,workflow.step=implement",
+		);
+	});
+
+	it("omits workflow.step from resource attributes when undefined", () => {
+		const env = buildOtelEnv(
+			{ runId: RUN_ID, issueKey: ISSUE_KEY, stepName: undefined },
+			{ LANGFUSE_PUBLIC_KEY: "pk", LANGFUSE_SECRET_KEY: "sk" },
+		);
+
+		expect(env["OTEL_RESOURCE_ATTRIBUTES"]).toBe(
+			"service.name=local-agents,run.id=run-abc,issue.key=KAN-13",
+		);
+	});
+
+	it("emits only service.name and run.id when both issueKey and stepName are undefined", () => {
+		const env = buildOtelEnv(
+			{ runId: RUN_ID, issueKey: undefined, stepName: undefined },
+			{ LANGFUSE_PUBLIC_KEY: "pk", LANGFUSE_SECRET_KEY: "sk" },
+		);
+
+		expect(env["OTEL_RESOURCE_ATTRIBUTES"]).toBe(
+			"service.name=local-agents,run.id=run-abc",
+		);
+	});
+});

--- a/server/orchestrator/otel-env.ts
+++ b/server/orchestrator/otel-env.ts
@@ -1,19 +1,20 @@
 import type { IssueKey, RunId } from "../types/brands.ts";
 
+type LangfuseCredentials = {
+	publicKey: string;
+	secretKey: string;
+	host: string;
+};
+
 type OtelEnvInputs = {
 	runId: RunId;
 	issueKey: IssueKey | undefined;
 	stepName: string | undefined;
+	langfuse: LangfuseCredentials;
 };
 
-export function buildOtelEnv(
-	inputs: OtelEnvInputs,
-	sourceEnv: NodeJS.ProcessEnv = process.env,
-): Record<string, string> {
-	const publicKey = sourceEnv["LANGFUSE_PUBLIC_KEY"];
-	const secretKey = sourceEnv["LANGFUSE_SECRET_KEY"];
-	if (!publicKey || !secretKey) return {};
-
+export function buildOtelEnv(inputs: OtelEnvInputs): Record<string, string> {
+	const { publicKey, secretKey, host } = inputs.langfuse;
 	const credentials = Buffer.from(`${publicKey}:${secretKey}`).toString(
 		"base64",
 	);
@@ -25,7 +26,7 @@ export function buildOtelEnv(
 	return {
 		CLAUDE_CODE_ENABLE_TELEMETRY: "1",
 		CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: "1",
-		OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:3000/api/public/otel",
+		OTEL_EXPORTER_OTLP_ENDPOINT: `${host}/api/public/otel`,
 		OTEL_EXPORTER_OTLP_HEADERS: `Authorization=Basic ${credentials}`,
 		OTEL_TRACES_EXPORTER: "otlp",
 		OTEL_METRICS_EXPORTER: "otlp",

--- a/server/orchestrator/otel-env.ts
+++ b/server/orchestrator/otel-env.ts
@@ -1,0 +1,41 @@
+import type { IssueKey, RunId } from "../types/brands.ts";
+
+type OtelEnvInputs = {
+	runId: RunId;
+	issueKey: IssueKey | undefined;
+	stepName: string | undefined;
+};
+
+export function buildOtelEnv(
+	inputs: OtelEnvInputs,
+	sourceEnv: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+	const publicKey = sourceEnv["LANGFUSE_PUBLIC_KEY"];
+	const secretKey = sourceEnv["LANGFUSE_SECRET_KEY"];
+	if (!publicKey || !secretKey) return {};
+
+	const credentials = Buffer.from(`${publicKey}:${secretKey}`).toString(
+		"base64",
+	);
+
+	const resourceParts = ["service.name=local-agents", `run.id=${inputs.runId}`];
+	if (inputs.issueKey) resourceParts.push(`issue.key=${inputs.issueKey}`);
+	if (inputs.stepName) resourceParts.push(`workflow.step=${inputs.stepName}`);
+
+	return {
+		CLAUDE_CODE_ENABLE_TELEMETRY: "1",
+		CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: "1",
+		OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:3000/api/public/otel",
+		OTEL_EXPORTER_OTLP_HEADERS: `Authorization=Basic ${credentials}`,
+		OTEL_TRACES_EXPORTER: "otlp",
+		OTEL_METRICS_EXPORTER: "otlp",
+		OTEL_LOGS_EXPORTER: "otlp",
+		OTEL_LOG_USER_PROMPTS: "1",
+		OTEL_LOG_TOOL_DETAILS: "1",
+		OTEL_LOG_TOOL_CONTENT: "1",
+		OTEL_TRACES_EXPORT_INTERVAL: "1000",
+		OTEL_METRICS_EXPORT_INTERVAL: "1000",
+		OTEL_LOGS_EXPORT_INTERVAL: "1000",
+		OTEL_RESOURCE_ATTRIBUTES: resourceParts.join(","),
+	};
+}

--- a/server/orchestrator/step-runner.ts
+++ b/server/orchestrator/step-runner.ts
@@ -142,6 +142,8 @@ async function runWorkflowStep({
 			cwd,
 			model,
 			runId: ctx.runId,
+			issueKey: issue.key,
+			stepName: step.name,
 			signal: ctx.signal,
 			env,
 			...(resumeSessionId && { resumeSessionId }),

--- a/server/server.ts
+++ b/server/server.ts
@@ -46,6 +46,11 @@ const orchestrator = createOrchestrator({
 	workflow,
 	runner,
 	logger,
+	langfuse: {
+		publicKey: env.LANGFUSE_PUBLIC_KEY,
+		secretKey: env.LANGFUSE_SECRET_KEY,
+		host: env.LANGFUSE_HOST,
+	},
 });
 
 const checkHealth: HealthCheck = () => {

--- a/server/test-support/test-orchestrator.ts
+++ b/server/test-support/test-orchestrator.ts
@@ -56,6 +56,11 @@ export async function createTestOrchestrator(
 		runner,
 		agent,
 		logger: testLogger,
+		langfuse: {
+			publicKey: "test-public-key",
+			secretKey: "test-secret-key",
+			host: "http://localhost:3000",
+		},
 	});
 
 	return {


### PR DESCRIPTION
Closes KAN-13: Set up self-hosted Langfuse + basic OTel telemetry from agent subprocess.

## Summary

Agents emit OpenTelemetry traces, metrics, and logs to a self-hosted Langfuse instance, giving us prompt inspection, per-step cost/latency, and per-model token breakdowns out of the box.

## What's included

**Telemetry wiring** (`server/orchestrator/otel-env.ts`):
- Builds OTel environment variables (headers, exporter endpoint, resource attributes) from required Langfuse credentials passed in from the composition root
- Includes run ID, issue key, and workflow step name in resource attributes for trace correlation
- `OTEL_EXPORTER_OTLP_ENDPOINT` is derived from `LANGFUSE_HOST` rather than hardcoded

**Server env schema** (`server/env.ts`):
- `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` are required — the server fails fast at startup with a readable zod error if either is missing
- `LANGFUSE_HOST` defaults to `http://localhost:3000`

**Self-hosted Langfuse** (`infra/langfuse/`):
- Docker Compose stack pinned to Langfuse v3 (web/worker/postgres/clickhouse/minio/redis — all four storage components are required by Langfuse v3, not optional)
- Secrets template (`.env.example`) — comments clarify that `NEXTAUTH_SECRET` etc. configure Langfuse's own containers (its web app is a Next.js / NextAuth.js app), not this repo's code
- Convenience npm scripts: `langfuse:up`, `langfuse:down`, `langfuse:logs`

**Integration points**:
- `agent-invoker.ts` accepts a `LangfuseConfig` and threads it into the OTel env merged onto every agent subprocess invocation
- `orchestrator.ts` receives `langfuse` via `OrchestratorConfig` (composition root in `server.ts` reads from `env.ts`; tests pass fixture values)
- `branch-resolver.ts` and `step-runner.ts` pass `issueKey` / `stepName` through so resource attributes are populated

**Test coverage**: `buildOtelEnv` is covered with full-shape assertions on the produced env, including host substitution and conditional resource-attribute keys.

## Implementation notes

- Telemetry is **not** opt-in: per the project's "no additive designs / no backcompat shims" rule, the keys are required and absence is a startup failure, not a silent disable
- Claude SDK's native `CLAUDE_CODE_ENABLE_TELEMETRY` and `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA` flags are always set
- OTel export batching configured to 1s intervals (aggressive for development/debugging)