### PR TITLE
chore: move Langfuse to port 3100 to free 3000 for the dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,8 @@ JIRA_EMAIL=
 JIRA_API_TOKEN=
 
 # Langfuse credentials (required). Get the keys from
-# http://localhost:3000 → Project → Settings → API keys after
+# http://localhost:3100 → Project → Settings → API keys after
 # `pnpm langfuse:up` and signing in.
 LANGFUSE_PUBLIC_KEY=
 LANGFUSE_SECRET_KEY=
-# LANGFUSE_HOST=http://localhost:3000
+# LANGFUSE_HOST=http://localhost:3100

--- a/infra/langfuse/docker-compose.yml
+++ b/infra/langfuse/docker-compose.yml
@@ -17,7 +17,7 @@ x-langfuse-env: &langfuse-env
   SALT: "${SALT}"
   ENCRYPTION_KEY: "${ENCRYPTION_KEY}"
   NEXTAUTH_SECRET: "${NEXTAUTH_SECRET}"
-  NEXTAUTH_URL: "http://localhost:3000"
+  NEXTAUTH_URL: "http://localhost:3100"
   TELEMETRY_ENABLED: "false"
   LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES: "false"
   CLICKHOUSE_MIGRATION_URL: "clickhouse://clickhouse:${CLICKHOUSE_PASSWORD}@clickhouse:9000"
@@ -59,7 +59,9 @@ services:
     restart: unless-stopped
     depends_on: *langfuse-depends
     ports:
-      - "3000:3000"
+      # Host 3100 → container 3000. The dashboard server defaults to host
+      # port 3000, so Langfuse moves out of its way.
+      - "3100:3000"
     environment:
       <<: *langfuse-env
 

--- a/server/env.ts
+++ b/server/env.ts
@@ -21,7 +21,7 @@ const envSchema = z.object({
 	JIRA_API_TOKEN: z.string().optional(),
 	LANGFUSE_PUBLIC_KEY: z.string().min(1),
 	LANGFUSE_SECRET_KEY: z.string().min(1),
-	LANGFUSE_HOST: z.url().default("http://localhost:3000"),
+	LANGFUSE_HOST: z.url().default("http://localhost:3100"),
 });
 
 type Env = z.infer<typeof envSchema>;


### PR DESCRIPTION
## Summary

The dashboard/orchestrator server defaults to `PORT=3000`, but the Langfuse web container was also mapped to host port 3000. Whichever started second would fail with `EADDRINUSE`.

Langfuse is the auxiliary service, so it moves: host port **3100** maps to its container's 3000. `NEXTAUTH_URL` updates to match so Langfuse's sign-in flow keeps working, and `LANGFUSE_HOST` in the server env schema defaults to the new URL.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 318 pass
- [x] Stack restarts cleanly: `docker compose down && up`
- [x] `http://localhost:3100/api/public/health` responds 200; port 3000 is free for the dashboard

Side effect for existing local Langfuse users: changing `NEXTAUTH_URL` invalidates the existing browser session — sign back in at the new URL. Project + API keys persist (they live in Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)