### PR TITLE
fix: disable ClickHouse cluster mode in Langfuse compose

### DIFF
--- a/infra/langfuse/docker-compose.yml
+++ b/infra/langfuse/docker-compose.yml
@@ -24,6 +24,9 @@ x-langfuse-env: &langfuse-env
   CLICKHOUSE_URL: "http://clickhouse:8123"
   CLICKHOUSE_USER: "clickhouse"
   CLICKHOUSE_PASSWORD: "${CLICKHOUSE_PASSWORD}"
+  # Without this, migrations use `ON CLUSTER default ... ReplicatedMergeTree`
+  # which requires ZooKeeper. Set to "false" for single-node local dev.
+  CLICKHOUSE_CLUSTER_ENABLED: "false"
   REDIS_HOST: "redis"
   REDIS_PORT: "6379"
   REDIS_AUTH: "${REDIS_AUTH}"


### PR DESCRIPTION
## Summary

`pnpm langfuse:up` fails on a fresh checkout because Langfuse's ClickHouse migrations default to `ReplicatedMergeTree ON CLUSTER default`, which requires ZooKeeper. There's no ZooKeeper in our single-node compose, so the first migration errors with ClickHouse code 139 (`NO_ZOOKEEPER`), `langfuse-web` exits, and the container restart-loops.

Setting `CLICKHOUSE_CLUSTER_ENABLED=false` tells Langfuse to use plain `MergeTree` without the `ON CLUSTER` clause — the correct mode for a single-node local deploy.

The visible error in the logs (`CLICKHOUSE_PASSWORD contains special characters that are not URL-encoded`) is a hardcoded hint Langfuse prints on any migration failure; it's misleading in this case. The real cause is the ZooKeeper line above it.

## Test plan

- [x] `pnpm langfuse:up` brings the stack up cleanly on a wiped volume set
- [x] `langfuse-web` reaches `(healthy)` instead of `Restarting`
- [x] http://localhost:3000/api/public/health responds 200
- [x] Sign-up flow works, project + API keys can be created

🤖 Generated with [Claude Code](https://claude.com/claude-code)