### PR TITLE
fix(server): require LANGFUSE_PROJECT_ID so trace URL always populates

### DIFF
--- a/server/env.ts
+++ b/server/env.ts
@@ -22,7 +22,7 @@ const envSchema = z.object({
 	LANGFUSE_PUBLIC_KEY: z.string().min(1),
 	LANGFUSE_SECRET_KEY: z.string().min(1),
 	LANGFUSE_HOST: z.url().default("http://localhost:3100"),
-	LANGFUSE_PROJECT_ID: z.string().min(1).optional(),
+	LANGFUSE_PROJECT_ID: z.string().min(1),
 });
 
 type Env = z.infer<typeof envSchema>;

--- a/server/orchestrator/agent-invoker.ts
+++ b/server/orchestrator/agent-invoker.ts
@@ -45,7 +45,7 @@ export type LangfuseConfig = {
 	publicKey: string;
 	secretKey: string;
 	host: string;
-	projectId: string | undefined;
+	projectId: string;
 };
 
 export function claudeSdkAgentInvoker({

--- a/server/orchestrator/orchestrator.scheduling.integration.test.ts
+++ b/server/orchestrator/orchestrator.scheduling.integration.test.ts
@@ -26,6 +26,9 @@ function dispatchedRunRow(issueNum: number) {
 		...baseRunRow,
 		issueUrl: `https://tracker.example.test/browse/${jiraIssueKey(issueNum)}`,
 		repoUrl: `https://code-host.example.test/${REPO}`,
+		langfuseTraceUrl: expect.stringMatching(
+			/^http:\/\/localhost:3100\/project\/test-project-id\/traces\/[0-9a-f]+$/,
+		),
 	};
 }
 

--- a/server/orchestrator/run-lifecycle.ts
+++ b/server/orchestrator/run-lifecycle.ts
@@ -55,7 +55,7 @@ type RunLifecycleDeps = {
 	agentSettingsFile: string;
 	agentEnv: Record<string, string>;
 	langfuseHost: string;
-	langfuseProjectId: string | undefined;
+	langfuseProjectId: string;
 };
 
 type FailurePhase =
@@ -115,12 +115,8 @@ export function createRunLifecycle(deps: RunLifecycleDeps): RunLifecycle {
 					},
 					() =>
 						runRunSpan(ctx.runId, issue.key, async (traceId) => {
-							const langfuseTraceUrl = langfuseProjectId
-								? `${langfuseHost}/project/${langfuseProjectId}/traces/${traceId}`
-								: null;
-							if (langfuseTraceUrl) {
-								runRepo.setRunLangfuseTraceUrl(ctx.runId, langfuseTraceUrl);
-							}
+							const langfuseTraceUrl = `${langfuseHost}/project/${langfuseProjectId}/traces/${traceId}`;
+							runRepo.setRunLangfuseTraceUrl(ctx.runId, langfuseTraceUrl);
 							try {
 								const startTime = clock.now();
 								let result: RunResult;

--- a/server/test-support/test-orchestrator.ts
+++ b/server/test-support/test-orchestrator.ts
@@ -60,7 +60,7 @@ export async function createTestOrchestrator(
 			publicKey: "test-public-key",
 			secretKey: "test-secret-key",
 			host: "http://localhost:3100",
-			projectId: undefined,
+			projectId: "test-project-id",
 		},
 	});
 


### PR DESCRIPTION
## Summary
- `LANGFUSE_PROJECT_ID` was optional, so when unset the orchestrator silently stored `langfuseTraceUrl: null` on the run and the UI had no link to render.
- Make the env var required and drop the conditional in `run-lifecycle.ts` — the trace URL is now always built.
- Tests use a fixed `test-project-id`; the scheduling integration test matches the URL with a regex.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (318 passing)
- [ ] Local run: kick off a new agent run and confirm the trace link appears on the run detail page and opens Langfuse at the unified run trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)